### PR TITLE
Rec. 2020 Color Conversions RGB <-> Y'UV #7

### DIFF
--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -1972,6 +1972,31 @@ inline XMVECTOR XM_CALLCONV XMColorSRGBToRGB( FXMVECTOR srgb )
     return XMVectorSelect( srgb, V, g_XMSelect1110 );
 }
 
+//------------------------------------------------------------------------------
+
+inline XMVECTOR XM_CALLCONV XMColorRGBToYUV_UHD( FXMVECTOR rgb )
+{
+    static const XMVECTORF32 Scale0 = { 0.2627f, -0.1215f,  0.6150f, 0.0f };
+    static const XMVECTORF32 Scale1 = { 0.6780f, -0.3136f, -0.5655f, 0.0f };
+    static const XMVECTORF32 Scale2 = { 0.0593f,  0.4351f, -0.0495f, 0.0f };
+
+    XMMATRIX M( Scale0, Scale1, Scale2, g_XMZero );
+    XMVECTOR clr = XMVector3Transform( rgb, M );
+
+    return XMVectorSelect( rgb, clr, g_XMSelect1110 );
+}
+
+inline XMVECTOR XM_CALLCONV XMColorYUVToRGB_UHD( FXMVECTOR yuv )
+{
+    static const XMVECTORF32 Scale1 = {    0.0f, -0.1891f, 2.1620f, 0.0f };
+    static const XMVECTORF32 Scale2 = { 1.1989f, -0.6566f,    0.0f, 0.0f };
+        
+    XMMATRIX M( g_XMOne, Scale1, Scale2, g_XMZero );
+    XMVECTOR clr = XMVector3Transform( yuv, M );
+
+    return XMVectorSelect( yuv, clr, g_XMSelect1110 );
+}
+
 /****************************************************************************
  *
  * Miscellaneous


### PR DESCRIPTION
BT.2020 conversions.

![image](https://cloud.githubusercontent.com/assets/3840081/16971502/32d513e4-4dd9-11e6-9fd5-b41c8fc55da2.png)

These are the formulas and constants I used for the color conversion

Applying these constants and formula gives:

    [ 0.2627      0.6780         0.0593 ]
    [ -0.1215     -0.3136        0.4351 ]
    [ 0.6150      -0.5655       -0.0495 ]


    [ 1      0            1.1989 ]
    [ 1      -0.1891     -0.4645 ]
    [ 1      2.162        0      ]

