### PR TITLE
Add support for GCC/MinGW compilers

### DIFF
--- a/Extensions/DirectXMathAVX.h
+++ b/Extensions/DirectXMathAVX.h
@@ -28,7 +28,7 @@ inline bool XMVerifyAVXSupport()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid( CPUInfo, 0 );
@@ -37,7 +37,7 @@ inline bool XMVerifyAVXSupport()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1 );

--- a/Extensions/DirectXMathAVX.h
+++ b/Extensions/DirectXMathAVX.h
@@ -94,7 +94,7 @@ inline XMVECTOR XM_CALLCONV XMVectorPermute( FXMVECTOR V1, FXMVECTOR V2, uint32_
 
     static const XMVECTORU32 three = { { { 3, 3, 3, 3 } } };
 
-    __declspec(align(16)) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
+    XM_ALIGNED_DATA(16) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
     __m128i vControl = _mm_load_si128( reinterpret_cast<const __m128i *>(&elem[0]) );
     
     __m128i vSelect = _mm_cmpgt_epi32( vControl, three );

--- a/Extensions/DirectXMathAVX2.h
+++ b/Extensions/DirectXMathAVX2.h
@@ -29,7 +29,7 @@ inline bool XMVerifyAVX2Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ inline bool XMVerifyAVX2Support()
     if ( CPUInfo[0] < 7  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);
@@ -48,7 +48,7 @@ inline bool XMVerifyAVX2Support()
     if ( (CPUInfo[2] & 0x38081001) != 0x38081001 )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__) 
     __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuidex(CPUInfo, 7, 0);

--- a/Extensions/DirectXMathAVX2.h
+++ b/Extensions/DirectXMathAVX2.h
@@ -124,7 +124,7 @@ inline XMVECTOR XM_CALLCONV XMVectorPermute( FXMVECTOR V1, FXMVECTOR V2, uint32_
 
     static const XMVECTORU32 three = { { { 3, 3, 3, 3 } } };
 
-    __declspec(align(16)) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
+    XM_ALIGNED_DATA(16) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
     __m128i vControl = _mm_load_si128( reinterpret_cast<const __m128i *>(&elem[0]) );
     
     __m128i vSelect = _mm_cmpgt_epi32( vControl, three );

--- a/Extensions/DirectXMathBE.h
+++ b/Extensions/DirectXMathBE.h
@@ -59,16 +59,17 @@ inline bool XMVerifySSSE3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
 #endif
 
+
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathF16C.h
+++ b/Extensions/DirectXMathF16C.h
@@ -29,7 +29,7 @@ inline bool XMVerifyF16CSupport()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ inline bool XMVerifyF16CSupport()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA3.h
+++ b/Extensions/DirectXMathFMA3.h
@@ -28,7 +28,7 @@ inline bool XMVerifyFMA3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifyFMA3Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -14,6 +14,9 @@
 #endif
 
 #include <ammintrin.h>
+#ifdef __GNUC__
+#include <x86intrin.h>
+#endif
 
 #include <DirectXMath.h>
 

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -13,8 +13,8 @@
 #error FMA4 not supported on ARM platform
 #endif
 
-#include <ammintrin.h>
 #ifdef __GNUC__
+#include <ammintrin.h>
 #include <x86intrin.h>
 #endif
 

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -30,7 +30,7 @@ inline bool XMVerifyFMA4Support()
 
    // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
    int CPUInfo[4] = {-1};
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
    __cpuid(CPUInfo, 0);
@@ -39,7 +39,7 @@ inline bool XMVerifyFMA4Support()
    if ( CPUInfo[0] < 1  )
        return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
    __cpuid(CPUInfo, 1);
@@ -49,7 +49,7 @@ inline bool XMVerifyFMA4Support()
     if ( (CPUInfo[2] & 0x18000000) != 0x18000000 )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0x80000000);

--- a/Extensions/DirectXMathSSE3.h
+++ b/Extensions/DirectXMathSSE3.h
@@ -29,7 +29,7 @@ inline bool XMVerifySSE3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifySSE3Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathSSE4.h
+++ b/Extensions/DirectXMathSSE4.h
@@ -29,7 +29,7 @@ inline bool XMVerifySSE4Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifySSE4Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -32,7 +32,11 @@
 #endif
 
 #ifndef XM_DEPRECATED
+#ifdef __GNUC__
+#define XM_DEPRECATED __attribute__ ((deprecated))
+#else
 #define XM_DEPRECATED __declspec(deprecated("This is deprecated and will be removed in a future version."))
+#endif
 #endif
 
 #if !defined(_XM_AVX2_INTRINSICS_) && defined(__AVX2__) && !defined(_XM_NO_INTRINSICS_)

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -104,7 +104,7 @@
 #pragma warning(pop)
 #endif
 
-#if defined(__clang__) && (__x86_64__ || __i386__)
+#if (defined(__clang__) || defined(__GNUC__)) && (__x86_64__ || __i386__)
 #include <cpuid.h>
 #endif
 

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -76,7 +76,7 @@
 #if !defined(_XM_ARM_NEON_INTRINSICS_) && !defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
 #if (defined(_M_IX86) || defined(_M_X64) || __i386__ || __x86_64__) && !defined(_M_HYBRID_X86_ARM64)
 #define _XM_SSE_INTRINSICS_
-#elif defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || __arm__ || __aarch64__
+#elif (defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || __arm__ || __aarch64__) && !defined(__GNUC__)
 #define _XM_ARM_NEON_INTRINSICS_
 #elif !defined(_XM_NO_INTRINSICS_)
 #error DirectX Math does not support this target

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -142,6 +142,15 @@
 #include <stdint.h>
 #pragma warning(pop)
 
+//align macros
+#ifdef __GNUC__
+#define XM_ALIGNED_DATA(x) __attribute__ ((aligned(x)))
+#define XM_ALIGNED_STRUCT(x) struct __attribute__ ((aligned(x)))
+#else
+#define XM_ALIGNED_DATA(x) __declspec(align(x))
+#define XM_ALIGNED_STRUCT(x) __declspec(align(x)) struct
+#endif
+
 /****************************************************************************
  *
  * Conditional intrinsics
@@ -342,7 +351,7 @@ namespace DirectX
 
     //------------------------------------------------------------------------------
     // Conversion types for constants
-    __declspec(align(16)) struct XMVECTORF32
+    XM_ALIGNED_STRUCT(16) XMVECTORF32
     {
         union
         {
@@ -358,7 +367,7 @@ namespace DirectX
 #endif
     };
 
-    __declspec(align(16)) struct XMVECTORI32
+    XM_ALIGNED_STRUCT(16) XMVECTORI32
     {
         union
         {
@@ -373,7 +382,7 @@ namespace DirectX
 #endif
     };
 
-    __declspec(align(16)) struct XMVECTORU8
+    XM_ALIGNED_STRUCT(16) XMVECTORU8
     {
         union
         {
@@ -388,7 +397,7 @@ namespace DirectX
 #endif
     };
 
-    __declspec(align(16)) struct XMVECTORU32
+    XM_ALIGNED_STRUCT(16) XMVECTORU32
     {
         union
         {
@@ -446,7 +455,7 @@ namespace DirectX
 #ifdef _XM_NO_INTRINSICS_
     struct XMMATRIX
 #else
-    __declspec(align(16)) struct XMMATRIX
+    XM_ALIGNED_STRUCT(16) XMMATRIX
 #endif
     {
 #ifdef _XM_NO_INTRINSICS_
@@ -529,7 +538,7 @@ namespace DirectX
     };
 
     // 2D Vector; 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT2A : public XMFLOAT2
+    XM_ALIGNED_STRUCT(16) XMFLOAT2A : public XMFLOAT2
     {
         XMFLOAT2A() = default;
 
@@ -601,7 +610,7 @@ namespace DirectX
     };
 
     // 3D Vector; 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT3A : public XMFLOAT3
+    XM_ALIGNED_STRUCT(16) XMFLOAT3A : public XMFLOAT3
     {
         XMFLOAT3A() = default;
 
@@ -676,7 +685,7 @@ namespace DirectX
     };
 
     // 4D Vector; 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT4A : public XMFLOAT4
+    XM_ALIGNED_STRUCT(16) XMFLOAT4A : public XMFLOAT4
     {
         XMFLOAT4A() = default;
 
@@ -806,7 +815,7 @@ namespace DirectX
     };
 
     // 4x3 Row-major Matrix: 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT4X3A : public XMFLOAT4X3
+    XM_ALIGNED_STRUCT(16) XMFLOAT4X3A : public XMFLOAT4X3
     {
         XMFLOAT4X3A() = default;
 
@@ -861,7 +870,7 @@ namespace DirectX
     };
 
     // 3x4 Column-major Matrix: 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT3X4A : public XMFLOAT3X4
+    XM_ALIGNED_STRUCT(16) XMFLOAT3X4A : public XMFLOAT3X4
     {
         XMFLOAT3X4A() = default;
 
@@ -917,7 +926,7 @@ namespace DirectX
     };
 
     // 4x4 Matrix: 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT4X4A : public XMFLOAT4X4
+    XM_ALIGNED_STRUCT(16) XMFLOAT4X4A : public XMFLOAT4X4
     {
         XMFLOAT4X4A() = default;
 

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -25,8 +25,10 @@
 
 #if _XM_VECTORCALL_
 #define XM_CALLCONV __vectorcall
-#else
+#elif !defined(__GNUC__) 
 #define XM_CALLCONV __fastcall
+#else
+#define XM_CALLCONV
 #endif
 
 #ifndef XM_DEPRECATED

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -85,7 +85,7 @@
 #endif
 #endif // !_XM_ARM_NEON_INTRINSICS_ && !_XM_SSE_INTRINSICS_ && !_XM_NO_INTRINSICS_
 
-#if !defined(_XM_NO_XMVECTOR_OVERLOADS_) && defined(__clang__)
+#if !defined(_XM_NO_XMVECTOR_OVERLOADS_) && (defined(__clang__) || defined(__GNUC__))
 #define _XM_NO_XMVECTOR_OVERLOADS_
 #endif
 

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -139,7 +139,27 @@
 #endif
 #endif // !_XM_NO_INTRINSICS_
 
+#ifdef _WIN32
 #include "sal.h"
+#else
+#define _Analysis_assume_(x)
+#define _In_
+#define _In_opt_
+#define _In_reads_(x)
+#define _In_reads_bytes_(x)
+#define _In_reads_opt_(x)
+#define _In_z_
+#define _Inout_
+#define _Inout_updates_(x)
+#define _Out_
+#define _Out_opt_
+#define _Out_writes_(x)
+#define _Out_writes_bytes_(x)
+#define _Out_writes_opt_(x)
+#define _Success_(x)
+#define _Use_decl_annotations_
+#endif
+
 #include <assert.h>
 
 #pragma warning(push)

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -1908,7 +1908,11 @@ namespace DirectX
      // separate math routine it would be reloaded.
 
 #ifndef XMGLOBALCONST
+#if defined(__GNUC__) && !defined(_WIN32)
+#define XMGLOBALCONST extern const __attribute__((weak))
+#else
 #define XMGLOBALCONST extern const __declspec(selectany)
+#endif
 #endif
 
     XMGLOBALCONST XMVECTORF32 g_XMSinCoefficients0 = { { { -0.16666667f, +0.0083333310f, -0.00019840874f, +2.7525562e-06f } } };

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -1917,7 +1917,7 @@ inline bool XMVerifyCPUSupport() noexcept
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -1931,7 +1931,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false;
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);
@@ -1966,7 +1966,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false; // No SSE2/SSE support
 
 #if defined(__AVX2__) || defined(_XM_AVX2_INTRINSICS_)
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuidex(CPUInfo, 7, 0);

--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -1297,7 +1297,7 @@ inline XMVECTOR XM_CALLCONV XMVectorPermute
 #elif defined(_XM_AVX_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     static const XMVECTORU32 three = { { { 3, 3, 3, 3 } } };
 
-    __declspec(align(16)) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
+    XM_ALIGNED_DATA(16) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
     __m128i vControl = _mm_load_si128(reinterpret_cast<const __m128i*>(&elem[0]));
 
     __m128i vSelect = _mm_cmpgt_epi32(vControl, three);
@@ -4055,8 +4055,8 @@ inline XMVECTOR XM_CALLCONV XMVectorPow
         } } };
     return vResult.v;
 #elif defined(_XM_SSE_INTRINSICS_)
-    __declspec(align(16)) float a[4];
-    __declspec(align(16)) float b[4];
+    XM_ALIGNED_DATA(16) float a[4];
+    XM_ALIGNED_DATA(16) float b[4];
     _mm_store_ps(a, V1);
     _mm_store_ps(b, V2);
     XMVECTOR vResult = _mm_setr_ps(

--- a/Inc/DirectXPackedVector.inl
+++ b/Inc/DirectXPackedVector.inl
@@ -1164,7 +1164,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat3PK(const XMFLOAT3PK* pSource) noexcept
 {
     assert(pSource);
 
-    __declspec(align(16)) uint32_t Result[4];
+    XM_ALIGNED_DATA(16) uint32_t Result[4];
     uint32_t Mantissa;
     uint32_t Exponent;
 
@@ -2481,7 +2481,7 @@ inline void XM_CALLCONV XMStoreFloat3PK
 {
     assert(pDestination);
 
-    __declspec(align(16)) uint32_t IValue[4];
+    XM_ALIGNED_DATA(16) uint32_t IValue[4];
     XMStoreFloat3A(reinterpret_cast<XMFLOAT3A*>(&IValue), V);
 
     uint32_t Result[3];

--- a/XDSP/XDSP.h
+++ b/XDSP/XDSP.h
@@ -22,6 +22,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifndef _WIN32
+#define memcpy_s(d,ds,s,c) memcpy(d,s,c)
+#endif
+
 #pragma warning(push)
 #pragma warning(disable: 6001 6262)
 


### PR DESCRIPTION
* Fixes compilation under GCC.
* Fixes AVX2 detection for Clang

Tested under 
* Ubuntu 19.04 AMD64
   * GCC 8.3
   * Clang 8.0
* Windows 10 AMD64
   * MSVC 16.3 Preview 1
   * MinGW 9.1

Test suite is OK for all cases: 476/476 (https://github.com/Mixaill/directxmathtest/tree/gcc-fixes)