### PR TITLE
Fixed conformance warnings based on clang

### DIFF
--- a/Inc/DirectXCollision.h
+++ b/Inc/DirectXCollision.h
@@ -18,14 +18,14 @@ enum ContainmentType
 {
     DISJOINT = 0,
     INTERSECTS = 1,
-    CONTAINS = 2,
+    CONTAINS = 2
 };
 
 enum PlaneIntersectionType
 {
     FRONT = 0,
     INTERSECTING = 1,
-    BACK = 2,
+    BACK = 2
 };
 
 struct BoundingBox;
@@ -319,7 +319,7 @@ namespace TriangleTests
                                                          _In_ GXMVECTOR Plane0, _In_ HXMVECTOR Plane1, _In_ HXMVECTOR Plane2,
                                                          _In_ CXMVECTOR Plane3, _In_ CXMVECTOR Plane4, _In_ CXMVECTOR Plane5 );
         // Test a triangle against six planes at once (see BoundingFrustum::GetPlanes)
-};
+}
 
 #pragma warning(pop)
 

--- a/Inc/DirectXCollision.inl
+++ b/Inc/DirectXCollision.inl
@@ -192,9 +192,9 @@ inline XMVECTOR CalculateEigenVector( _In_ float m11, _In_ float m12, _In_ float
                                       _In_ float m22, _In_ float m23, _In_ float m33, _In_ float e )
 {
     float fTmp[3];
-    fTmp[0] = ( float )( m12 * m23 - m13 * ( m22 - e ) );
-    fTmp[1] = ( float )( m13 * m12 - m23 * ( m11 - e ) );
-    fTmp[2] = ( float )( ( m11 - e ) * ( m22 - e ) - m12 * m12 );
+    fTmp[0] = m12 * m23 - m13 * ( m22 - e );
+    fTmp[1] = m13 * m12 - m23 * ( m11 - e );
+    fTmp[2] = ( m11 - e ) * ( m22 - e ) - m12 * m12;
 
     XMVECTOR vTmp = XMLoadFloat3( reinterpret_cast<const XMFLOAT3*>(fTmp) );
 
@@ -236,11 +236,11 @@ inline XMVECTOR CalculateEigenVector( _In_ float m11, _In_ float m12, _In_ float
             vTmp = XMVectorSetZ( vTmp, 0.0f );
             // recalculate y to make equation work
             if( m12 != 0 )
-                vTmp = XMVectorSetY( vTmp, ( float )( -f1 / f2 ) );
+                vTmp = XMVectorSetY( vTmp, -f1 / f2 );
         }
         else
         {
-            vTmp = XMVectorSetZ( vTmp, ( float )( ( f2 - f1 ) / f3 ) );
+            vTmp = XMVectorSetZ( vTmp, ( f2 - f1 ) / f3 );
         }
     }
 
@@ -2006,7 +2006,7 @@ inline void XM_CALLCONV BoundingOrientedBox::Transform( BoundingOrientedBox& Out
 _Use_decl_annotations_
 inline void BoundingOrientedBox::GetCorners( XMFLOAT3* Corners ) const
 {
-    assert( Corners != 0 );
+    assert( Corners != nullptr );
 
     // Load the box
     XMVECTOR vCenter = XMLoadFloat3( &Center );
@@ -2698,7 +2698,7 @@ _Use_decl_annotations_
 inline void BoundingOrientedBox::CreateFromPoints( BoundingOrientedBox& Out, size_t Count, const XMFLOAT3* pPoints, size_t Stride )
 {
     assert( Count > 0 );
-    assert( pPoints != 0 );
+    assert( pPoints != nullptr );
 
     XMVECTOR CenterOfMass = XMVectorZero();
 
@@ -2895,7 +2895,7 @@ inline void XM_CALLCONV BoundingFrustum::Transform( BoundingFrustum& Out, float 
 _Use_decl_annotations_
 inline void BoundingFrustum::GetCorners( XMFLOAT3* Corners ) const
 {
-    assert( Corners != 0 );
+    assert( Corners != nullptr );
 
     // Load origin and orientation of the frustum.
     XMVECTOR vOrigin = XMLoadFloat3( &Origin );

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -1666,7 +1666,7 @@ namespace Internal
     {
         static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR v2) { return _mm_shuffle_ps(v2, v1, Shuffle); }
     };
-};
+}
 
 #endif // _XM_SSE_INTRINSICS_ && !_XM_NO_INTRINSICS_
 
@@ -1944,12 +1944,12 @@ XMGLOBALCONST XMVECTORI32 g_XMFltMax                = { { { 0x7F7FFFFF, 0x7F7FFF
 XMGLOBALCONST XMVECTORU32 g_XMNegOneMask            = { { { 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF } } };
 XMGLOBALCONST XMVECTORU32 g_XMMaskA8R8G8B8          = { { { 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000 } } };
 XMGLOBALCONST XMVECTORU32 g_XMFlipA8R8G8B8          = { { { 0x00000000, 0x00000000, 0x00000000, 0x80000000 } } };
-XMGLOBALCONST XMVECTORF32 g_XMFixAA8R8G8B8          = { { { 0.0f, 0.0f, 0.0f, (float) (0x80000000U) } } };
-XMGLOBALCONST XMVECTORF32 g_XMNormalizeA8R8G8B8     = { { { 1.0f / (255.0f*(float) (0x10000)), 1.0f / (255.0f*(float) (0x100)), 1.0f / 255.0f, 1.0f / (255.0f*(float) (0x1000000)) } } };
+XMGLOBALCONST XMVECTORF32 g_XMFixAA8R8G8B8          = { { { 0.0f, 0.0f, 0.0f, float(0x80000000U) } } };
+XMGLOBALCONST XMVECTORF32 g_XMNormalizeA8R8G8B8     = { { { 1.0f / (255.0f*float(0x10000)), 1.0f / (255.0f*float(0x100)), 1.0f / 255.0f, 1.0f / (255.0f*float(0x1000000)) } } };
 XMGLOBALCONST XMVECTORU32 g_XMMaskA2B10G10R10       = { { { 0x000003FF, 0x000FFC00, 0x3FF00000, 0xC0000000 } } };
 XMGLOBALCONST XMVECTORU32 g_XMFlipA2B10G10R10       = { { { 0x00000200, 0x00080000, 0x20000000, 0x80000000 } } };
-XMGLOBALCONST XMVECTORF32 g_XMFixAA2B10G10R10       = { { { -512.0f, -512.0f*(float) (0x400), -512.0f*(float) (0x100000), (float) (0x80000000U) } } };
-XMGLOBALCONST XMVECTORF32 g_XMNormalizeA2B10G10R10  = { { { 1.0f / 511.0f, 1.0f / (511.0f*(float) (0x400)), 1.0f / (511.0f*(float) (0x100000)), 1.0f / (3.0f*(float) (0x40000000)) } } };
+XMGLOBALCONST XMVECTORF32 g_XMFixAA2B10G10R10       = { { { -512.0f, -512.0f*float(0x400), -512.0f*float(0x100000), float(0x80000000U) } } };
+XMGLOBALCONST XMVECTORF32 g_XMNormalizeA2B10G10R10  = { { { 1.0f / 511.0f, 1.0f / (511.0f*float(0x400)), 1.0f / (511.0f*float(0x100000)), 1.0f / (3.0f*float(0x40000000)) } } };
 XMGLOBALCONST XMVECTORU32 g_XMMaskX16Y16            = { { { 0x0000FFFF, 0xFFFF0000, 0x00000000, 0x00000000 } } };
 XMGLOBALCONST XMVECTORI32 g_XMFlipX16Y16            = { { { 0x00008000, 0x00000000, 0x00000000, 0x00000000 } } };
 XMGLOBALCONST XMVECTORF32 g_XMFixX16Y16             = { { { -32768.0f, 0.0f, 0.0f, 0.0f } } };
@@ -1979,7 +1979,7 @@ XMGLOBALCONST XMVECTORU32 g_XMFlipW                 = { { { 0, 0, 0, 0x80000000 
 XMGLOBALCONST XMVECTORU32 g_XMFlipYZ                = { { { 0, 0x80000000, 0x80000000, 0 } } };
 XMGLOBALCONST XMVECTORU32 g_XMFlipZW                = { { { 0, 0, 0x80000000, 0x80000000 } } };
 XMGLOBALCONST XMVECTORU32 g_XMFlipYW                = { { { 0, 0x80000000, 0, 0x80000000 } } };
-XMGLOBALCONST XMVECTORI32 g_XMMaskDec4              = { { { 0x3FF, 0x3FF << 10, 0x3FF << 20, 0x3 << 30 } } };
+XMGLOBALCONST XMVECTORI32 g_XMMaskDec4              = { { { 0x3FF, 0x3FF << 10, 0x3FF << 20, static_cast<int>(0xC0000000) } } };
 XMGLOBALCONST XMVECTORI32 g_XMXorDec4               = { { { 0x200, 0x200 << 10, 0x200 << 20, 0 } } };
 XMGLOBALCONST XMVECTORF32 g_XMAddUDec4              = { { { 0, 0, 0, 32768.0f*65536.0f } } };
 XMGLOBALCONST XMVECTORF32 g_XMAddDec4               = { { { -512.0f, -512.0f*1024.0f, -512.0f*1024.0f*1024.0f, 0 } } };
@@ -2067,7 +2067,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetBinaryConstant(uint32_t C0, uint32_t C1, 
 #else // XM_SSE_INTRINSICS_
     static const XMVECTORU32 g_vMask1 = { { { 1, 1, 1, 1 } } };
     // Move the parms to a vector
-    __m128i vTemp = _mm_set_epi32(C3,C2,C1,C0);
+    __m128i vTemp = _mm_set_epi32(static_cast<int>(C3), static_cast<int>(C2), static_cast<int>(C1), static_cast<int>(C0));
     // Mask off the low bits
     vTemp = _mm_and_si128(vTemp,g_vMask1);
     // 0xFFFFFFFF on true bits
@@ -2099,7 +2099,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatConstant(int32_t IntConstant, uint32_t 
     // Convert DivExponent into 1.0f/(1<<DivExponent)
     uint32_t uScale = 0x3F800000U - (DivExponent << 23);
     // Splat the scalar value (It's really a float)
-    vScale = vdupq_n_s32(uScale);
+    vScale = vdupq_n_u32(uScale);
     // Multiply by the reciprocal (Perform a right shift by DivExponent)
     vResult = vmulq_f32(vResult,reinterpret_cast<const float32x4_t *>(&vScale)[0]);
     return vResult;
@@ -2111,7 +2111,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatConstant(int32_t IntConstant, uint32_t 
     // Convert DivExponent into 1.0f/(1<<DivExponent)
     uint32_t uScale = 0x3F800000U - (DivExponent << 23);
     // Splat the scalar value (It's really a float)
-    vScale = _mm_set1_epi32(uScale);
+    vScale = _mm_set1_epi32(static_cast<int>(uScale));
     // Multiply by the reciprocal (Perform a right shift by DivExponent)
     vResult = _mm_mul_ps(vResult,_mm_castsi128_ps(vScale));
     return vResult;

--- a/Inc/DirectXMathConvert.inl
+++ b/Inc/DirectXMathConvert.inl
@@ -29,12 +29,12 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorIntToFloat
 {
     assert(DivExponent<32);
 #if defined(_XM_NO_INTRINSICS_)
-    float fScale = 1.0f / (float)(1U << DivExponent);
+    float fScale = 1.0f / static_cast<float>(1U << DivExponent);
     uint32_t ElementIndex = 0;
     XMVECTOR Result;
     do {
-        int32_t iTemp = (int32_t)VInt.vector4_u32[ElementIndex];
-        Result.vector4_f32[ElementIndex] = ((float)iTemp) * fScale;
+        auto iTemp = static_cast<int32_t>(VInt.vector4_u32[ElementIndex]);
+        Result.vector4_f32[ElementIndex] = static_cast<float>(iTemp) * fScale;
     } while (++ElementIndex<4);
     return Result;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
@@ -47,7 +47,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorIntToFloat
     // Convert DivExponent into 1.0f/(1<<DivExponent)
     uint32_t uScale = 0x3F800000U - (DivExponent << 23);
     // Splat the scalar value
-    __m128i vScale = _mm_set1_epi32(uScale);
+    __m128i vScale = _mm_set1_epi32(static_cast<int>(uScale));
     vResult = _mm_mul_ps(vResult,_mm_castsi128_ps(vScale));
     return vResult;
 #endif
@@ -64,7 +64,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorFloatToInt
     assert(MulExponent<32);
 #if defined(_XM_NO_INTRINSICS_)
     // Get the scalar factor.
-    float fScale = (float)(1U << MulExponent);
+    auto fScale = static_cast<float>(1U << MulExponent);
     uint32_t ElementIndex = 0;
     XMVECTOR Result;
     do {
@@ -75,9 +75,9 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorFloatToInt
         } else if (fTemp > (65536.0f*32768.0f)-128.0f) {
             iResult = 0x7FFFFFFF;
         } else {
-            iResult = (int32_t)fTemp;
+            iResult = static_cast<int32_t>(fTemp);
         }
-        Result.vector4_u32[ElementIndex] = (uint32_t)iResult;
+        Result.vector4_u32[ElementIndex] = static_cast<uint32_t>(iResult);
     } while (++ElementIndex<4);
     return Result;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
@@ -92,7 +92,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorFloatToInt
     vOverflow = vorrq_u32(vOverflow,vResult);
     return vOverflow;
 #else // _XM_SSE_INTRINSICS_
-    XMVECTOR vResult = _mm_set_ps1((float)(1U << MulExponent));
+    XMVECTOR vResult = _mm_set_ps1(static_cast<float>(1U << MulExponent));
     vResult = _mm_mul_ps(vResult,VFloat);
     // In case of positive overflow, detect it
     XMVECTOR vOverflow = _mm_cmpgt_ps(vResult,g_XMMaxInt);
@@ -116,11 +116,11 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorUIntToFloat
 {
     assert(DivExponent<32);
 #if defined(_XM_NO_INTRINSICS_)
-    float fScale = 1.0f / (float)(1U << DivExponent);
+    float fScale = 1.0f / static_cast<float>(1U << DivExponent);
     uint32_t ElementIndex = 0;
     XMVECTOR Result;
     do {
-        Result.vector4_f32[ElementIndex] = (float)VUInt.vector4_u32[ElementIndex] * fScale;
+        Result.vector4_f32[ElementIndex] = static_cast<float>(VUInt.vector4_u32[ElementIndex]) * fScale;
     } while (++ElementIndex<4);
     return Result;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
@@ -143,7 +143,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorUIntToFloat
     // Convert DivExponent into 1.0f/(1<<DivExponent)
     uint32_t uScale = 0x3F800000U - (DivExponent << 23);
     // Splat
-    iMask = _mm_set1_epi32(uScale);
+    iMask = _mm_set1_epi32(static_cast<int>(uScale));
     vResult = _mm_mul_ps(vResult,_mm_castsi128_ps(iMask));
     return vResult;
 #endif
@@ -160,7 +160,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorFloatToUInt
     assert(MulExponent<32);
 #if defined(_XM_NO_INTRINSICS_)
     // Get the scalar factor.
-    float fScale = (float)(1U << MulExponent);
+    auto fScale = static_cast<float>(1U << MulExponent);
     uint32_t ElementIndex = 0;
     XMVECTOR Result;
     do {
@@ -171,7 +171,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorFloatToUInt
         } else if (fTemp >= (65536.0f*65536.0f)) {
             uResult = 0xFFFFFFFFU;
         } else {
-            uResult = (uint32_t)fTemp;
+            uResult = static_cast<uint32_t>(fTemp);
         }
         Result.vector4_u32[ElementIndex] = uResult;
     } while (++ElementIndex<4);
@@ -292,7 +292,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt2A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
     V.vector4_u32[0] = pSource[0];
@@ -344,7 +344,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat2A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
     V.vector4_f32[0] = pSource->x;
@@ -372,8 +372,8 @@ inline XMVECTOR XM_CALLCONV XMLoadSInt2
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
-    V.vector4_f32[0] = (float)pSource->x;
-    V.vector4_f32[1] = (float)pSource->y;
+    V.vector4_f32[0] = static_cast<float>(pSource->x);
+    V.vector4_f32[1] = static_cast<float>(pSource->y);
     V.vector4_f32[2] = 0.f;
     V.vector4_f32[3] = 0.f;
     return V;
@@ -400,8 +400,8 @@ inline XMVECTOR XM_CALLCONV XMLoadUInt2
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
-    V.vector4_f32[0] = (float)pSource->x;
-    V.vector4_f32[1] = (float)pSource->y;
+    V.vector4_f32[0] = static_cast<float>(pSource->x);
+    V.vector4_f32[1] = static_cast<float>(pSource->y);
     V.vector4_f32[2] = 0.f;
     V.vector4_f32[3] = 0.f;
     return V;
@@ -467,7 +467,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt3A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
     V.vector4_u32[0] = pSource[0];
@@ -524,7 +524,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat3A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
     V.vector4_f32[0] = pSource->x;
@@ -554,9 +554,9 @@ inline XMVECTOR XM_CALLCONV XMLoadSInt3
 #if defined(_XM_NO_INTRINSICS_)
 
     XMVECTOR V;
-    V.vector4_f32[0] = (float)pSource->x;
-    V.vector4_f32[1] = (float)pSource->y;
-    V.vector4_f32[2] = (float)pSource->z;
+    V.vector4_f32[0] = static_cast<float>(pSource->x);
+    V.vector4_f32[1] = static_cast<float>(pSource->y);
+    V.vector4_f32[2] = static_cast<float>(pSource->z);
     V.vector4_f32[3] = 0.f;
     return V;
 
@@ -586,9 +586,9 @@ inline XMVECTOR XM_CALLCONV XMLoadUInt3
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
-    V.vector4_f32[0] = (float)pSource->x;
-    V.vector4_f32[1] = (float)pSource->y;
-    V.vector4_f32[2] = (float)pSource->z;
+    V.vector4_f32[0] = static_cast<float>(pSource->x);
+    V.vector4_f32[1] = static_cast<float>(pSource->y);
+    V.vector4_f32[2] = static_cast<float>(pSource->z);
     V.vector4_f32[3] = 0.f;
     return V;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
@@ -651,7 +651,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt4A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
     V.vector4_u32[0] = pSource[0];
@@ -697,7 +697,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat4A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
     V.vector4_f32[0] = pSource->x;
@@ -723,10 +723,10 @@ inline XMVECTOR XM_CALLCONV XMLoadSInt4
 #if defined(_XM_NO_INTRINSICS_)
 
     XMVECTOR V;
-    V.vector4_f32[0] = (float)pSource->x;
-    V.vector4_f32[1] = (float)pSource->y;
-    V.vector4_f32[2] = (float)pSource->z;
-    V.vector4_f32[3] = (float)pSource->w;
+    V.vector4_f32[0] = static_cast<float>(pSource->x);
+    V.vector4_f32[1] = static_cast<float>(pSource->y);
+    V.vector4_f32[2] = static_cast<float>(pSource->z);
+    V.vector4_f32[3] = static_cast<float>(pSource->w);
     return V;
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
@@ -748,10 +748,10 @@ inline XMVECTOR XM_CALLCONV XMLoadUInt4
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR V;
-    V.vector4_f32[0] = (float)pSource->x;
-    V.vector4_f32[1] = (float)pSource->y;
-    V.vector4_f32[2] = (float)pSource->z;
-    V.vector4_f32[3] = (float)pSource->w;
+    V.vector4_f32[0] = static_cast<float>(pSource->x);
+    V.vector4_f32[1] = static_cast<float>(pSource->y);
+    V.vector4_f32[2] = static_cast<float>(pSource->z);
+    V.vector4_f32[3] = static_cast<float>(pSource->w);
     return V;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     uint32x4_t v = vld1q_u32( reinterpret_cast<const uint32_t*>(pSource) );
@@ -808,7 +808,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat3x3
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     float32x4_t v0 = vld1q_f32( &pSource->m[0][0] );
     float32x4_t v1 = vld1q_f32( &pSource->m[1][1] );
-    float32x2_t v2 = vcreate_f32( (uint64_t)*(const uint32_t*)&pSource->m[2][2] );
+    float32x2_t v2 = vcreate_f32(static_cast<uint64_t>(*reinterpret_cast<const uint32_t*>(&pSource->m[2][2])));
     float32x4_t T = vextq_f32( v0, v1, 3 );
 
     XMMATRIX M;
@@ -927,7 +927,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat4x3A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
 
     XMMATRIX M;
@@ -1089,7 +1089,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat3x4A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
 
     XMMATRIX M;
@@ -1220,7 +1220,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat4x4A
 )
 {
     assert(pSource);
-    assert(((uintptr_t)pSource & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
 
     XMMATRIX M;
@@ -1333,7 +1333,7 @@ inline void XM_CALLCONV XMStoreInt2A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     pDestination[0] = V.vector4_u32[0];
     pDestination[1] = V.vector4_u32[1];
@@ -1376,7 +1376,7 @@ inline void XM_CALLCONV XMStoreFloat2A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     pDestination->x = V.vector4_f32[0];
     pDestination->y = V.vector4_f32[1];
@@ -1398,8 +1398,8 @@ inline void XM_CALLCONV XMStoreSInt2
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
-    pDestination->x = (int32_t)V.vector4_f32[0];
-    pDestination->y = (int32_t)V.vector4_f32[1];
+    pDestination->x = static_cast<int32_t>(V.vector4_f32[0]);
+    pDestination->y = static_cast<int32_t>(V.vector4_f32[1]);
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     int32x2_t v = vget_low_s32(V);
     v = vcvt_s32_f32( v );
@@ -1430,8 +1430,8 @@ inline void XM_CALLCONV XMStoreUInt2
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
-    pDestination->x = (uint32_t)V.vector4_f32[0];
-    pDestination->y = (uint32_t)V.vector4_f32[1];
+    pDestination->x = static_cast<uint32_t>(V.vector4_f32[0]);
+    pDestination->y = static_cast<uint32_t>(V.vector4_f32[1]);
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     float32x2_t v = vget_low_f32(V);
     uint32x2_t iv = vcvt_u32_f32( v );
@@ -1496,7 +1496,7 @@ inline void XM_CALLCONV XMStoreInt3A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     pDestination[0] = V.vector4_u32[0];
     pDestination[1] = V.vector4_u32[1];
@@ -1547,7 +1547,7 @@ inline void XM_CALLCONV XMStoreFloat3A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     pDestination->x = V.vector4_f32[0];
     pDestination->y = V.vector4_f32[1];
@@ -1573,9 +1573,9 @@ inline void XM_CALLCONV XMStoreSInt3
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
-    pDestination->x = (int32_t)V.vector4_f32[0];
-    pDestination->y = (int32_t)V.vector4_f32[1];
-    pDestination->z = (int32_t)V.vector4_f32[2];
+    pDestination->x = static_cast<int32_t>(V.vector4_f32[0]);
+    pDestination->y = static_cast<int32_t>(V.vector4_f32[1]);
+    pDestination->z = static_cast<int32_t>(V.vector4_f32[2]);
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     int32x4_t v = vcvtq_s32_f32(V);
     int32x2_t vL = vget_low_s32(v);
@@ -1609,9 +1609,9 @@ inline void XM_CALLCONV XMStoreUInt3
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
-    pDestination->x = (uint32_t)V.vector4_f32[0];
-    pDestination->y = (uint32_t)V.vector4_f32[1];
-    pDestination->z = (uint32_t)V.vector4_f32[2];
+    pDestination->x = static_cast<uint32_t>(V.vector4_f32[0]);
+    pDestination->y = static_cast<uint32_t>(V.vector4_f32[1]);
+    pDestination->z = static_cast<uint32_t>(V.vector4_f32[2]);
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     uint32x4_t v = vcvtq_u32_f32(V);
     uint32x2_t vL = vget_low_u32(v);
@@ -1674,7 +1674,7 @@ inline void XM_CALLCONV XMStoreInt4A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     pDestination[0] = V.vector4_u32[0];
     pDestination[1] = V.vector4_u32[1];
@@ -1717,7 +1717,7 @@ inline void XM_CALLCONV XMStoreFloat4A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
     pDestination->x = V.vector4_f32[0];
     pDestination->y = V.vector4_f32[1];
@@ -1740,10 +1740,10 @@ inline void XM_CALLCONV XMStoreSInt4
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
-    pDestination->x = (int32_t)V.vector4_f32[0];
-    pDestination->y = (int32_t)V.vector4_f32[1];
-    pDestination->z = (int32_t)V.vector4_f32[2];
-    pDestination->w = (int32_t)V.vector4_f32[3];
+    pDestination->x = static_cast<int32_t>(V.vector4_f32[0]);
+    pDestination->y = static_cast<int32_t>(V.vector4_f32[1]);
+    pDestination->z = static_cast<int32_t>(V.vector4_f32[2]);
+    pDestination->w = static_cast<int32_t>(V.vector4_f32[3]);
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     int32x4_t v = vcvtq_s32_f32(V);
     vst1q_s32( reinterpret_cast<int32_t*>(pDestination), v );
@@ -1770,10 +1770,10 @@ inline void XM_CALLCONV XMStoreUInt4
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
-    pDestination->x = (uint32_t)V.vector4_f32[0];
-    pDestination->y = (uint32_t)V.vector4_f32[1];
-    pDestination->z = (uint32_t)V.vector4_f32[2];
-    pDestination->w = (uint32_t)V.vector4_f32[3];
+    pDestination->x = static_cast<uint32_t>(V.vector4_f32[0]);
+    pDestination->y = static_cast<uint32_t>(V.vector4_f32[1]);
+    pDestination->z = static_cast<uint32_t>(V.vector4_f32[2]);
+    pDestination->w = static_cast<uint32_t>(V.vector4_f32[3]);
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     uint32x4_t v = vcvtq_u32_f32(V);
     vst1q_u32( reinterpret_cast<uint32_t*>(pDestination), v );
@@ -1910,7 +1910,7 @@ inline void XM_CALLCONV XMStoreFloat4x3A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
 
     pDestination->m[0][0] = M.r[0].vector4_f32[0];
@@ -2035,7 +2035,7 @@ inline void XM_CALLCONV XMStoreFloat3x4A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
 
     pDestination->m[0][0] = M.r[0].vector4_f32[0];
@@ -2139,7 +2139,7 @@ inline void XM_CALLCONV XMStoreFloat4x4A
 )
 {
     assert(pDestination);
-    assert(((uintptr_t)pDestination & 0xF) == 0);
+    assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
 #if defined(_XM_NO_INTRINSICS_)
 
     pDestination->m[0][0] = M.r[0].vector4_f32[0];

--- a/Inc/DirectXMathMatrix.inl
+++ b/Inc/DirectXMathMatrix.inl
@@ -29,7 +29,7 @@ inline bool XM_CALLCONV XMMatrixIsNaN
 {
 #if defined(_XM_NO_INTRINSICS_)
     size_t i = 16;
-    const uint32_t *pWork = (const uint32_t *)(&M.m[0][0]);
+    auto pWork = reinterpret_cast<const uint32_t *>(&M.m[0][0]);
     do {
         // Fetch value into integer unit
         uint32_t uTest = pWork[0];
@@ -94,7 +94,7 @@ inline bool XM_CALLCONV XMMatrixIsInfinite
 {
 #if defined(_XM_NO_INTRINSICS_)
     size_t i = 16;
-    const uint32_t *pWork = (const uint32_t *)(&M.m[0][0]);
+    auto pWork = reinterpret_cast<const uint32_t *>(&M.m[0][0]);
     do {
         // Fetch value into integer unit
         uint32_t uTest = pWork[0];
@@ -157,7 +157,7 @@ inline bool XM_CALLCONV XMMatrixIsIdentity
 {
 #if defined(_XM_NO_INTRINSICS_)
     // Use the integer pipeline to reduce branching to a minimum
-    const uint32_t *pWork = (const uint32_t*)(&M.m[0][0]);
+    auto pWork = reinterpret_cast<const uint32_t*>(&M.m[0][0]);
     // Convert 1.0f to zero and or them together
     uint32_t uOne = pWork[0]^0x3F800000U;
     // Or all the 0.0f entries together
@@ -995,7 +995,7 @@ inline bool XM_CALLCONV XMMatrixDecompose
     matTemp.r[2] = M.r[2];
     matTemp.r[3] = g_XMIdentityR3.v;
 
-    float *pfScales = (float *)outScale;
+    auto pfScales = reinterpret_cast<float *>(outScale);
 
     size_t a, b, c;
     XMVectorGetXPtr(&pfScales[0],XMVector3Length(ppvBasis[0][0])); 
@@ -2981,10 +2981,10 @@ inline XMMATRIX::XMMATRIX
 )
 {
     assert( pArray != nullptr );
-    r[0] = XMLoadFloat4((const XMFLOAT4*)pArray);
-    r[1] = XMLoadFloat4((const XMFLOAT4*)(pArray + 4));
-    r[2] = XMLoadFloat4((const XMFLOAT4*)(pArray + 8));
-    r[3] = XMLoadFloat4((const XMFLOAT4*)(pArray + 12));
+    r[0] = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray));
+    r[1] = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray + 4));
+    r[2] = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray + 8));
+    r[3] = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray + 12));
 }
 
 //------------------------------------------------------------------------------

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -1124,7 +1124,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneNormalize
 #if defined(_XM_NO_INTRINSICS_)
     float fLengthSq = sqrtf((P.vector4_f32[0]*P.vector4_f32[0])+(P.vector4_f32[1]*P.vector4_f32[1])+(P.vector4_f32[2]*P.vector4_f32[2]));
     // Prevent divide by zero
-    if (fLengthSq)
+    if (fLengthSq > 0)
     {
         fLengthSq = 1.0f/fLengthSq;
     }
@@ -1748,7 +1748,7 @@ inline XMVECTOR XM_CALLCONV XMColorHSVToRGB( FXMVECTOR hsv )
     // t = v*(1 - (1-f)*s)
     XMVECTOR t = XMVectorMultiply( v, XMVectorSubtract( g_XMOne, XMVectorMultiply( XMVectorSubtract( g_XMOne, f ), s ) ) );
 
-    int ii = static_cast<int>( XMVectorGetX( XMVectorMod( i, g_XMSix ) ) );
+    auto ii = static_cast<int>( XMVectorGetX( XMVectorMod( i, g_XMSix ) ) );
 
     XMVECTOR _rgb;
 
@@ -2143,7 +2143,7 @@ inline float XMScalarModAngle
     Angle = Angle + XM_PI;
     // Perform the modulo, unsigned
     float fTemp = fabsf(Angle);
-    fTemp = fTemp - (XM_2PI * (float)((int32_t)(fTemp/XM_2PI)));
+    fTemp = fTemp - (XM_2PI * static_cast<float>(static_cast<int32_t>(fTemp/XM_2PI)));
     // Restore the number to the range of -XM_PI to XM_PI-epsilon
     fTemp = fTemp - XM_PI;
     // If the modulo'd value was negative, restore negation
@@ -2164,11 +2164,11 @@ inline float XMScalarSin
     float quotient = XM_1DIV2PI*Value;
     if (Value >= 0.0f)
     {
-        quotient = (float)((int)(quotient + 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient + 0.5f));
     }
     else
     {
-        quotient = (float)((int)(quotient - 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient - 0.5f));
     }
     float y = Value - XM_2PI*quotient;
 
@@ -2198,11 +2198,11 @@ inline float XMScalarSinEst
     float quotient = XM_1DIV2PI*Value;
     if (Value >= 0.0f)
     {
-        quotient = (float)((int)(quotient + 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient + 0.5f));
     }
     else
     {
-        quotient = (float)((int)(quotient - 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient - 0.5f));
     }
     float y = Value - XM_2PI*quotient;
 
@@ -2232,11 +2232,11 @@ inline float XMScalarCos
     float quotient = XM_1DIV2PI*Value;
     if (Value >= 0.0f)
     {
-        quotient = (float)((int)(quotient + 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient + 0.5f));
     }
     else
     {
-        quotient = (float)((int)(quotient - 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient - 0.5f));
     }
     float y = Value - XM_2PI*quotient;
 
@@ -2274,11 +2274,11 @@ inline float XMScalarCosEst
     float quotient = XM_1DIV2PI*Value;
     if (Value >= 0.0f)
     {
-        quotient = (float)((int)(quotient + 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient + 0.5f));
     }
     else
     {
-        quotient = (float)((int)(quotient - 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient - 0.5f));
     }
     float y = Value - XM_2PI*quotient;
 
@@ -2322,11 +2322,11 @@ inline void XMScalarSinCos
     float quotient = XM_1DIV2PI*Value;
     if (Value >= 0.0f)
     {
-        quotient = (float)((int)(quotient + 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient + 0.5f));
     }
     else
     {
-        quotient = (float)((int)(quotient - 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient - 0.5f));
     }
     float y = Value - XM_2PI*quotient;
 
@@ -2374,11 +2374,11 @@ inline void XMScalarSinCosEst
     float quotient = XM_1DIV2PI*Value;
     if (Value >= 0.0f)
     {
-        quotient = (float)((int)(quotient + 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient + 0.5f));
     }
     else
     {
-        quotient = (float)((int)(quotient - 0.5f));
+        quotient = static_cast<float>(static_cast<int>(quotient - 0.5f));
     }
     float y = Value - XM_2PI*quotient;
 

--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -9,6 +9,11 @@
 
 #pragma once
 
+#if defined(_XM_NO_INTRINSICS_)
+#define XMISNAN(x)  isnan(x)
+#define XMISINF(x)  isinf(x)
+#endif
+
 #if defined(_XM_SSE_INTRINSICS_)
 
 #define XM3UNPACK3INTO4(l1,l2,l3) \
@@ -2173,10 +2178,10 @@ inline XMVECTOR XM_CALLCONV XMVectorIsNaN
 #if defined(_XM_NO_INTRINSICS_)
 
     XMVECTORU32 Control = { { {
-            isnan(V.vector4_f32[0]) ? 0xFFFFFFFFU : 0,
-            isnan(V.vector4_f32[1]) ? 0xFFFFFFFFU : 0,
-            isnan(V.vector4_f32[2]) ? 0xFFFFFFFFU : 0,
-            isnan(V.vector4_f32[3]) ? 0xFFFFFFFFU : 0
+            XMISNAN(V.vector4_f32[0]) ? 0xFFFFFFFFU : 0,
+            XMISNAN(V.vector4_f32[1]) ? 0xFFFFFFFFU : 0,
+            XMISNAN(V.vector4_f32[2]) ? 0xFFFFFFFFU : 0,
+            XMISNAN(V.vector4_f32[3]) ? 0xFFFFFFFFU : 0
         } } };
     return Control.v;
 
@@ -2201,10 +2206,10 @@ inline XMVECTOR XM_CALLCONV XMVectorIsInfinite
 #if defined(_XM_NO_INTRINSICS_)
 
     XMVECTORU32 Control = { { {
-            isinf(V.vector4_f32[0]) ? 0xFFFFFFFFU : 0,
-            isinf(V.vector4_f32[1]) ? 0xFFFFFFFFU : 0,
-            isinf(V.vector4_f32[2]) ? 0xFFFFFFFFU : 0,
-            isinf(V.vector4_f32[3]) ? 0xFFFFFFFFU : 0
+            XMISINF(V.vector4_f32[0]) ? 0xFFFFFFFFU : 0,
+            XMISINF(V.vector4_f32[1]) ? 0xFFFFFFFFU : 0,
+            XMISINF(V.vector4_f32[2]) ? 0xFFFFFFFFU : 0,
+            XMISINF(V.vector4_f32[3]) ? 0xFFFFFFFFU : 0
         } } };
     return Control.v;
 
@@ -2373,7 +2378,7 @@ inline XMVECTOR XM_CALLCONV XMVectorTruncate
 
     for (i = 0; i < 4; i++)
     {
-        if (isnan(V.vector4_f32[i]))
+        if (XMISNAN(V.vector4_f32[i]))
         {
             Result.vector4_u32[i] = 0x7FC00000;
         }
@@ -6744,8 +6749,8 @@ inline bool XM_CALLCONV XMVector2IsNaN
 )
 {
 #if defined(_XM_NO_INTRINSICS_)
-    return (isnan(V.vector4_f32[0]) ||
-            isnan(V.vector4_f32[1]));
+    return (XMISNAN(V.vector4_f32[0]) ||
+            XMISNAN(V.vector4_f32[1]));
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     float32x2_t VL = vget_low_f32( V );
     // Test against itself. NaN is always not equal
@@ -6769,8 +6774,8 @@ inline bool XM_CALLCONV XMVector2IsInfinite
 {
 #if defined(_XM_NO_INTRINSICS_)
 
-    return (isinf(V.vector4_f32[0]) ||
-            isinf(V.vector4_f32[1]));
+    return (XMISINF(V.vector4_f32[0]) ||
+            XMISINF(V.vector4_f32[1]));
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     // Mask off the sign bit
     uint32x2_t vTemp = vand_u32( vget_low_f32( V ) , vget_low_f32( g_XMAbsMask ) );
@@ -9124,9 +9129,9 @@ inline bool XM_CALLCONV XMVector3IsNaN
 {
 #if defined(_XM_NO_INTRINSICS_)
 
-    return (isnan(V.vector4_f32[0]) ||
-            isnan(V.vector4_f32[1]) ||
-            isnan(V.vector4_f32[2]));
+    return (XMISNAN(V.vector4_f32[0]) ||
+            XMISNAN(V.vector4_f32[1]) ||
+            XMISNAN(V.vector4_f32[2]));
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     // Test against itself. NaN is always not equal
@@ -9151,9 +9156,9 @@ inline bool XM_CALLCONV XMVector3IsInfinite
 )
 {
 #if defined(_XM_NO_INTRINSICS_)
-    return (isinf(V.vector4_f32[0]) ||
-            isinf(V.vector4_f32[1]) ||
-            isinf(V.vector4_f32[2]));
+    return (XMISINF(V.vector4_f32[0]) ||
+            XMISINF(V.vector4_f32[1]) ||
+            XMISINF(V.vector4_f32[2]));
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     // Mask off the sign bit
     uint32x4_t vTempInf = vandq_u32( V, g_XMAbsMask );
@@ -13115,10 +13120,10 @@ inline bool XM_CALLCONV XMVector4IsNaN
 )
 {
 #if defined(_XM_NO_INTRINSICS_)
-    return (isnan(V.vector4_f32[0]) ||
-            isnan(V.vector4_f32[1]) ||
-            isnan(V.vector4_f32[2]) ||
-            isnan(V.vector4_f32[3]));
+    return (XMISNAN(V.vector4_f32[0]) ||
+            XMISNAN(V.vector4_f32[1]) ||
+            XMISNAN(V.vector4_f32[2]) ||
+            XMISNAN(V.vector4_f32[3]));
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     // Test against itself. NaN is always not equal
     uint32x4_t vTempNan = vceqq_f32( V, V );
@@ -13143,10 +13148,10 @@ inline bool XM_CALLCONV XMVector4IsInfinite
 {
 #if defined(_XM_NO_INTRINSICS_)
 
-    return (isinf(V.vector4_f32[0]) ||
-            isinf(V.vector4_f32[1]) ||
-            isinf(V.vector4_f32[2]) ||
-            isinf(V.vector4_f32[3]));
+    return (XMISINF(V.vector4_f32[0]) ||
+            XMISINF(V.vector4_f32[1]) ||
+            XMISINF(V.vector4_f32[2]) ||
+            XMISINF(V.vector4_f32[3]));
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     // Mask off the sign bit
@@ -14589,6 +14594,11 @@ inline XMVECTOR XM_CALLCONV operator*
 }
 
 #endif /* !_XM_NO_XMVECTOR_OVERLOADS_ */
+
+#if defined(_XM_NO_INTRINSICS_)
+#undef XMISNAN
+#undef XMISINF
+#endif
 
 #if defined(_XM_SSE_INTRINSICS_)
 #undef XM3UNPACK3INTO4


### PR DESCRIPTION
Fixed some warnings 

* old-style-casts
* zero-as-null-pointer-constant
* undefined reinterpret-cast behavior
* sign-conversion
* sign-shift-overflow
* extra-semi