### PR TITLE
Added noexcept to all functions

### DIFF
--- a/Inc/DirectXCollision.h
+++ b/Inc/DirectXCollision.h
@@ -54,49 +54,49 @@ namespace DirectX
         BoundingSphere(BoundingSphere&&) = default;
         BoundingSphere& operator=(BoundingSphere&&) = default;
 
-        XM_CONSTEXPR BoundingSphere(_In_ const XMFLOAT3& center, _In_ float radius)
+        XM_CONSTEXPR BoundingSphere(_In_ const XMFLOAT3& center, _In_ float radius) noexcept
             : Center(center), Radius(radius) {}
 
         // Methods
-        void    XM_CALLCONV     Transform(_Out_ BoundingSphere& Out, _In_ FXMMATRIX M) const;
-        void    XM_CALLCONV     Transform(_Out_ BoundingSphere& Out, _In_ float Scale, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) const;
+        void    XM_CALLCONV     Transform(_Out_ BoundingSphere& Out, _In_ FXMMATRIX M) const noexcept;
+        void    XM_CALLCONV     Transform(_Out_ BoundingSphere& Out, _In_ float Scale, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) const noexcept;
         // Transform the sphere
 
-        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR Point) const;
-        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const;
-        ContainmentType Contains(_In_ const BoundingSphere& sh) const;
-        ContainmentType Contains(_In_ const BoundingBox& box) const;
-        ContainmentType Contains(_In_ const BoundingOrientedBox& box) const;
-        ContainmentType Contains(_In_ const BoundingFrustum& fr) const;
+        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR Point) const noexcept;
+        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const noexcept;
+        ContainmentType Contains(_In_ const BoundingSphere& sh) const noexcept;
+        ContainmentType Contains(_In_ const BoundingBox& box) const noexcept;
+        ContainmentType Contains(_In_ const BoundingOrientedBox& box) const noexcept;
+        ContainmentType Contains(_In_ const BoundingFrustum& fr) const noexcept;
 
-        bool Intersects(_In_ const BoundingSphere& sh) const;
-        bool Intersects(_In_ const BoundingBox& box) const;
-        bool Intersects(_In_ const BoundingOrientedBox& box) const;
-        bool Intersects(_In_ const BoundingFrustum& fr) const;
+        bool Intersects(_In_ const BoundingSphere& sh) const noexcept;
+        bool Intersects(_In_ const BoundingBox& box) const noexcept;
+        bool Intersects(_In_ const BoundingOrientedBox& box) const noexcept;
+        bool Intersects(_In_ const BoundingFrustum& fr) const noexcept;
 
-        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const;
+        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const noexcept;
         // Triangle-sphere test
 
-        PlaneIntersectionType    XM_CALLCONV     Intersects(_In_ FXMVECTOR Plane) const;
+        PlaneIntersectionType    XM_CALLCONV     Intersects(_In_ FXMVECTOR Plane) const noexcept;
         // Plane-sphere test
 
-        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR Origin, _In_ FXMVECTOR Direction, _Out_ float& Dist) const;
+        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR Origin, _In_ FXMVECTOR Direction, _Out_ float& Dist) const noexcept;
         // Ray-sphere test
 
         ContainmentType     XM_CALLCONV     ContainedBy(_In_ FXMVECTOR Plane0, _In_ FXMVECTOR Plane1, _In_ FXMVECTOR Plane2,
-            _In_ GXMVECTOR Plane3, _In_ HXMVECTOR Plane4, _In_ HXMVECTOR Plane5) const;
+            _In_ GXMVECTOR Plane3, _In_ HXMVECTOR Plane4, _In_ HXMVECTOR Plane5) const noexcept;
         // Test sphere against six planes (see BoundingFrustum::GetPlanes)
 
     // Static methods
-        static void CreateMerged(_Out_ BoundingSphere& Out, _In_ const BoundingSphere& S1, _In_ const BoundingSphere& S2);
+        static void CreateMerged(_Out_ BoundingSphere& Out, _In_ const BoundingSphere& S1, _In_ const BoundingSphere& S2) noexcept;
 
-        static void CreateFromBoundingBox(_Out_ BoundingSphere& Out, _In_ const BoundingBox& box);
-        static void CreateFromBoundingBox(_Out_ BoundingSphere& Out, _In_ const BoundingOrientedBox& box);
+        static void CreateFromBoundingBox(_Out_ BoundingSphere& Out, _In_ const BoundingBox& box) noexcept;
+        static void CreateFromBoundingBox(_Out_ BoundingSphere& Out, _In_ const BoundingOrientedBox& box) noexcept;
 
         static void CreateFromPoints(_Out_ BoundingSphere& Out, _In_ size_t Count,
-            _In_reads_bytes_(sizeof(XMFLOAT3) + Stride * (Count - 1)) const XMFLOAT3* pPoints, _In_ size_t Stride);
+            _In_reads_bytes_(sizeof(XMFLOAT3) + Stride * (Count - 1)) const XMFLOAT3* pPoints, _In_ size_t Stride) noexcept;
 
-        static void CreateFromFrustum(_Out_ BoundingSphere& Out, _In_ const BoundingFrustum& fr);
+        static void CreateFromFrustum(_Out_ BoundingSphere& Out, _In_ const BoundingFrustum& fr) noexcept;
     };
 
     //-------------------------------------------------------------------------------------
@@ -118,49 +118,49 @@ namespace DirectX
         BoundingBox(BoundingBox&&) = default;
         BoundingBox& operator=(BoundingBox&&) = default;
 
-        XM_CONSTEXPR BoundingBox(_In_ const XMFLOAT3& center, _In_ const XMFLOAT3& extents)
+        XM_CONSTEXPR BoundingBox(_In_ const XMFLOAT3& center, _In_ const XMFLOAT3& extents) noexcept
             : Center(center), Extents(extents) {}
 
         // Methods
-        void    XM_CALLCONV     Transform(_Out_ BoundingBox& Out, _In_ FXMMATRIX M) const;
-        void    XM_CALLCONV     Transform(_Out_ BoundingBox& Out, _In_ float Scale, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) const;
+        void    XM_CALLCONV     Transform(_Out_ BoundingBox& Out, _In_ FXMMATRIX M) const noexcept;
+        void    XM_CALLCONV     Transform(_Out_ BoundingBox& Out, _In_ float Scale, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) const noexcept;
 
-        void GetCorners(_Out_writes_(8) XMFLOAT3* Corners) const;
+        void GetCorners(_Out_writes_(8) XMFLOAT3* Corners) const noexcept;
         // Gets the 8 corners of the box
 
-        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR Point) const;
-        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const;
-        ContainmentType Contains(_In_ const BoundingSphere& sh) const;
-        ContainmentType Contains(_In_ const BoundingBox& box) const;
-        ContainmentType Contains(_In_ const BoundingOrientedBox& box) const;
-        ContainmentType Contains(_In_ const BoundingFrustum& fr) const;
+        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR Point) const noexcept;
+        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const noexcept;
+        ContainmentType Contains(_In_ const BoundingSphere& sh) const noexcept;
+        ContainmentType Contains(_In_ const BoundingBox& box) const noexcept;
+        ContainmentType Contains(_In_ const BoundingOrientedBox& box) const noexcept;
+        ContainmentType Contains(_In_ const BoundingFrustum& fr) const noexcept;
 
-        bool Intersects(_In_ const BoundingSphere& sh) const;
-        bool Intersects(_In_ const BoundingBox& box) const;
-        bool Intersects(_In_ const BoundingOrientedBox& box) const;
-        bool Intersects(_In_ const BoundingFrustum& fr) const;
+        bool Intersects(_In_ const BoundingSphere& sh) const noexcept;
+        bool Intersects(_In_ const BoundingBox& box) const noexcept;
+        bool Intersects(_In_ const BoundingOrientedBox& box) const noexcept;
+        bool Intersects(_In_ const BoundingFrustum& fr) const noexcept;
 
-        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const;
+        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const noexcept;
         // Triangle-Box test
 
-        PlaneIntersectionType    XM_CALLCONV     Intersects(_In_ FXMVECTOR Plane) const;
+        PlaneIntersectionType    XM_CALLCONV     Intersects(_In_ FXMVECTOR Plane) const noexcept;
         // Plane-box test
 
-        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR Origin, _In_ FXMVECTOR Direction, _Out_ float& Dist) const;
+        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR Origin, _In_ FXMVECTOR Direction, _Out_ float& Dist) const noexcept;
         // Ray-Box test
 
         ContainmentType     XM_CALLCONV     ContainedBy(_In_ FXMVECTOR Plane0, _In_ FXMVECTOR Plane1, _In_ FXMVECTOR Plane2,
-            _In_ GXMVECTOR Plane3, _In_ HXMVECTOR Plane4, _In_ HXMVECTOR Plane5) const;
+            _In_ GXMVECTOR Plane3, _In_ HXMVECTOR Plane4, _In_ HXMVECTOR Plane5) const noexcept;
         // Test box against six planes (see BoundingFrustum::GetPlanes)
 
     // Static methods
-        static void CreateMerged(_Out_ BoundingBox& Out, _In_ const BoundingBox& b1, _In_ const BoundingBox& b2);
+        static void CreateMerged(_Out_ BoundingBox& Out, _In_ const BoundingBox& b1, _In_ const BoundingBox& b2) noexcept;
 
-        static void CreateFromSphere(_Out_ BoundingBox& Out, _In_ const BoundingSphere& sh);
+        static void CreateFromSphere(_Out_ BoundingBox& Out, _In_ const BoundingSphere& sh) noexcept;
 
-        static void    XM_CALLCONV     CreateFromPoints(_Out_ BoundingBox& Out, _In_ FXMVECTOR pt1, _In_ FXMVECTOR pt2);
+        static void    XM_CALLCONV     CreateFromPoints(_Out_ BoundingBox& Out, _In_ FXMVECTOR pt1, _In_ FXMVECTOR pt2) noexcept;
         static void CreateFromPoints(_Out_ BoundingBox& Out, _In_ size_t Count,
-            _In_reads_bytes_(sizeof(XMFLOAT3) + Stride * (Count - 1)) const XMFLOAT3* pPoints, _In_ size_t Stride);
+            _In_reads_bytes_(sizeof(XMFLOAT3) + Stride * (Count - 1)) const XMFLOAT3* pPoints, _In_ size_t Stride) noexcept;
     };
 
     //-------------------------------------------------------------------------------------
@@ -183,46 +183,46 @@ namespace DirectX
         BoundingOrientedBox(BoundingOrientedBox&&) = default;
         BoundingOrientedBox& operator=(BoundingOrientedBox&&) = default;
 
-        XM_CONSTEXPR BoundingOrientedBox(_In_ const XMFLOAT3& _Center, _In_ const XMFLOAT3& _Extents, _In_ const XMFLOAT4& _Orientation)
+        XM_CONSTEXPR BoundingOrientedBox(_In_ const XMFLOAT3& _Center, _In_ const XMFLOAT3& _Extents, _In_ const XMFLOAT4& _Orientation) noexcept
             : Center(_Center), Extents(_Extents), Orientation(_Orientation) {}
 
         // Methods
-        void    XM_CALLCONV     Transform(_Out_ BoundingOrientedBox& Out, _In_ FXMMATRIX M) const;
-        void    XM_CALLCONV     Transform(_Out_ BoundingOrientedBox& Out, _In_ float Scale, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) const;
+        void    XM_CALLCONV     Transform(_Out_ BoundingOrientedBox& Out, _In_ FXMMATRIX M) const noexcept;
+        void    XM_CALLCONV     Transform(_Out_ BoundingOrientedBox& Out, _In_ float Scale, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) const noexcept;
 
-        void GetCorners(_Out_writes_(8) XMFLOAT3* Corners) const;
+        void GetCorners(_Out_writes_(8) XMFLOAT3* Corners) const noexcept;
         // Gets the 8 corners of the box
 
-        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR Point) const;
-        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const;
-        ContainmentType Contains(_In_ const BoundingSphere& sh) const;
-        ContainmentType Contains(_In_ const BoundingBox& box) const;
-        ContainmentType Contains(_In_ const BoundingOrientedBox& box) const;
-        ContainmentType Contains(_In_ const BoundingFrustum& fr) const;
+        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR Point) const noexcept;
+        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const noexcept;
+        ContainmentType Contains(_In_ const BoundingSphere& sh) const noexcept;
+        ContainmentType Contains(_In_ const BoundingBox& box) const noexcept;
+        ContainmentType Contains(_In_ const BoundingOrientedBox& box) const noexcept;
+        ContainmentType Contains(_In_ const BoundingFrustum& fr) const noexcept;
 
-        bool Intersects(_In_ const BoundingSphere& sh) const;
-        bool Intersects(_In_ const BoundingBox& box) const;
-        bool Intersects(_In_ const BoundingOrientedBox& box) const;
-        bool Intersects(_In_ const BoundingFrustum& fr) const;
+        bool Intersects(_In_ const BoundingSphere& sh) const noexcept;
+        bool Intersects(_In_ const BoundingBox& box) const noexcept;
+        bool Intersects(_In_ const BoundingOrientedBox& box) const noexcept;
+        bool Intersects(_In_ const BoundingFrustum& fr) const noexcept;
 
-        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const;
+        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const noexcept;
         // Triangle-OrientedBox test
 
-        PlaneIntersectionType    XM_CALLCONV     Intersects(_In_ FXMVECTOR Plane) const;
+        PlaneIntersectionType    XM_CALLCONV     Intersects(_In_ FXMVECTOR Plane) const noexcept;
         // Plane-OrientedBox test
 
-        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR Origin, _In_ FXMVECTOR Direction, _Out_ float& Dist) const;
+        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR Origin, _In_ FXMVECTOR Direction, _Out_ float& Dist) const noexcept;
         // Ray-OrientedBox test
 
         ContainmentType     XM_CALLCONV     ContainedBy(_In_ FXMVECTOR Plane0, _In_ FXMVECTOR Plane1, _In_ FXMVECTOR Plane2,
-            _In_ GXMVECTOR Plane3, _In_ HXMVECTOR Plane4, _In_ HXMVECTOR Plane5) const;
+            _In_ GXMVECTOR Plane3, _In_ HXMVECTOR Plane4, _In_ HXMVECTOR Plane5) const noexcept;
         // Test OrientedBox against six planes (see BoundingFrustum::GetPlanes)
 
     // Static methods
-        static void CreateFromBoundingBox(_Out_ BoundingOrientedBox& Out, _In_ const BoundingBox& box);
+        static void CreateFromBoundingBox(_Out_ BoundingOrientedBox& Out, _In_ const BoundingBox& box) noexcept;
 
         static void CreateFromPoints(_Out_ BoundingOrientedBox& Out, _In_ size_t Count,
-            _In_reads_bytes_(sizeof(XMFLOAT3) + Stride * (Count - 1)) const XMFLOAT3* pPoints, _In_ size_t Stride);
+            _In_reads_bytes_(sizeof(XMFLOAT3) + Stride * (Count - 1)) const XMFLOAT3* pPoints, _In_ size_t Stride) noexcept;
     };
 
     //-------------------------------------------------------------------------------------
@@ -254,51 +254,51 @@ namespace DirectX
 
         XM_CONSTEXPR BoundingFrustum(_In_ const XMFLOAT3& _Origin, _In_ const XMFLOAT4& _Orientation,
             _In_ float _RightSlope, _In_ float _LeftSlope, _In_ float _TopSlope, _In_ float _BottomSlope,
-            _In_ float _Near, _In_ float _Far)
+            _In_ float _Near, _In_ float _Far) noexcept
             : Origin(_Origin), Orientation(_Orientation),
             RightSlope(_RightSlope), LeftSlope(_LeftSlope), TopSlope(_TopSlope), BottomSlope(_BottomSlope),
             Near(_Near), Far(_Far) {}
-        BoundingFrustum(_In_ CXMMATRIX Projection);
+        BoundingFrustum(_In_ CXMMATRIX Projection) noexcept;
 
         // Methods
-        void    XM_CALLCONV     Transform(_Out_ BoundingFrustum& Out, _In_ FXMMATRIX M) const;
-        void    XM_CALLCONV     Transform(_Out_ BoundingFrustum& Out, _In_ float Scale, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) const;
+        void    XM_CALLCONV     Transform(_Out_ BoundingFrustum& Out, _In_ FXMMATRIX M) const noexcept;
+        void    XM_CALLCONV     Transform(_Out_ BoundingFrustum& Out, _In_ float Scale, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) const noexcept;
 
-        void GetCorners(_Out_writes_(8) XMFLOAT3* Corners) const;
+        void GetCorners(_Out_writes_(8) XMFLOAT3* Corners) const noexcept;
         // Gets the 8 corners of the frustum
 
-        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR Point) const;
-        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const;
-        ContainmentType Contains(_In_ const BoundingSphere& sp) const;
-        ContainmentType Contains(_In_ const BoundingBox& box) const;
-        ContainmentType Contains(_In_ const BoundingOrientedBox& box) const;
-        ContainmentType Contains(_In_ const BoundingFrustum& fr) const;
+        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR Point) const noexcept;
+        ContainmentType    XM_CALLCONV     Contains(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const noexcept;
+        ContainmentType Contains(_In_ const BoundingSphere& sp) const noexcept;
+        ContainmentType Contains(_In_ const BoundingBox& box) const noexcept;
+        ContainmentType Contains(_In_ const BoundingOrientedBox& box) const noexcept;
+        ContainmentType Contains(_In_ const BoundingFrustum& fr) const noexcept;
         // Frustum-Frustum test
 
-        bool Intersects(_In_ const BoundingSphere& sh) const;
-        bool Intersects(_In_ const BoundingBox& box) const;
-        bool Intersects(_In_ const BoundingOrientedBox& box) const;
-        bool Intersects(_In_ const BoundingFrustum& fr) const;
+        bool Intersects(_In_ const BoundingSphere& sh) const noexcept;
+        bool Intersects(_In_ const BoundingBox& box) const noexcept;
+        bool Intersects(_In_ const BoundingOrientedBox& box) const noexcept;
+        bool Intersects(_In_ const BoundingFrustum& fr) const noexcept;
 
-        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const;
+        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) const noexcept;
         // Triangle-Frustum test
 
-        PlaneIntersectionType    XM_CALLCONV     Intersects(_In_ FXMVECTOR Plane) const;
+        PlaneIntersectionType    XM_CALLCONV     Intersects(_In_ FXMVECTOR Plane) const noexcept;
         // Plane-Frustum test
 
-        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR rayOrigin, _In_ FXMVECTOR Direction, _Out_ float& Dist) const;
+        bool    XM_CALLCONV     Intersects(_In_ FXMVECTOR rayOrigin, _In_ FXMVECTOR Direction, _Out_ float& Dist) const noexcept;
         // Ray-Frustum test
 
         ContainmentType     XM_CALLCONV     ContainedBy(_In_ FXMVECTOR Plane0, _In_ FXMVECTOR Plane1, _In_ FXMVECTOR Plane2,
-            _In_ GXMVECTOR Plane3, _In_ HXMVECTOR Plane4, _In_ HXMVECTOR Plane5) const;
+            _In_ GXMVECTOR Plane3, _In_ HXMVECTOR Plane4, _In_ HXMVECTOR Plane5) const noexcept;
         // Test frustum against six planes (see BoundingFrustum::GetPlanes)
 
         void GetPlanes(_Out_opt_ XMVECTOR* NearPlane, _Out_opt_ XMVECTOR* FarPlane, _Out_opt_ XMVECTOR* RightPlane,
-            _Out_opt_ XMVECTOR* LeftPlane, _Out_opt_ XMVECTOR* TopPlane, _Out_opt_ XMVECTOR* BottomPlane) const;
+            _Out_opt_ XMVECTOR* LeftPlane, _Out_opt_ XMVECTOR* TopPlane, _Out_opt_ XMVECTOR* BottomPlane) const noexcept;
         // Create 6 Planes representation of Frustum
 
     // Static methods
-        static void     XM_CALLCONV     CreateFromMatrix(_Out_ BoundingFrustum& Out, _In_ FXMMATRIX Projection);
+        static void     XM_CALLCONV     CreateFromMatrix(_Out_ BoundingFrustum& Out, _In_ FXMMATRIX Projection) noexcept;
     };
 
     //-----------------------------------------------------------------------------
@@ -306,18 +306,18 @@ namespace DirectX
     //-----------------------------------------------------------------------------
     namespace TriangleTests
     {
-        bool                    XM_CALLCONV     Intersects(_In_ FXMVECTOR Origin, _In_ FXMVECTOR Direction, _In_ FXMVECTOR V0, _In_ GXMVECTOR V1, _In_ HXMVECTOR V2, _Out_ float& Dist);
+        bool                    XM_CALLCONV     Intersects(_In_ FXMVECTOR Origin, _In_ FXMVECTOR Direction, _In_ FXMVECTOR V0, _In_ GXMVECTOR V1, _In_ HXMVECTOR V2, _Out_ float& Dist) noexcept;
         // Ray-Triangle
 
-        bool                    XM_CALLCONV     Intersects(_In_ FXMVECTOR A0, _In_ FXMVECTOR A1, _In_ FXMVECTOR A2, _In_ GXMVECTOR B0, _In_ HXMVECTOR B1, _In_ HXMVECTOR B2);
+        bool                    XM_CALLCONV     Intersects(_In_ FXMVECTOR A0, _In_ FXMVECTOR A1, _In_ FXMVECTOR A2, _In_ GXMVECTOR B0, _In_ HXMVECTOR B1, _In_ HXMVECTOR B2) noexcept;
         // Triangle-Triangle
 
-        PlaneIntersectionType   XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2, _In_ GXMVECTOR Plane);
+        PlaneIntersectionType   XM_CALLCONV     Intersects(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2, _In_ GXMVECTOR Plane) noexcept;
         // Plane-Triangle
 
         ContainmentType         XM_CALLCONV     ContainedBy(_In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2,
             _In_ GXMVECTOR Plane0, _In_ HXMVECTOR Plane1, _In_ HXMVECTOR Plane2,
-            _In_ CXMVECTOR Plane3, _In_ CXMVECTOR Plane4, _In_ CXMVECTOR Plane5);
+            _In_ CXMVECTOR Plane3, _In_ CXMVECTOR Plane4, _In_ CXMVECTOR Plane5) noexcept;
         // Test a triangle against six planes at once (see BoundingFrustum::GetPlanes)
     }
 

--- a/Inc/DirectXCollision.inl
+++ b/Inc/DirectXCollision.inl
@@ -33,7 +33,7 @@ namespace Internal
     // Return true if any of the elements of a 3 vector are equal to 0xffffffff.
     // Slightly more efficient than using XMVector3EqualInt.
     //-----------------------------------------------------------------------------
-    inline bool XMVector3AnyTrue(_In_ FXMVECTOR V)
+    inline bool XMVector3AnyTrue(_In_ FXMVECTOR V) noexcept
     {
         // Duplicate the fourth element from the first element.
         XMVECTOR C = XMVectorSwizzle<XM_SWIZZLE_X, XM_SWIZZLE_Y, XM_SWIZZLE_Z, XM_SWIZZLE_X>(V);
@@ -46,7 +46,7 @@ namespace Internal
     // Return true if all of the elements of a 3 vector are equal to 0xffffffff.
     // Slightly more efficient than using XMVector3EqualInt.
     //-----------------------------------------------------------------------------
-    inline bool XMVector3AllTrue(_In_ FXMVECTOR V)
+    inline bool XMVector3AllTrue(_In_ FXMVECTOR V) noexcept
     {
         // Duplicate the fourth element from the first element.
         XMVECTOR C = XMVectorSwizzle<XM_SWIZZLE_X, XM_SWIZZLE_Y, XM_SWIZZLE_Z, XM_SWIZZLE_X>(V);
@@ -63,7 +63,7 @@ namespace Internal
     //-----------------------------------------------------------------------------
     // Return true if the vector is a unit vector (length == 1).
     //-----------------------------------------------------------------------------
-    inline bool XMVector3IsUnit(_In_ FXMVECTOR V)
+    inline bool XMVector3IsUnit(_In_ FXMVECTOR V) noexcept
     {
         XMVECTOR Difference = XMVectorSubtract(XMVector3Length(V), XMVectorSplatOne());
         return XMVector4Less(XMVectorAbs(Difference), g_UnitVectorEpsilon);
@@ -72,7 +72,7 @@ namespace Internal
     //-----------------------------------------------------------------------------
     // Return true if the quaterion is a unit quaternion.
     //-----------------------------------------------------------------------------
-    inline bool XMQuaternionIsUnit(_In_ FXMVECTOR Q)
+    inline bool XMQuaternionIsUnit(_In_ FXMVECTOR Q) noexcept
     {
         XMVECTOR Difference = XMVectorSubtract(XMVector4Length(Q), XMVectorSplatOne());
         return XMVector4Less(XMVectorAbs(Difference), g_UnitQuaternionEpsilon);
@@ -81,7 +81,7 @@ namespace Internal
     //-----------------------------------------------------------------------------
     // Return true if the plane is a unit plane.
     //-----------------------------------------------------------------------------
-    inline bool XMPlaneIsUnit(_In_ FXMVECTOR Plane)
+    inline bool XMPlaneIsUnit(_In_ FXMVECTOR Plane) noexcept
     {
         XMVECTOR Difference = XMVectorSubtract(XMVector3Length(Plane), XMVectorSplatOne());
         return XMVector4Less(XMVectorAbs(Difference), g_UnitPlaneEpsilon);
@@ -90,7 +90,7 @@ namespace Internal
 #endif // _PREFAST_ || !NDEBUG
 
     //-----------------------------------------------------------------------------
-    inline XMVECTOR XMPlaneTransform(_In_ FXMVECTOR Plane, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation)
+    inline XMVECTOR XMPlaneTransform(_In_ FXMVECTOR Plane, _In_ FXMVECTOR Rotation, _In_ FXMVECTOR Translation) noexcept
     {
         XMVECTOR vNormal = XMVector3Rotate(Plane, Rotation);
         XMVECTOR vD = XMVectorSubtract(XMVectorSplatW(Plane), XMVector3Dot(vNormal, Translation));
@@ -101,7 +101,7 @@ namespace Internal
     //-----------------------------------------------------------------------------
     // Return the point on the line segement (S1, S2) nearest the point P.
     //-----------------------------------------------------------------------------
-    inline XMVECTOR PointOnLineSegmentNearestPoint(_In_ FXMVECTOR S1, _In_ FXMVECTOR S2, _In_ FXMVECTOR P)
+    inline XMVECTOR PointOnLineSegmentNearestPoint(_In_ FXMVECTOR S1, _In_ FXMVECTOR S2, _In_ FXMVECTOR P) noexcept
     {
         XMVECTOR Dir = XMVectorSubtract(S2, S1);
         XMVECTOR Projection = XMVectorSubtract(XMVector3Dot(P, Dir), XMVector3Dot(S1, Dir));
@@ -125,7 +125,7 @@ namespace Internal
     // Test if the point (P) on the plane of the triangle is inside the triangle
     // (V0, V1, V2).
     //-----------------------------------------------------------------------------
-    inline XMVECTOR XM_CALLCONV PointOnPlaneInsideTriangle(_In_ FXMVECTOR P, _In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ GXMVECTOR V2)
+    inline XMVECTOR XM_CALLCONV PointOnPlaneInsideTriangle(_In_ FXMVECTOR P, _In_ FXMVECTOR V0, _In_ FXMVECTOR V1, _In_ GXMVECTOR V2) noexcept
     {
         // Compute the triangle normal.
         XMVECTOR N = XMVector3Cross(XMVectorSubtract(V2, V0), XMVectorSubtract(V1, V0));
@@ -148,7 +148,7 @@ namespace Internal
     }
 
     //-----------------------------------------------------------------------------
-    inline bool SolveCubic(_In_ float e, _In_ float f, _In_ float g, _Out_ float* t, _Out_ float* u, _Out_ float* v)
+    inline bool SolveCubic(_In_ float e, _In_ float f, _In_ float g, _Out_ float* t, _Out_ float* u, _Out_ float* v) noexcept
     {
         float p, q, h, rc, d, theta, costh3, sinth3;
 
@@ -189,7 +189,7 @@ namespace Internal
 
     //-----------------------------------------------------------------------------
     inline XMVECTOR CalculateEigenVector(_In_ float m11, _In_ float m12, _In_ float m13,
-        _In_ float m22, _In_ float m23, _In_ float m33, _In_ float e)
+        _In_ float m22, _In_ float m23, _In_ float m33, _In_ float e) noexcept
     {
         float fTmp[3];
         fTmp[0] = m12 * m23 - m13 * (m22 - e);
@@ -260,7 +260,7 @@ namespace Internal
     inline bool CalculateEigenVectors(_In_ float m11, _In_ float m12, _In_ float m13,
         _In_ float m22, _In_ float m23, _In_ float m33,
         _In_ float e1, _In_ float e2, _In_ float e3,
-        _Out_ XMVECTOR* pV1, _Out_ XMVECTOR* pV2, _Out_ XMVECTOR* pV3)
+        _Out_ XMVECTOR* pV1, _Out_ XMVECTOR* pV2, _Out_ XMVECTOR* pV3) noexcept
     {
         *pV1 = DirectX::Internal::CalculateEigenVector(m11, m12, m13, m22, m23, m33, e1);
         *pV2 = DirectX::Internal::CalculateEigenVector(m11, m12, m13, m22, m23, m33, e2);
@@ -354,7 +354,7 @@ namespace Internal
     //-----------------------------------------------------------------------------
     inline bool CalculateEigenVectorsFromCovarianceMatrix(_In_ float Cxx, _In_ float Cyy, _In_ float Czz,
         _In_ float Cxy, _In_ float Cxz, _In_ float Cyz,
-        _Out_ XMVECTOR* pV1, _Out_ XMVECTOR* pV2, _Out_ XMVECTOR* pV3)
+        _Out_ XMVECTOR* pV1, _Out_ XMVECTOR* pV2, _Out_ XMVECTOR* pV3) noexcept
     {
         // Calculate the eigenvalues by solving a cubic equation.
         float e = -(Cxx + Cyy + Czz);
@@ -375,8 +375,10 @@ namespace Internal
     }
 
     //-----------------------------------------------------------------------------
-    inline void XM_CALLCONV FastIntersectTrianglePlane(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2, GXMVECTOR Plane,
-        XMVECTOR& Outside, XMVECTOR& Inside)
+    inline void XM_CALLCONV FastIntersectTrianglePlane(
+        FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2,
+        GXMVECTOR Plane,
+        XMVECTOR& Outside, XMVECTOR& Inside) noexcept
     {
         // Plane0
         XMVECTOR Dist0 = XMVector4Dot(V0, Plane);
@@ -400,7 +402,7 @@ namespace Internal
 
     //-----------------------------------------------------------------------------
     inline void FastIntersectSpherePlane(_In_ FXMVECTOR Center, _In_ FXMVECTOR Radius, _In_ FXMVECTOR Plane,
-        _Out_ XMVECTOR& Outside, _Out_ XMVECTOR& Inside)
+        _Out_ XMVECTOR& Outside, _Out_ XMVECTOR& Inside) noexcept
     {
         XMVECTOR Dist = XMVector4Dot(Center, Plane);
 
@@ -413,7 +415,7 @@ namespace Internal
 
     //-----------------------------------------------------------------------------
     inline void FastIntersectAxisAlignedBoxPlane(_In_ FXMVECTOR Center, _In_ FXMVECTOR Extents, _In_ FXMVECTOR Plane,
-        _Out_ XMVECTOR& Outside, _Out_ XMVECTOR& Inside)
+        _Out_ XMVECTOR& Outside, _Out_ XMVECTOR& Inside) noexcept
     {
         // Compute the distance to the center of the box.
         XMVECTOR Dist = XMVector4Dot(Center, Plane);
@@ -433,8 +435,11 @@ namespace Internal
     }
 
     //-----------------------------------------------------------------------------
-    inline void XM_CALLCONV FastIntersectOrientedBoxPlane(_In_ FXMVECTOR Center, _In_ FXMVECTOR Extents, _In_ FXMVECTOR Axis0, _In_ GXMVECTOR Axis1,
-        _In_ HXMVECTOR Axis2, _In_ HXMVECTOR Plane, _Out_ XMVECTOR& Outside, _Out_ XMVECTOR& Inside)
+    inline void XM_CALLCONV FastIntersectOrientedBoxPlane(
+        _In_ FXMVECTOR Center, _In_ FXMVECTOR Extents, _In_ FXMVECTOR Axis0,
+        _In_ GXMVECTOR Axis1,
+        _In_ HXMVECTOR Axis2, _In_ HXMVECTOR Plane,
+        _Out_ XMVECTOR& Outside, _Out_ XMVECTOR& Inside) noexcept
     {
         // Compute the distance to the center of the box.
         XMVECTOR Dist = XMVector4Dot(Center, Plane);
@@ -457,9 +462,12 @@ namespace Internal
     }
 
     //-----------------------------------------------------------------------------
-    inline void XM_CALLCONV FastIntersectFrustumPlane(_In_ FXMVECTOR Point0, _In_ FXMVECTOR Point1, _In_ FXMVECTOR Point2, _In_ GXMVECTOR Point3,
-        _In_ HXMVECTOR Point4, _In_ HXMVECTOR Point5, _In_ CXMVECTOR Point6, _In_ CXMVECTOR Point7,
-        _In_ CXMVECTOR Plane, _Out_ XMVECTOR& Outside, _Out_ XMVECTOR& Inside)
+    inline void XM_CALLCONV FastIntersectFrustumPlane(
+        _In_ FXMVECTOR Point0, _In_ FXMVECTOR Point1, _In_ FXMVECTOR Point2,
+        _In_ GXMVECTOR Point3,
+        _In_ HXMVECTOR Point4, _In_ HXMVECTOR Point5,
+        _In_ CXMVECTOR Point6, _In_ CXMVECTOR Point7, _In_ CXMVECTOR Plane,
+        _Out_ XMVECTOR& Outside, _Out_ XMVECTOR& Inside) noexcept
     {
         // Find the min/max projection of the frustum onto the plane normal.
         XMVECTOR Min, Max, Dist;
@@ -516,7 +524,7 @@ namespace Internal
  // Transform a sphere by an angle preserving transform.
  //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingSphere::Transform(BoundingSphere& Out, FXMMATRIX M) const
+inline void XM_CALLCONV BoundingSphere::Transform(BoundingSphere& Out, FXMMATRIX M) const noexcept
 {
     // Load the center of the sphere.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -539,7 +547,7 @@ inline void XM_CALLCONV BoundingSphere::Transform(BoundingSphere& Out, FXMMATRIX
 }
 
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingSphere::Transform(BoundingSphere& Out, float Scale, FXMVECTOR Rotation, FXMVECTOR Translation) const
+inline void XM_CALLCONV BoundingSphere::Transform(BoundingSphere& Out, float Scale, FXMVECTOR Rotation, FXMVECTOR Translation) const noexcept
 {
     // Load the center of the sphere.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -559,7 +567,7 @@ inline void XM_CALLCONV BoundingSphere::Transform(BoundingSphere& Out, float Sca
 // Point in sphere test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingSphere::Contains(FXMVECTOR Point) const
+inline ContainmentType XM_CALLCONV BoundingSphere::Contains(FXMVECTOR Point) const noexcept
 {
     XMVECTOR vCenter = XMLoadFloat3(&Center);
     XMVECTOR vRadius = XMVectorReplicatePtr(&Radius);
@@ -575,7 +583,7 @@ inline ContainmentType XM_CALLCONV BoundingSphere::Contains(FXMVECTOR Point) con
 // Triangle in sphere test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingSphere::Contains(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const
+inline ContainmentType XM_CALLCONV BoundingSphere::Contains(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const noexcept
 {
     if (!Intersects(V0, V1, V2))
         return DISJOINT;
@@ -601,7 +609,7 @@ inline ContainmentType XM_CALLCONV BoundingSphere::Contains(FXMVECTOR V0, FXMVEC
 // Sphere in sphere test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingSphere::Contains(const BoundingSphere& sh) const
+inline ContainmentType BoundingSphere::Contains(const BoundingSphere& sh) const noexcept
 {
     XMVECTOR Center1 = XMLoadFloat3(&Center);
     float r1 = Radius;
@@ -623,7 +631,7 @@ inline ContainmentType BoundingSphere::Contains(const BoundingSphere& sh) const
 // Axis-aligned box in sphere test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingSphere::Contains(const BoundingBox& box) const
+inline ContainmentType BoundingSphere::Contains(const BoundingBox& box) const noexcept
 {
     if (!box.Intersects(*this))
         return DISJOINT;
@@ -654,7 +662,7 @@ inline ContainmentType BoundingSphere::Contains(const BoundingBox& box) const
 // Oriented box in sphere test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingSphere::Contains(const BoundingOrientedBox& box) const
+inline ContainmentType BoundingSphere::Contains(const BoundingOrientedBox& box) const noexcept
 {
     if (!box.Intersects(*this))
         return DISJOINT;
@@ -687,7 +695,7 @@ inline ContainmentType BoundingSphere::Contains(const BoundingOrientedBox& box) 
 // Frustum in sphere test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingSphere::Contains(const BoundingFrustum& fr) const
+inline ContainmentType BoundingSphere::Contains(const BoundingFrustum& fr) const noexcept
 {
     if (!fr.Intersects(*this))
         return DISJOINT;
@@ -735,7 +743,7 @@ inline ContainmentType BoundingSphere::Contains(const BoundingFrustum& fr) const
 // Sphere vs. sphere test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingSphere::Intersects(const BoundingSphere& sh) const
+inline bool BoundingSphere::Intersects(const BoundingSphere& sh) const noexcept
 {
     // Load A.
     XMVECTOR vCenterA = XMLoadFloat3(&Center);
@@ -761,13 +769,13 @@ inline bool BoundingSphere::Intersects(const BoundingSphere& sh) const
 // Box vs. sphere test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingSphere::Intersects(const BoundingBox& box) const
+inline bool BoundingSphere::Intersects(const BoundingBox& box) const noexcept
 {
     return box.Intersects(*this);
 }
 
 _Use_decl_annotations_
-inline bool BoundingSphere::Intersects(const BoundingOrientedBox& box) const
+inline bool BoundingSphere::Intersects(const BoundingOrientedBox& box) const noexcept
 {
     return box.Intersects(*this);
 }
@@ -777,7 +785,7 @@ inline bool BoundingSphere::Intersects(const BoundingOrientedBox& box) const
 // Frustum vs. sphere test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingSphere::Intersects(const BoundingFrustum& fr) const
+inline bool BoundingSphere::Intersects(const BoundingFrustum& fr) const noexcept
 {
     return fr.Intersects(*this);
 }
@@ -787,7 +795,7 @@ inline bool BoundingSphere::Intersects(const BoundingFrustum& fr) const
 // Triangle vs sphere test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const
+inline bool XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const noexcept
 {
     // Load the sphere.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -846,7 +854,7 @@ inline bool XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR V0, FXMVECTOR V1, F
 // Sphere-plane intersection
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline PlaneIntersectionType XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR Plane) const
+inline PlaneIntersectionType XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR Plane) const noexcept
 {
     assert(DirectX::Internal::XMPlaneIsUnit(Plane));
 
@@ -877,7 +885,7 @@ inline PlaneIntersectionType XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR Pl
 // Compute the intersection of a ray (Origin, Direction) with a sphere.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR Origin, FXMVECTOR Direction, float& Dist) const
+inline bool XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR Origin, FXMVECTOR Direction, float& Dist) const noexcept
 {
     assert(DirectX::Internal::XMVector3IsUnit(Direction));
 
@@ -931,8 +939,10 @@ inline bool XM_CALLCONV BoundingSphere::Intersects(FXMVECTOR Origin, FXMVECTOR D
 // Test a sphere vs 6 planes (typically forming a frustum).
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingSphere::ContainedBy(FXMVECTOR Plane0, FXMVECTOR Plane1, FXMVECTOR Plane2,
-    GXMVECTOR Plane3, HXMVECTOR Plane4, HXMVECTOR Plane5) const
+inline ContainmentType XM_CALLCONV BoundingSphere::ContainedBy(
+    FXMVECTOR Plane0, FXMVECTOR Plane1, FXMVECTOR Plane2,
+    GXMVECTOR Plane3,
+    HXMVECTOR Plane4, HXMVECTOR Plane5) const noexcept
 {
     // Load the sphere.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -986,7 +996,7 @@ inline ContainmentType XM_CALLCONV BoundingSphere::ContainedBy(FXMVECTOR Plane0,
 // Creates a bounding sphere that contains two other bounding spheres
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingSphere::CreateMerged(BoundingSphere& Out, const BoundingSphere& S1, const BoundingSphere& S2)
+inline void BoundingSphere::CreateMerged(BoundingSphere& Out, const BoundingSphere& S1, const BoundingSphere& S2) noexcept
 {
     XMVECTOR Center1 = XMLoadFloat3(&S1.Center);
     float r1 = S1.Radius;
@@ -1031,7 +1041,7 @@ inline void BoundingSphere::CreateMerged(BoundingSphere& Out, const BoundingSphe
 // Create sphere enscribing bounding box
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingSphere::CreateFromBoundingBox(BoundingSphere& Out, const BoundingBox& box)
+inline void BoundingSphere::CreateFromBoundingBox(BoundingSphere& Out, const BoundingBox& box) noexcept
 {
     Out.Center = box.Center;
     XMVECTOR vExtents = XMLoadFloat3(&box.Extents);
@@ -1039,7 +1049,7 @@ inline void BoundingSphere::CreateFromBoundingBox(BoundingSphere& Out, const Bou
 }
 
 _Use_decl_annotations_
-inline void BoundingSphere::CreateFromBoundingBox(BoundingSphere& Out, const BoundingOrientedBox& box)
+inline void BoundingSphere::CreateFromBoundingBox(BoundingSphere& Out, const BoundingOrientedBox& box) noexcept
 {
     // Bounding box orientation is irrelevant because a sphere is rotationally invariant
     Out.Center = box.Center;
@@ -1056,7 +1066,7 @@ inline void BoundingSphere::CreateFromBoundingBox(BoundingSphere& Out, const Bou
 // Graphics Gems.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingSphere::CreateFromPoints(BoundingSphere& Out, size_t Count, const XMFLOAT3* pPoints, size_t Stride)
+inline void BoundingSphere::CreateFromPoints(BoundingSphere& Out, size_t Count, const XMFLOAT3* pPoints, size_t Stride) noexcept
 {
     assert(Count > 0);
     assert(pPoints);
@@ -1163,7 +1173,7 @@ inline void BoundingSphere::CreateFromPoints(BoundingSphere& Out, size_t Count, 
 // Create sphere containing frustum
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingSphere::CreateFromFrustum(BoundingSphere& Out, const BoundingFrustum& fr)
+inline void BoundingSphere::CreateFromFrustum(BoundingSphere& Out, const BoundingFrustum& fr) noexcept
 {
     XMFLOAT3 Corners[BoundingFrustum::CORNER_COUNT];
     fr.GetCorners(Corners);
@@ -1181,7 +1191,7 @@ inline void BoundingSphere::CreateFromFrustum(BoundingSphere& Out, const Boundin
  // Transform an axis aligned box by an angle preserving transform.
  //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingBox::Transform(BoundingBox& Out, FXMMATRIX M) const
+inline void XM_CALLCONV BoundingBox::Transform(BoundingBox& Out, FXMMATRIX M) const noexcept
 {
     // Load center and extents.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -1209,7 +1219,7 @@ inline void XM_CALLCONV BoundingBox::Transform(BoundingBox& Out, FXMMATRIX M) co
 }
 
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingBox::Transform(BoundingBox& Out, float Scale, FXMVECTOR Rotation, FXMVECTOR Translation) const
+inline void XM_CALLCONV BoundingBox::Transform(BoundingBox& Out, float Scale, FXMVECTOR Rotation, FXMVECTOR Translation) const noexcept
 {
     assert(DirectX::Internal::XMQuaternionIsUnit(Rotation));
 
@@ -1245,7 +1255,7 @@ inline void XM_CALLCONV BoundingBox::Transform(BoundingBox& Out, float Scale, FX
 // Get the corner points of the box
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingBox::GetCorners(XMFLOAT3* Corners) const
+inline void BoundingBox::GetCorners(XMFLOAT3* Corners) const noexcept
 {
     assert(Corners != nullptr);
 
@@ -1265,7 +1275,7 @@ inline void BoundingBox::GetCorners(XMFLOAT3* Corners) const
 // Point in axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingBox::Contains(FXMVECTOR Point) const
+inline ContainmentType XM_CALLCONV BoundingBox::Contains(FXMVECTOR Point) const noexcept
 {
     XMVECTOR vCenter = XMLoadFloat3(&Center);
     XMVECTOR vExtents = XMLoadFloat3(&Extents);
@@ -1278,7 +1288,7 @@ inline ContainmentType XM_CALLCONV BoundingBox::Contains(FXMVECTOR Point) const
 // Triangle in axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingBox::Contains(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const
+inline ContainmentType XM_CALLCONV BoundingBox::Contains(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const noexcept
 {
     if (!Intersects(V0, V1, V2))
         return DISJOINT;
@@ -1303,7 +1313,7 @@ inline ContainmentType XM_CALLCONV BoundingBox::Contains(FXMVECTOR V0, FXMVECTOR
 // Sphere in axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingBox::Contains(const BoundingSphere& sh) const
+inline ContainmentType BoundingBox::Contains(const BoundingSphere& sh) const noexcept
 {
     XMVECTOR SphereCenter = XMLoadFloat3(&sh.Center);
     XMVECTOR SphereRadius = XMVectorReplicatePtr(&sh.Radius);
@@ -1350,7 +1360,7 @@ inline ContainmentType BoundingBox::Contains(const BoundingSphere& sh) const
 // Axis-aligned box in axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingBox::Contains(const BoundingBox& box) const
+inline ContainmentType BoundingBox::Contains(const BoundingBox& box) const noexcept
 {
     XMVECTOR CenterA = XMLoadFloat3(&Center);
     XMVECTOR ExtentsA = XMLoadFloat3(&Extents);
@@ -1381,7 +1391,7 @@ inline ContainmentType BoundingBox::Contains(const BoundingBox& box) const
 // Oriented box in axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingBox::Contains(const BoundingOrientedBox& box) const
+inline ContainmentType BoundingBox::Contains(const BoundingOrientedBox& box) const noexcept
 {
     if (!box.Intersects(*this))
         return DISJOINT;
@@ -1414,7 +1424,7 @@ inline ContainmentType BoundingBox::Contains(const BoundingOrientedBox& box) con
 // Frustum in axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingBox::Contains(const BoundingFrustum& fr) const
+inline ContainmentType BoundingBox::Contains(const BoundingFrustum& fr) const noexcept
 {
     if (!fr.Intersects(*this))
         return DISJOINT;
@@ -1442,7 +1452,7 @@ inline ContainmentType BoundingBox::Contains(const BoundingFrustum& fr) const
 // Sphere vs axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingBox::Intersects(const BoundingSphere& sh) const
+inline bool BoundingBox::Intersects(const BoundingSphere& sh) const noexcept
 {
     XMVECTOR SphereCenter = XMLoadFloat3(&sh.Center);
     XMVECTOR SphereRadius = XMVectorReplicatePtr(&sh.Radius);
@@ -1482,7 +1492,7 @@ inline bool BoundingBox::Intersects(const BoundingSphere& sh) const
 // Axis-aligned box vs. axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingBox::Intersects(const BoundingBox& box) const
+inline bool BoundingBox::Intersects(const BoundingBox& box) const noexcept
 {
     XMVECTOR CenterA = XMLoadFloat3(&Center);
     XMVECTOR ExtentsA = XMLoadFloat3(&Extents);
@@ -1507,7 +1517,7 @@ inline bool BoundingBox::Intersects(const BoundingBox& box) const
 // Oriented box vs. axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingBox::Intersects(const BoundingOrientedBox& box) const
+inline bool BoundingBox::Intersects(const BoundingOrientedBox& box) const noexcept
 {
     return box.Intersects(*this);
 }
@@ -1517,7 +1527,7 @@ inline bool BoundingBox::Intersects(const BoundingOrientedBox& box) const
 // Frustum vs. axis-aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingBox::Intersects(const BoundingFrustum& fr) const
+inline bool BoundingBox::Intersects(const BoundingFrustum& fr) const noexcept
 {
     return fr.Intersects(*this);
 }
@@ -1527,7 +1537,7 @@ inline bool BoundingBox::Intersects(const BoundingFrustum& fr) const
 // Triangle vs. axis aligned box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool XM_CALLCONV BoundingBox::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const
+inline bool XM_CALLCONV BoundingBox::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const noexcept
 {
     XMVECTOR Zero = XMVectorZero();
 
@@ -1693,7 +1703,7 @@ inline bool XM_CALLCONV BoundingBox::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMV
 
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline PlaneIntersectionType XM_CALLCONV BoundingBox::Intersects(FXMVECTOR Plane) const
+inline PlaneIntersectionType XM_CALLCONV BoundingBox::Intersects(FXMVECTOR Plane) const noexcept
 {
     assert(DirectX::Internal::XMPlaneIsUnit(Plane));
 
@@ -1725,7 +1735,7 @@ inline PlaneIntersectionType XM_CALLCONV BoundingBox::Intersects(FXMVECTOR Plane
 // box using the slabs method.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool XM_CALLCONV BoundingBox::Intersects(FXMVECTOR Origin, FXMVECTOR Direction, float& Dist) const
+inline bool XM_CALLCONV BoundingBox::Intersects(FXMVECTOR Origin, FXMVECTOR Direction, float& Dist) const noexcept
 {
     assert(DirectX::Internal::XMVector3IsUnit(Direction));
 
@@ -1787,8 +1797,10 @@ inline bool XM_CALLCONV BoundingBox::Intersects(FXMVECTOR Origin, FXMVECTOR Dire
 // Test an axis alinged box vs 6 planes (typically forming a frustum).
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingBox::ContainedBy(FXMVECTOR Plane0, FXMVECTOR Plane1, FXMVECTOR Plane2,
-    GXMVECTOR Plane3, HXMVECTOR Plane4, HXMVECTOR Plane5) const
+inline ContainmentType XM_CALLCONV BoundingBox::ContainedBy(
+    FXMVECTOR Plane0, FXMVECTOR Plane1, FXMVECTOR Plane2,
+    GXMVECTOR Plane3,
+    HXMVECTOR Plane4, HXMVECTOR Plane5) const noexcept
 {
     // Load the box.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -1842,7 +1854,7 @@ inline ContainmentType XM_CALLCONV BoundingBox::ContainedBy(FXMVECTOR Plane0, FX
 // Create axis-aligned box that contains two other bounding boxes
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingBox::CreateMerged(BoundingBox& Out, const BoundingBox& b1, const BoundingBox& b2)
+inline void BoundingBox::CreateMerged(BoundingBox& Out, const BoundingBox& b1, const BoundingBox& b2) noexcept
 {
     XMVECTOR b1Center = XMLoadFloat3(&b1.Center);
     XMVECTOR b1Extents = XMLoadFloat3(&b1.Extents);
@@ -1867,7 +1879,7 @@ inline void BoundingBox::CreateMerged(BoundingBox& Out, const BoundingBox& b1, c
 // Create axis-aligned box that contains a bounding sphere
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingBox::CreateFromSphere(BoundingBox& Out, const BoundingSphere& sh)
+inline void BoundingBox::CreateFromSphere(BoundingBox& Out, const BoundingSphere& sh) noexcept
 {
     XMVECTOR spCenter = XMLoadFloat3(&sh.Center);
     XMVECTOR shRadius = XMVectorReplicatePtr(&sh.Radius);
@@ -1886,7 +1898,7 @@ inline void BoundingBox::CreateFromSphere(BoundingBox& Out, const BoundingSphere
 // Create axis-aligned box from min/max points
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingBox::CreateFromPoints(BoundingBox& Out, FXMVECTOR pt1, FXMVECTOR pt2)
+inline void XM_CALLCONV BoundingBox::CreateFromPoints(BoundingBox& Out, FXMVECTOR pt1, FXMVECTOR pt2) noexcept
 {
     XMVECTOR Min = XMVectorMin(pt1, pt2);
     XMVECTOR Max = XMVectorMax(pt1, pt2);
@@ -1901,7 +1913,7 @@ inline void XM_CALLCONV BoundingBox::CreateFromPoints(BoundingBox& Out, FXMVECTO
 // Find the minimum axis aligned bounding box containing a set of points.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingBox::CreateFromPoints(BoundingBox& Out, size_t Count, const XMFLOAT3* pPoints, size_t Stride)
+inline void BoundingBox::CreateFromPoints(BoundingBox& Out, size_t Count, const XMFLOAT3* pPoints, size_t Stride) noexcept
 {
     assert(Count > 0);
     assert(pPoints);
@@ -1935,7 +1947,7 @@ inline void BoundingBox::CreateFromPoints(BoundingBox& Out, size_t Count, const 
  // Transform an oriented box by an angle preserving transform.
  //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingOrientedBox::Transform(BoundingOrientedBox& Out, FXMMATRIX M) const
+inline void XM_CALLCONV BoundingOrientedBox::Transform(BoundingOrientedBox& Out, FXMMATRIX M) const noexcept
 {
     // Load the box.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -1972,7 +1984,7 @@ inline void XM_CALLCONV BoundingOrientedBox::Transform(BoundingOrientedBox& Out,
 }
 
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingOrientedBox::Transform(BoundingOrientedBox& Out, float Scale, FXMVECTOR Rotation, FXMVECTOR Translation) const
+inline void XM_CALLCONV BoundingOrientedBox::Transform(BoundingOrientedBox& Out, float Scale, FXMVECTOR Rotation, FXMVECTOR Translation) const noexcept
 {
     assert(DirectX::Internal::XMQuaternionIsUnit(Rotation));
 
@@ -2004,7 +2016,7 @@ inline void XM_CALLCONV BoundingOrientedBox::Transform(BoundingOrientedBox& Out,
 // Get the corner points of the box
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingOrientedBox::GetCorners(XMFLOAT3* Corners) const
+inline void BoundingOrientedBox::GetCorners(XMFLOAT3* Corners) const noexcept
 {
     assert(Corners != nullptr);
 
@@ -2027,7 +2039,7 @@ inline void BoundingOrientedBox::GetCorners(XMFLOAT3* Corners) const
 // Point in oriented box test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingOrientedBox::Contains(FXMVECTOR Point) const
+inline ContainmentType XM_CALLCONV BoundingOrientedBox::Contains(FXMVECTOR Point) const noexcept
 {
     XMVECTOR vCenter = XMLoadFloat3(&Center);
     XMVECTOR vExtents = XMLoadFloat3(&Extents);
@@ -2044,7 +2056,7 @@ inline ContainmentType XM_CALLCONV BoundingOrientedBox::Contains(FXMVECTOR Point
 // Triangle in oriented bounding box
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingOrientedBox::Contains(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const
+inline ContainmentType XM_CALLCONV BoundingOrientedBox::Contains(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const noexcept
 {
     // Load the box center & orientation.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -2068,7 +2080,7 @@ inline ContainmentType XM_CALLCONV BoundingOrientedBox::Contains(FXMVECTOR V0, F
 // Sphere in oriented bounding box
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingOrientedBox::Contains(const BoundingSphere& sh) const
+inline ContainmentType BoundingOrientedBox::Contains(const BoundingSphere& sh) const noexcept
 {
     XMVECTOR SphereCenter = XMLoadFloat3(&sh.Center);
     XMVECTOR SphereRadius = XMVectorReplicatePtr(&sh.Radius);
@@ -2122,7 +2134,7 @@ inline ContainmentType BoundingOrientedBox::Contains(const BoundingSphere& sh) c
 // the oriented box vs. oriented box test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingOrientedBox::Contains(const BoundingBox& box) const
+inline ContainmentType BoundingOrientedBox::Contains(const BoundingBox& box) const noexcept
 {
     // Make the axis aligned box oriented and do an OBB vs OBB test.
     BoundingOrientedBox obox(box.Center, box.Extents, XMFLOAT4(0.f, 0.f, 0.f, 1.f));
@@ -2134,7 +2146,7 @@ inline ContainmentType BoundingOrientedBox::Contains(const BoundingBox& box) con
 // Oriented bounding box in oriented bounding box
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingOrientedBox::Contains(const BoundingOrientedBox& box) const
+inline ContainmentType BoundingOrientedBox::Contains(const BoundingOrientedBox& box) const noexcept
 {
     if (!Intersects(box))
         return DISJOINT;
@@ -2174,7 +2186,7 @@ inline ContainmentType BoundingOrientedBox::Contains(const BoundingOrientedBox& 
 // Frustum in oriented bounding box
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingOrientedBox::Contains(const BoundingFrustum& fr) const
+inline ContainmentType BoundingOrientedBox::Contains(const BoundingFrustum& fr) const noexcept
 {
     if (!fr.Intersects(*this))
         return DISJOINT;
@@ -2205,7 +2217,7 @@ inline ContainmentType BoundingOrientedBox::Contains(const BoundingFrustum& fr) 
 // Sphere vs. oriented box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingOrientedBox::Intersects(const BoundingSphere& sh) const
+inline bool BoundingOrientedBox::Intersects(const BoundingSphere& sh) const noexcept
 {
     XMVECTOR SphereCenter = XMLoadFloat3(&sh.Center);
     XMVECTOR SphereRadius = XMVectorReplicatePtr(&sh.Radius);
@@ -2251,7 +2263,7 @@ inline bool BoundingOrientedBox::Intersects(const BoundingSphere& sh) const
 // the oriented box vs. oriented box test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingOrientedBox::Intersects(const BoundingBox& box) const
+inline bool BoundingOrientedBox::Intersects(const BoundingBox& box) const noexcept
 {
     // Make the axis aligned box oriented and do an OBB vs OBB test.
     BoundingOrientedBox obox(box.Center, box.Extents, XMFLOAT4(0.f, 0.f, 0.f, 1.f));
@@ -2264,7 +2276,7 @@ inline bool BoundingOrientedBox::Intersects(const BoundingBox& box) const
 // theorem.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingOrientedBox::Intersects(const BoundingOrientedBox& box) const
+inline bool BoundingOrientedBox::Intersects(const BoundingOrientedBox& box) const noexcept
 {
     // Build the 3x3 rotation matrix that defines the orientation of B relative to A.
     XMVECTOR A_quat = XMLoadFloat4(&Orientation);
@@ -2469,7 +2481,7 @@ inline bool BoundingOrientedBox::Intersects(const BoundingOrientedBox& box) cons
 // Frustum vs. oriented box test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingOrientedBox::Intersects(const BoundingFrustum& fr) const
+inline bool BoundingOrientedBox::Intersects(const BoundingFrustum& fr) const noexcept
 {
     return fr.Intersects(*this);
 }
@@ -2479,7 +2491,7 @@ inline bool BoundingOrientedBox::Intersects(const BoundingFrustum& fr) const
 // Triangle vs. oriented box test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const
+inline bool XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const noexcept
 {
     // Load the box center & orientation.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -2501,7 +2513,7 @@ inline bool XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECTOR V0, FXMVECTOR 
 
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline PlaneIntersectionType XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECTOR Plane) const
+inline PlaneIntersectionType XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECTOR Plane) const noexcept
 {
     assert(DirectX::Internal::XMPlaneIsUnit(Plane));
 
@@ -2539,7 +2551,7 @@ inline PlaneIntersectionType XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECT
 // using the slabs method.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECTOR Origin, FXMVECTOR Direction, float& Dist) const
+inline bool XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECTOR Origin, FXMVECTOR Direction, float& Dist) const noexcept
 {
     assert(DirectX::Internal::XMVector3IsUnit(Direction));
 
@@ -2614,8 +2626,10 @@ inline bool XM_CALLCONV BoundingOrientedBox::Intersects(FXMVECTOR Origin, FXMVEC
 // Test an oriented box vs 6 planes (typically forming a frustum).
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingOrientedBox::ContainedBy(FXMVECTOR Plane0, FXMVECTOR Plane1, FXMVECTOR Plane2,
-    GXMVECTOR Plane3, HXMVECTOR Plane4, HXMVECTOR Plane5) const
+inline ContainmentType XM_CALLCONV BoundingOrientedBox::ContainedBy(
+    FXMVECTOR Plane0, FXMVECTOR Plane1, FXMVECTOR Plane2,
+    GXMVECTOR Plane3,
+    HXMVECTOR Plane4, HXMVECTOR Plane5) const noexcept
 {
     // Load the box.
     XMVECTOR vCenter = XMLoadFloat3(&Center);
@@ -2675,7 +2689,7 @@ inline ContainmentType XM_CALLCONV BoundingOrientedBox::ContainedBy(FXMVECTOR Pl
 // Create oriented bounding box from axis-aligned bounding box
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingOrientedBox::CreateFromBoundingBox(BoundingOrientedBox& Out, const BoundingBox& box)
+inline void BoundingOrientedBox::CreateFromBoundingBox(BoundingOrientedBox& Out, const BoundingBox& box) noexcept
 {
     Out.Center = box.Center;
     Out.Extents = box.Extents;
@@ -2695,7 +2709,7 @@ inline void BoundingOrientedBox::CreateFromBoundingBox(BoundingOrientedBox& Out,
 // best know algorithm is O(N^3) and is significanly more complex to implement.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingOrientedBox::CreateFromPoints(BoundingOrientedBox& Out, size_t Count, const XMFLOAT3* pPoints, size_t Stride)
+inline void BoundingOrientedBox::CreateFromPoints(BoundingOrientedBox& Out, size_t Count, const XMFLOAT3* pPoints, size_t Stride) noexcept
 {
     assert(Count > 0);
     assert(pPoints != nullptr);
@@ -2804,7 +2818,7 @@ inline void BoundingOrientedBox::CreateFromPoints(BoundingOrientedBox& Out, size
  ****************************************************************************/
 
 _Use_decl_annotations_
-inline BoundingFrustum::BoundingFrustum(CXMMATRIX Projection)
+inline BoundingFrustum::BoundingFrustum(CXMMATRIX Projection) noexcept
 {
     CreateFromMatrix(*this, Projection);
 }
@@ -2814,7 +2828,7 @@ inline BoundingFrustum::BoundingFrustum(CXMMATRIX Projection)
 // Transform a frustum by an angle preserving transform.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingFrustum::Transform(BoundingFrustum& Out, FXMMATRIX M) const
+inline void XM_CALLCONV BoundingFrustum::Transform(BoundingFrustum& Out, FXMMATRIX M) const noexcept
 {
     // Load the frustum.
     XMVECTOR vOrigin = XMLoadFloat3(&Origin);
@@ -2857,7 +2871,7 @@ inline void XM_CALLCONV BoundingFrustum::Transform(BoundingFrustum& Out, FXMMATR
 }
 
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingFrustum::Transform(BoundingFrustum& Out, float Scale, FXMVECTOR Rotation, FXMVECTOR Translation) const
+inline void XM_CALLCONV BoundingFrustum::Transform(BoundingFrustum& Out, float Scale, FXMVECTOR Rotation, FXMVECTOR Translation) const noexcept
 {
     assert(DirectX::Internal::XMQuaternionIsUnit(Rotation));
 
@@ -2893,7 +2907,7 @@ inline void XM_CALLCONV BoundingFrustum::Transform(BoundingFrustum& Out, float S
 // Get the corner points of the frustum
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void BoundingFrustum::GetCorners(XMFLOAT3* Corners) const
+inline void BoundingFrustum::GetCorners(XMFLOAT3* Corners) const noexcept
 {
     assert(Corners != nullptr);
 
@@ -2940,7 +2954,7 @@ inline void BoundingFrustum::GetCorners(XMFLOAT3* Corners) const
 // Point in frustum test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingFrustum::Contains(FXMVECTOR Point) const
+inline ContainmentType XM_CALLCONV BoundingFrustum::Contains(FXMVECTOR Point) const noexcept
 {
     // Build frustum planes.
     XMVECTOR Planes[6];
@@ -2981,7 +2995,7 @@ inline ContainmentType XM_CALLCONV BoundingFrustum::Contains(FXMVECTOR Point) co
 // Triangle vs frustum test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingFrustum::Contains(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const
+inline ContainmentType XM_CALLCONV BoundingFrustum::Contains(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const noexcept
 {
     // Load origin and orientation of the frustum.
     XMVECTOR vOrigin = XMLoadFloat3(&Origin);
@@ -3018,7 +3032,7 @@ inline ContainmentType XM_CALLCONV BoundingFrustum::Contains(FXMVECTOR V0, FXMVE
 
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingFrustum::Contains(const BoundingSphere& sh) const
+inline ContainmentType BoundingFrustum::Contains(const BoundingSphere& sh) const noexcept
 {
     // Load origin and orientation of the frustum.
     XMVECTOR vOrigin = XMLoadFloat3(&Origin);
@@ -3055,7 +3069,7 @@ inline ContainmentType BoundingFrustum::Contains(const BoundingSphere& sh) const
 
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingFrustum::Contains(const BoundingBox& box) const
+inline ContainmentType BoundingFrustum::Contains(const BoundingBox& box) const noexcept
 {
     // Load origin and orientation of the frustum.
     XMVECTOR vOrigin = XMLoadFloat3(&Origin);
@@ -3092,7 +3106,7 @@ inline ContainmentType BoundingFrustum::Contains(const BoundingBox& box) const
 
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingFrustum::Contains(const BoundingOrientedBox& box) const
+inline ContainmentType BoundingFrustum::Contains(const BoundingOrientedBox& box) const noexcept
 {
     // Load origin and orientation of the frustum.
     XMVECTOR vOrigin = XMLoadFloat3(&Origin);
@@ -3129,7 +3143,7 @@ inline ContainmentType BoundingFrustum::Contains(const BoundingOrientedBox& box)
 
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType BoundingFrustum::Contains(const BoundingFrustum& fr) const
+inline ContainmentType BoundingFrustum::Contains(const BoundingFrustum& fr) const noexcept
 {
     // Load origin and orientation of the frustum.
     XMVECTOR vOrigin = XMLoadFloat3(&Origin);
@@ -3172,7 +3186,7 @@ inline ContainmentType BoundingFrustum::Contains(const BoundingFrustum& fr) cons
 // sphere
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingFrustum::Intersects(const BoundingSphere& sh) const
+inline bool BoundingFrustum::Intersects(const BoundingSphere& sh) const noexcept
 {
     XMVECTOR Zero = XMVectorZero();
 
@@ -3348,7 +3362,7 @@ inline bool BoundingFrustum::Intersects(const BoundingSphere& sh) const
 // the oriented box vs frustum test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingFrustum::Intersects(const BoundingBox& box) const
+inline bool BoundingFrustum::Intersects(const BoundingBox& box) const noexcept
 {
     // Make the axis aligned box oriented and do an OBB vs frustum test.
     BoundingOrientedBox obox(box.Center, box.Extents, XMFLOAT4(0.f, 0.f, 0.f, 1.f));
@@ -3360,7 +3374,7 @@ inline bool BoundingFrustum::Intersects(const BoundingBox& box) const
 // Exact oriented box vs frustum test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingFrustum::Intersects(const BoundingOrientedBox& box) const
+inline bool BoundingFrustum::Intersects(const BoundingOrientedBox& box) const noexcept
 {
     static const XMVECTORU32 SelectY = { { { XM_SELECT_0, XM_SELECT_1, XM_SELECT_0, XM_SELECT_0 } } };
     static const XMVECTORU32 SelectZ = { { { XM_SELECT_0, XM_SELECT_0, XM_SELECT_1, XM_SELECT_0 } } };
@@ -3551,7 +3565,7 @@ inline bool BoundingFrustum::Intersects(const BoundingOrientedBox& box) const
 // Exact frustum vs frustum test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool BoundingFrustum::Intersects(const BoundingFrustum& fr) const
+inline bool BoundingFrustum::Intersects(const BoundingFrustum& fr) const noexcept
 {
     // Load origin and orientation of frustum B.
     XMVECTOR OriginB = XMLoadFloat3(&Origin);
@@ -3769,7 +3783,7 @@ inline bool BoundingFrustum::Intersects(const BoundingFrustum& fr) const
 // Triangle vs frustum test.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const
+inline bool XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2) const noexcept
 {
     // Build the frustum planes (NOTE: D is negated from the usual).
     XMVECTOR Planes[6];
@@ -3919,7 +3933,7 @@ inline bool XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR V0, FXMVECTOR V1, 
 
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline PlaneIntersectionType XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR Plane) const
+inline PlaneIntersectionType XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR Plane) const noexcept
 {
     assert(DirectX::Internal::XMPlaneIsUnit(Plane));
 
@@ -3976,7 +3990,7 @@ inline PlaneIntersectionType XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR P
 // Ray vs. frustum test
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline bool XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR rayOrigin, FXMVECTOR Direction, float& Dist) const
+inline bool XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR rayOrigin, FXMVECTOR Direction, float& Dist) const noexcept
 {
     // If ray starts inside the frustum, return a distance of 0 for the hit
     if (Contains(rayOrigin) == CONTAINS)
@@ -4076,8 +4090,10 @@ inline bool XM_CALLCONV BoundingFrustum::Intersects(FXMVECTOR rayOrigin, FXMVECT
 // Test a frustum vs 6 planes (typically forming another frustum).
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline ContainmentType XM_CALLCONV BoundingFrustum::ContainedBy(FXMVECTOR Plane0, FXMVECTOR Plane1, FXMVECTOR Plane2,
-    GXMVECTOR Plane3, HXMVECTOR Plane4, HXMVECTOR Plane5) const
+inline ContainmentType XM_CALLCONV BoundingFrustum::ContainedBy(
+    FXMVECTOR Plane0, FXMVECTOR Plane1, FXMVECTOR Plane2,
+    GXMVECTOR Plane3,
+    HXMVECTOR Plane4, HXMVECTOR Plane5) const noexcept
 {
     // Load origin and orientation of the frustum.
     XMVECTOR vOrigin = XMLoadFloat3(&Origin);
@@ -4180,7 +4196,7 @@ inline ContainmentType XM_CALLCONV BoundingFrustum::ContainedBy(FXMVECTOR Plane0
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
 inline void BoundingFrustum::GetPlanes(XMVECTOR* NearPlane, XMVECTOR* FarPlane, XMVECTOR* RightPlane,
-    XMVECTOR* LeftPlane, XMVECTOR* TopPlane, XMVECTOR* BottomPlane) const
+    XMVECTOR* LeftPlane, XMVECTOR* TopPlane, XMVECTOR* BottomPlane) const noexcept
 {
     // Load origin and orientation of the frustum.
     XMVECTOR vOrigin = XMLoadFloat3(&Origin);
@@ -4236,7 +4252,7 @@ inline void BoundingFrustum::GetPlanes(XMVECTOR* NearPlane, XMVECTOR* FarPlane, 
 // constructed frustum to be incorrect.
 //-----------------------------------------------------------------------------
 _Use_decl_annotations_
-inline void XM_CALLCONV BoundingFrustum::CreateFromMatrix(BoundingFrustum& Out, FXMMATRIX Projection)
+inline void XM_CALLCONV BoundingFrustum::CreateFromMatrix(BoundingFrustum& Out, FXMMATRIX Projection) noexcept
 {
     // Corners of the projection frustum in homogenous space.
     static XMVECTORF32 HomogenousPoints[6] =
@@ -4304,7 +4320,10 @@ namespace TriangleTests
     // pp 21-28, 1997.
     //-----------------------------------------------------------------------------
     _Use_decl_annotations_
-        inline bool XM_CALLCONV Intersects(FXMVECTOR Origin, FXMVECTOR Direction, FXMVECTOR V0, GXMVECTOR V1, HXMVECTOR V2, float& Dist)
+        inline bool XM_CALLCONV Intersects(
+            FXMVECTOR Origin, FXMVECTOR Direction, FXMVECTOR V0,
+            GXMVECTOR V1,
+            HXMVECTOR V2, float& Dist) noexcept
     {
         assert(DirectX::Internal::XMVector3IsUnit(Direction));
 
@@ -4415,7 +4434,7 @@ namespace TriangleTests
     // actaully result in a seperation.
     //-----------------------------------------------------------------------------
     _Use_decl_annotations_
-        inline bool XM_CALLCONV Intersects(FXMVECTOR A0, FXMVECTOR A1, FXMVECTOR A2, GXMVECTOR B0, HXMVECTOR B1, HXMVECTOR B2)
+        inline bool XM_CALLCONV Intersects(FXMVECTOR A0, FXMVECTOR A1, FXMVECTOR A2, GXMVECTOR B0, HXMVECTOR B1, HXMVECTOR B2) noexcept
     {
         static const XMVECTORU32 SelectY = { { { XM_SELECT_0, XM_SELECT_1, XM_SELECT_0, XM_SELECT_0 } } };
         static const XMVECTORU32 SelectZ = { { { XM_SELECT_0, XM_SELECT_0, XM_SELECT_1, XM_SELECT_0 } } };
@@ -4701,7 +4720,7 @@ namespace TriangleTests
     // Ray-triangle test
     //-----------------------------------------------------------------------------
     _Use_decl_annotations_
-        inline PlaneIntersectionType XM_CALLCONV Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2, GXMVECTOR Plane)
+        inline PlaneIntersectionType XM_CALLCONV Intersects(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2, GXMVECTOR Plane) noexcept
     {
         XMVECTOR One = XMVectorSplatOne();
 
@@ -4732,9 +4751,11 @@ namespace TriangleTests
     // Test a triangle vs 6 planes (typically forming a frustum).
     //-----------------------------------------------------------------------------
     _Use_decl_annotations_
-        inline ContainmentType XM_CALLCONV ContainedBy(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2,
-            GXMVECTOR Plane0, HXMVECTOR Plane1, HXMVECTOR Plane2,
-            CXMVECTOR Plane3, CXMVECTOR Plane4, CXMVECTOR Plane5)
+        inline ContainmentType XM_CALLCONV ContainedBy(
+            FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR V2,
+            GXMVECTOR Plane0,
+            HXMVECTOR Plane1, HXMVECTOR Plane2,
+            CXMVECTOR Plane3, CXMVECTOR Plane4, CXMVECTOR Plane5) noexcept
     {
         XMVECTOR One = XMVectorSplatOne();
 

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -269,18 +269,18 @@ namespace DirectX
 
      // Unit conversion
 
-    inline XM_CONSTEXPR float XMConvertToRadians(float fDegrees) { return fDegrees * (XM_PI / 180.0f); }
-    inline XM_CONSTEXPR float XMConvertToDegrees(float fRadians) { return fRadians * (180.0f / XM_PI); }
+    inline XM_CONSTEXPR float XMConvertToRadians(float fDegrees) noexcept { return fDegrees * (XM_PI / 180.0f); }
+    inline XM_CONSTEXPR float XMConvertToDegrees(float fRadians) noexcept { return fRadians * (180.0f / XM_PI); }
 
     // Condition register evaluation proceeding a recording (R) comparison
 
-    inline bool XMComparisonAllTrue(uint32_t CR) { return (((CR)&XM_CRMASK_CR6TRUE) == XM_CRMASK_CR6TRUE); }
-    inline bool XMComparisonAnyTrue(uint32_t CR) { return (((CR)&XM_CRMASK_CR6FALSE) != XM_CRMASK_CR6FALSE); }
-    inline bool XMComparisonAllFalse(uint32_t CR) { return (((CR)&XM_CRMASK_CR6FALSE) == XM_CRMASK_CR6FALSE); }
-    inline bool XMComparisonAnyFalse(uint32_t CR) { return (((CR)&XM_CRMASK_CR6TRUE) != XM_CRMASK_CR6TRUE); }
-    inline bool XMComparisonMixed(uint32_t CR) { return (((CR)&XM_CRMASK_CR6) == 0); }
-    inline bool XMComparisonAllInBounds(uint32_t CR) { return (((CR)&XM_CRMASK_CR6BOUNDS) == XM_CRMASK_CR6BOUNDS); }
-    inline bool XMComparisonAnyOutOfBounds(uint32_t CR) { return (((CR)&XM_CRMASK_CR6BOUNDS) != XM_CRMASK_CR6BOUNDS); }
+    inline bool XMComparisonAllTrue(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6TRUE) == XM_CRMASK_CR6TRUE); }
+    inline bool XMComparisonAnyTrue(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6FALSE) != XM_CRMASK_CR6FALSE); }
+    inline bool XMComparisonAllFalse(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6FALSE) == XM_CRMASK_CR6FALSE); }
+    inline bool XMComparisonAnyFalse(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6TRUE) != XM_CRMASK_CR6TRUE); }
+    inline bool XMComparisonMixed(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6) == 0); }
+    inline bool XMComparisonAllInBounds(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6BOUNDS) == XM_CRMASK_CR6BOUNDS); }
+    inline bool XMComparisonAnyOutOfBounds(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6BOUNDS) != XM_CRMASK_CR6BOUNDS); }
 
 
     /****************************************************************************
@@ -358,11 +358,11 @@ namespace DirectX
             XMVECTOR v;
         };
 
-        inline operator XMVECTOR() const { return v; }
-        inline operator const float* () const { return f; }
+        inline operator XMVECTOR() const noexcept { return v; }
+        inline operator const float* () const noexcept { return f; }
 #if !defined(_XM_NO_INTRINSICS_) && defined(_XM_SSE_INTRINSICS_)
-        inline operator __m128i() const { return _mm_castps_si128(v); }
-        inline operator __m128d() const { return _mm_castps_pd(v); }
+        inline operator __m128i() const noexcept { return _mm_castps_si128(v); }
+        inline operator __m128d() const noexcept { return _mm_castps_pd(v); }
 #endif
     };
 
@@ -374,10 +374,10 @@ namespace DirectX
             XMVECTOR v;
         };
 
-        inline operator XMVECTOR() const { return v; }
+        inline operator XMVECTOR() const noexcept { return v; }
 #if !defined(_XM_NO_INTRINSICS_) && defined(_XM_SSE_INTRINSICS_)
-        inline operator __m128i() const { return _mm_castps_si128(v); }
-        inline operator __m128d() const { return _mm_castps_pd(v); }
+        inline operator __m128i() const noexcept { return _mm_castps_si128(v); }
+        inline operator __m128d() const noexcept { return _mm_castps_pd(v); }
 #endif
     };
 
@@ -389,10 +389,10 @@ namespace DirectX
             XMVECTOR v;
         };
 
-        inline operator XMVECTOR() const { return v; }
+        inline operator XMVECTOR() const noexcept { return v; }
 #if !defined(_XM_NO_INTRINSICS_) && defined(_XM_SSE_INTRINSICS_)
-        inline operator __m128i() const { return _mm_castps_si128(v); }
-        inline operator __m128d() const { return _mm_castps_pd(v); }
+        inline operator __m128i() const noexcept { return _mm_castps_si128(v); }
+        inline operator __m128d() const noexcept { return _mm_castps_pd(v); }
 #endif
     };
 
@@ -404,10 +404,10 @@ namespace DirectX
             XMVECTOR v;
         };
 
-        inline operator XMVECTOR() const { return v; }
+        inline operator XMVECTOR() const noexcept { return v; }
 #if !defined(_XM_NO_INTRINSICS_) && defined(_XM_SSE_INTRINSICS_)
-        inline operator __m128i() const { return _mm_castps_si128(v); }
-        inline operator __m128d() const { return _mm_castps_pd(v); }
+        inline operator __m128i() const noexcept { return _mm_castps_si128(v); }
+        inline operator __m128d() const noexcept { return _mm_castps_pd(v); }
 #endif
     };
 
@@ -415,24 +415,24 @@ namespace DirectX
     // Vector operators
 
 #ifndef _XM_NO_XMVECTOR_OVERLOADS_
-    XMVECTOR    XM_CALLCONV     operator+ (FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     operator- (FXMVECTOR V);
+    XMVECTOR    XM_CALLCONV     operator+ (FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     operator- (FXMVECTOR V) noexcept;
 
-    XMVECTOR& XM_CALLCONV     operator+= (XMVECTOR& V1, FXMVECTOR V2);
-    XMVECTOR& XM_CALLCONV     operator-= (XMVECTOR& V1, FXMVECTOR V2);
-    XMVECTOR& XM_CALLCONV     operator*= (XMVECTOR& V1, FXMVECTOR V2);
-    XMVECTOR& XM_CALLCONV     operator/= (XMVECTOR& V1, FXMVECTOR V2);
+    XMVECTOR& XM_CALLCONV     operator+= (XMVECTOR& V1, FXMVECTOR V2) noexcept;
+    XMVECTOR& XM_CALLCONV     operator-= (XMVECTOR& V1, FXMVECTOR V2) noexcept;
+    XMVECTOR& XM_CALLCONV     operator*= (XMVECTOR& V1, FXMVECTOR V2) noexcept;
+    XMVECTOR& XM_CALLCONV     operator/= (XMVECTOR& V1, FXMVECTOR V2) noexcept;
 
-    XMVECTOR& operator*= (XMVECTOR& V, float S);
-    XMVECTOR& operator/= (XMVECTOR& V, float S);
+    XMVECTOR& operator*= (XMVECTOR& V, float S) noexcept;
+    XMVECTOR& operator/= (XMVECTOR& V, float S) noexcept;
 
-    XMVECTOR    XM_CALLCONV     operator+ (FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     operator- (FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     operator* (FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     operator/ (FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     operator* (FXMVECTOR V, float S);
-    XMVECTOR    XM_CALLCONV     operator* (float S, FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     operator/ (FXMVECTOR V, float S);
+    XMVECTOR    XM_CALLCONV     operator+ (FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     operator- (FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     operator* (FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     operator/ (FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     operator* (FXMVECTOR V, float S) noexcept;
+    XMVECTOR    XM_CALLCONV     operator* (float S, FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     operator/ (FXMVECTOR V, float S) noexcept;
 #endif /* !_XM_NO_XMVECTOR_OVERLOADS_ */
 
     //------------------------------------------------------------------------------
@@ -487,34 +487,34 @@ namespace DirectX
         XMMATRIX& operator=(XMMATRIX&&) = default;
 #endif
 
-        constexpr XMMATRIX(FXMVECTOR R0, FXMVECTOR R1, FXMVECTOR R2, CXMVECTOR R3) : r{ R0,R1,R2,R3 } {}
+        constexpr XMMATRIX(FXMVECTOR R0, FXMVECTOR R1, FXMVECTOR R2, CXMVECTOR R3) noexcept : r{ R0,R1,R2,R3 } {}
         XMMATRIX(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
             float m20, float m21, float m22, float m23,
-            float m30, float m31, float m32, float m33);
-        explicit XMMATRIX(_In_reads_(16) const float* pArray);
+            float m30, float m31, float m32, float m33) noexcept;
+        explicit XMMATRIX(_In_reads_(16) const float* pArray) noexcept;
 
 #ifdef _XM_NO_INTRINSICS_
-        float       operator() (size_t Row, size_t Column) const { return m[Row][Column]; }
-        float& operator() (size_t Row, size_t Column) { return m[Row][Column]; }
+        float       operator() (size_t Row, size_t Column) const noexcept { return m[Row][Column]; }
+        float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
 #endif
 
-        XMMATRIX    operator+ () const { return *this; }
-        XMMATRIX    operator- () const;
+        XMMATRIX    operator+ () const noexcept { return *this; }
+        XMMATRIX    operator- () const noexcept;
 
-        XMMATRIX& XM_CALLCONV     operator+= (FXMMATRIX M);
-        XMMATRIX& XM_CALLCONV     operator-= (FXMMATRIX M);
-        XMMATRIX& XM_CALLCONV     operator*= (FXMMATRIX M);
-        XMMATRIX& operator*= (float S);
-        XMMATRIX& operator/= (float S);
+        XMMATRIX& XM_CALLCONV     operator+= (FXMMATRIX M) noexcept;
+        XMMATRIX& XM_CALLCONV     operator-= (FXMMATRIX M) noexcept;
+        XMMATRIX& XM_CALLCONV     operator*= (FXMMATRIX M) noexcept;
+        XMMATRIX& operator*= (float S) noexcept;
+        XMMATRIX& operator/= (float S) noexcept;
 
-        XMMATRIX    XM_CALLCONV     operator+ (FXMMATRIX M) const;
-        XMMATRIX    XM_CALLCONV     operator- (FXMMATRIX M) const;
-        XMMATRIX    XM_CALLCONV     operator* (FXMMATRIX M) const;
-        XMMATRIX    operator* (float S) const;
-        XMMATRIX    operator/ (float S) const;
+        XMMATRIX    XM_CALLCONV     operator+ (FXMMATRIX M) const noexcept;
+        XMMATRIX    XM_CALLCONV     operator- (FXMMATRIX M) const noexcept;
+        XMMATRIX    XM_CALLCONV     operator* (FXMMATRIX M) const noexcept;
+        XMMATRIX    operator* (float S) const noexcept;
+        XMMATRIX    operator/ (float S) const noexcept;
 
-        friend XMMATRIX     XM_CALLCONV     operator* (float S, FXMMATRIX M);
+        friend XMMATRIX     XM_CALLCONV     operator* (float S, FXMMATRIX M) noexcept;
     };
 
     //------------------------------------------------------------------------------
@@ -532,8 +532,8 @@ namespace DirectX
         XMFLOAT2(XMFLOAT2&&) = default;
         XMFLOAT2& operator=(XMFLOAT2&&) = default;
 
-        XM_CONSTEXPR XMFLOAT2(float _x, float _y) : x(_x), y(_y) {}
-        explicit XMFLOAT2(_In_reads_(2) const float* pArray) : x(pArray[0]), y(pArray[1]) {}
+        XM_CONSTEXPR XMFLOAT2(float _x, float _y) noexcept : x(_x), y(_y) {}
+        explicit XMFLOAT2(_In_reads_(2) const float* pArray)  noexcept : x(pArray[0]), y(pArray[1]) {}
     };
 
     // 2D Vector; 32 bit floating point components aligned on a 16 byte boundary
@@ -547,8 +547,8 @@ namespace DirectX
         XMFLOAT2A(XMFLOAT2A&&) = default;
         XMFLOAT2A& operator=(XMFLOAT2A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT2A(float _x, float _y) : XMFLOAT2(_x, _y) {}
-        explicit XMFLOAT2A(_In_reads_(2) const float* pArray) : XMFLOAT2(pArray) {}
+        XM_CONSTEXPR XMFLOAT2A(float _x, float _y) noexcept : XMFLOAT2(_x, _y) {}
+        explicit XMFLOAT2A(_In_reads_(2) const float* pArray) noexcept : XMFLOAT2(pArray) {}
     };
 
     //------------------------------------------------------------------------------
@@ -566,8 +566,8 @@ namespace DirectX
         XMINT2(XMINT2&&) = default;
         XMINT2& operator=(XMINT2&&) = default;
 
-        XM_CONSTEXPR XMINT2(int32_t _x, int32_t _y) : x(_x), y(_y) {}
-        explicit XMINT2(_In_reads_(2) const int32_t* pArray) : x(pArray[0]), y(pArray[1]) {}
+        XM_CONSTEXPR XMINT2(int32_t _x, int32_t _y) noexcept : x(_x), y(_y) {}
+        explicit XMINT2(_In_reads_(2) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
     };
 
     // 2D Vector; 32 bit unsigned integer components
@@ -584,8 +584,8 @@ namespace DirectX
         XMUINT2(XMUINT2&&) = default;
         XMUINT2& operator=(XMUINT2&&) = default;
 
-        XM_CONSTEXPR XMUINT2(uint32_t _x, uint32_t _y) : x(_x), y(_y) {}
-        explicit XMUINT2(_In_reads_(2) const uint32_t* pArray) : x(pArray[0]), y(pArray[1]) {}
+        XM_CONSTEXPR XMUINT2(uint32_t _x, uint32_t _y) noexcept : x(_x), y(_y) {}
+        explicit XMUINT2(_In_reads_(2) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
     };
 
     //------------------------------------------------------------------------------
@@ -604,8 +604,8 @@ namespace DirectX
         XMFLOAT3(XMFLOAT3&&) = default;
         XMFLOAT3& operator=(XMFLOAT3&&) = default;
 
-        XM_CONSTEXPR XMFLOAT3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
-        explicit XMFLOAT3(_In_reads_(3) const float* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
+        XM_CONSTEXPR XMFLOAT3(float _x, float _y, float _z) noexcept : x(_x), y(_y), z(_z) {}
+        explicit XMFLOAT3(_In_reads_(3) const float* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
     };
 
     // 3D Vector; 32 bit floating point components aligned on a 16 byte boundary
@@ -619,8 +619,8 @@ namespace DirectX
         XMFLOAT3A(XMFLOAT3A&&) = default;
         XMFLOAT3A& operator=(XMFLOAT3A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT3A(float _x, float _y, float _z) : XMFLOAT3(_x, _y, _z) {}
-        explicit XMFLOAT3A(_In_reads_(3) const float* pArray) : XMFLOAT3(pArray) {}
+        XM_CONSTEXPR XMFLOAT3A(float _x, float _y, float _z) noexcept : XMFLOAT3(_x, _y, _z) {}
+        explicit XMFLOAT3A(_In_reads_(3) const float* pArray) noexcept : XMFLOAT3(pArray) {}
     };
 
     //------------------------------------------------------------------------------
@@ -639,8 +639,8 @@ namespace DirectX
         XMINT3(XMINT3&&) = default;
         XMINT3& operator=(XMINT3&&) = default;
 
-        XM_CONSTEXPR XMINT3(int32_t _x, int32_t _y, int32_t _z) : x(_x), y(_y), z(_z) {}
-        explicit XMINT3(_In_reads_(3) const int32_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
+        XM_CONSTEXPR XMINT3(int32_t _x, int32_t _y, int32_t _z) noexcept : x(_x), y(_y), z(_z) {}
+        explicit XMINT3(_In_reads_(3) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
     };
 
     // 3D Vector; 32 bit unsigned integer components
@@ -658,8 +658,8 @@ namespace DirectX
         XMUINT3(XMUINT3&&) = default;
         XMUINT3& operator=(XMUINT3&&) = default;
 
-        XM_CONSTEXPR XMUINT3(uint32_t _x, uint32_t _y, uint32_t _z) : x(_x), y(_y), z(_z) {}
-        explicit XMUINT3(_In_reads_(3) const uint32_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
+        XM_CONSTEXPR XMUINT3(uint32_t _x, uint32_t _y, uint32_t _z) noexcept : x(_x), y(_y), z(_z) {}
+        explicit XMUINT3(_In_reads_(3) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
     };
 
     //------------------------------------------------------------------------------
@@ -679,8 +679,8 @@ namespace DirectX
         XMFLOAT4(XMFLOAT4&&) = default;
         XMFLOAT4& operator=(XMFLOAT4&&) = default;
 
-        XM_CONSTEXPR XMFLOAT4(float _x, float _y, float _z, float _w) : x(_x), y(_y), z(_z), w(_w) {}
-        explicit XMFLOAT4(_In_reads_(4) const float* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+        XM_CONSTEXPR XMFLOAT4(float _x, float _y, float _z, float _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+        explicit XMFLOAT4(_In_reads_(4) const float* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
     };
 
     // 4D Vector; 32 bit floating point components aligned on a 16 byte boundary
@@ -694,8 +694,8 @@ namespace DirectX
         XMFLOAT4A(XMFLOAT4A&&) = default;
         XMFLOAT4A& operator=(XMFLOAT4A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT4A(float _x, float _y, float _z, float _w) : XMFLOAT4(_x, _y, _z, _w) {}
-        explicit XMFLOAT4A(_In_reads_(4) const float* pArray) : XMFLOAT4(pArray) {}
+        XM_CONSTEXPR XMFLOAT4A(float _x, float _y, float _z, float _w) noexcept : XMFLOAT4(_x, _y, _z, _w) {}
+        explicit XMFLOAT4A(_In_reads_(4) const float* pArray) noexcept : XMFLOAT4(pArray) {}
     };
 
     //------------------------------------------------------------------------------
@@ -715,8 +715,8 @@ namespace DirectX
         XMINT4(XMINT4&&) = default;
         XMINT4& operator=(XMINT4&&) = default;
 
-        XM_CONSTEXPR XMINT4(int32_t _x, int32_t _y, int32_t _z, int32_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-        explicit XMINT4(_In_reads_(4) const int32_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+        XM_CONSTEXPR XMINT4(int32_t _x, int32_t _y, int32_t _z, int32_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+        explicit XMINT4(_In_reads_(4) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
     };
 
     // 4D Vector; 32 bit unsigned integer components
@@ -735,8 +735,8 @@ namespace DirectX
         XMUINT4(XMUINT4&&) = default;
         XMUINT4& operator=(XMUINT4&&) = default;
 
-        XM_CONSTEXPR XMUINT4(uint32_t _x, uint32_t _y, uint32_t _z, uint32_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-        explicit XMUINT4(_In_reads_(4) const uint32_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+        XM_CONSTEXPR XMUINT4(uint32_t _x, uint32_t _y, uint32_t _z, uint32_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+        explicit XMUINT4(_In_reads_(4) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
     };
 
     //------------------------------------------------------------------------------
@@ -764,14 +764,14 @@ namespace DirectX
 
         XM_CONSTEXPR XMFLOAT3X3(float m00, float m01, float m02,
             float m10, float m11, float m12,
-            float m20, float m21, float m22)
+            float m20, float m21, float m22) noexcept
             : _11(m00), _12(m01), _13(m02),
             _21(m10), _22(m11), _23(m12),
             _31(m20), _32(m21), _33(m22) {}
-        explicit XMFLOAT3X3(_In_reads_(9) const float* pArray);
+        explicit XMFLOAT3X3(_In_reads_(9) const float* pArray) noexcept;
 
-        float       operator() (size_t Row, size_t Column) const { return m[Row][Column]; }
-        float& operator() (size_t Row, size_t Column) { return m[Row][Column]; }
+        float       operator() (size_t Row, size_t Column) const  noexcept { return m[Row][Column]; }
+        float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
     };
 
     //------------------------------------------------------------------------------
@@ -802,15 +802,15 @@ namespace DirectX
         XM_CONSTEXPR XMFLOAT4X3(float m00, float m01, float m02,
             float m10, float m11, float m12,
             float m20, float m21, float m22,
-            float m30, float m31, float m32)
+            float m30, float m31, float m32) noexcept
             : _11(m00), _12(m01), _13(m02),
             _21(m10), _22(m11), _23(m12),
             _31(m20), _32(m21), _33(m22),
             _41(m30), _42(m31), _43(m32) {}
-        explicit XMFLOAT4X3(_In_reads_(12) const float* pArray);
+        explicit XMFLOAT4X3(_In_reads_(12) const float* pArray) noexcept;
 
-        float       operator() (size_t Row, size_t Column) const { return m[Row][Column]; }
-        float& operator() (size_t Row, size_t Column) { return m[Row][Column]; }
+        float       operator() (size_t Row, size_t Column) const  noexcept { return m[Row][Column]; }
+        float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
     };
 
     // 4x3 Row-major Matrix: 32 bit floating point components aligned on a 16 byte boundary
@@ -827,9 +827,9 @@ namespace DirectX
         XM_CONSTEXPR XMFLOAT4X3A(float m00, float m01, float m02,
             float m10, float m11, float m12,
             float m20, float m21, float m22,
-            float m30, float m31, float m32) :
+            float m30, float m31, float m32)  noexcept :
             XMFLOAT4X3(m00, m01, m02, m10, m11, m12, m20, m21, m22, m30, m31, m32) {}
-        explicit XMFLOAT4X3A(_In_reads_(12) const float* pArray) : XMFLOAT4X3(pArray) {}
+        explicit XMFLOAT4X3A(_In_reads_(12) const float* pArray)  noexcept : XMFLOAT4X3(pArray) {}
     };
 
     //------------------------------------------------------------------------------
@@ -858,14 +858,14 @@ namespace DirectX
 
         XM_CONSTEXPR XMFLOAT3X4(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
-            float m20, float m21, float m22, float m23)
+            float m20, float m21, float m22, float m23) noexcept
             : _11(m00), _12(m01), _13(m02), _14(m03),
             _21(m10), _22(m11), _23(m12), _24(m13),
             _31(m20), _32(m21), _33(m22), _34(m23) {}
-        explicit XMFLOAT3X4(_In_reads_(12) const float* pArray);
+        explicit XMFLOAT3X4(_In_reads_(12) const float* pArray) noexcept;
 
-        float       operator() (size_t Row, size_t Column) const { return m[Row][Column]; }
-        float& operator() (size_t Row, size_t Column) { return m[Row][Column]; }
+        float       operator() (size_t Row, size_t Column) const noexcept { return m[Row][Column]; }
+        float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
     };
 
     // 3x4 Column-major Matrix: 32 bit floating point components aligned on a 16 byte boundary
@@ -881,9 +881,9 @@ namespace DirectX
 
         XM_CONSTEXPR XMFLOAT3X4A(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
-            float m20, float m21, float m22, float m23) :
+            float m20, float m21, float m22, float m23)  noexcept :
             XMFLOAT3X4(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23) {}
-        explicit XMFLOAT3X4A(_In_reads_(12) const float* pArray) : XMFLOAT3X4(pArray) {}
+        explicit XMFLOAT3X4A(_In_reads_(12) const float* pArray) noexcept : XMFLOAT3X4(pArray) {}
     };
 
     //------------------------------------------------------------------------------
@@ -913,15 +913,15 @@ namespace DirectX
         XM_CONSTEXPR XMFLOAT4X4(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
             float m20, float m21, float m22, float m23,
-            float m30, float m31, float m32, float m33)
+            float m30, float m31, float m32, float m33) noexcept
             : _11(m00), _12(m01), _13(m02), _14(m03),
             _21(m10), _22(m11), _23(m12), _24(m13),
             _31(m20), _32(m21), _33(m22), _34(m23),
             _41(m30), _42(m31), _43(m32), _44(m33) {}
-        explicit XMFLOAT4X4(_In_reads_(16) const float* pArray);
+        explicit XMFLOAT4X4(_In_reads_(16) const float* pArray) noexcept;
 
-        float       operator() (size_t Row, size_t Column) const { return m[Row][Column]; }
-        float& operator() (size_t Row, size_t Column) { return m[Row][Column]; }
+        float       operator() (size_t Row, size_t Column) const noexcept { return m[Row][Column]; }
+        float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
     };
 
     // 4x4 Matrix: 32 bit floating point components aligned on a 16 byte boundary
@@ -938,9 +938,9 @@ namespace DirectX
         XM_CONSTEXPR XMFLOAT4X4A(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
             float m20, float m21, float m22, float m23,
-            float m30, float m31, float m32, float m33)
+            float m30, float m31, float m32, float m33) noexcept
             : XMFLOAT4X4(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33) {}
-        explicit XMFLOAT4X4A(_In_reads_(16) const float* pArray) : XMFLOAT4X4(pArray) {}
+        explicit XMFLOAT4X4A(_In_reads_(16) const float* pArray) noexcept : XMFLOAT4X4(pArray) {}
     };
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -957,10 +957,10 @@ namespace DirectX
  *
  ****************************************************************************/
 
-    XMVECTOR    XM_CALLCONV     XMConvertVectorIntToFloat(FXMVECTOR VInt, uint32_t DivExponent);
-    XMVECTOR    XM_CALLCONV     XMConvertVectorFloatToInt(FXMVECTOR VFloat, uint32_t MulExponent);
-    XMVECTOR    XM_CALLCONV     XMConvertVectorUIntToFloat(FXMVECTOR VUInt, uint32_t DivExponent);
-    XMVECTOR    XM_CALLCONV     XMConvertVectorFloatToUInt(FXMVECTOR VFloat, uint32_t MulExponent);
+    XMVECTOR    XM_CALLCONV     XMConvertVectorIntToFloat(FXMVECTOR VInt, uint32_t DivExponent) noexcept;
+    XMVECTOR    XM_CALLCONV     XMConvertVectorFloatToInt(FXMVECTOR VFloat, uint32_t MulExponent) noexcept;
+    XMVECTOR    XM_CALLCONV     XMConvertVectorUIntToFloat(FXMVECTOR VUInt, uint32_t DivExponent) noexcept;
+    XMVECTOR    XM_CALLCONV     XMConvertVectorFloatToUInt(FXMVECTOR VFloat, uint32_t MulExponent) noexcept;
 
 #if defined(__XNAMATH_H__) && defined(XMVectorSetBinaryConstant)
 #undef XMVectorSetBinaryConstant
@@ -968,9 +968,9 @@ namespace DirectX
 #undef XMVectorSplatConstantInt
 #endif
 
-    XMVECTOR    XM_CALLCONV     XMVectorSetBinaryConstant(uint32_t C0, uint32_t C1, uint32_t C2, uint32_t C3);
-    XMVECTOR    XM_CALLCONV     XMVectorSplatConstant(int32_t IntConstant, uint32_t DivExponent);
-    XMVECTOR    XM_CALLCONV     XMVectorSplatConstantInt(int32_t IntConstant);
+    XMVECTOR    XM_CALLCONV     XMVectorSetBinaryConstant(uint32_t C0, uint32_t C1, uint32_t C2, uint32_t C3) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatConstant(int32_t IntConstant, uint32_t DivExponent) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatConstantInt(int32_t IntConstant) noexcept;
 
     /****************************************************************************
      *
@@ -978,37 +978,37 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    XMVECTOR    XM_CALLCONV     XMLoadInt(_In_ const uint32_t* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadFloat(_In_ const float* pSource);
+    XMVECTOR    XM_CALLCONV     XMLoadInt(_In_ const uint32_t* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadFloat(_In_ const float* pSource) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMLoadInt2(_In_reads_(2) const uint32_t* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadInt2A(_In_reads_(2) const uint32_t* PSource);
-    XMVECTOR    XM_CALLCONV     XMLoadFloat2(_In_ const XMFLOAT2* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadFloat2A(_In_ const XMFLOAT2A* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadSInt2(_In_ const XMINT2* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadUInt2(_In_ const XMUINT2* pSource);
+    XMVECTOR    XM_CALLCONV     XMLoadInt2(_In_reads_(2) const uint32_t* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadInt2A(_In_reads_(2) const uint32_t* PSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadFloat2(_In_ const XMFLOAT2* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadFloat2A(_In_ const XMFLOAT2A* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadSInt2(_In_ const XMINT2* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadUInt2(_In_ const XMUINT2* pSource) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMLoadInt3(_In_reads_(3) const uint32_t* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadInt3A(_In_reads_(3) const uint32_t* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadFloat3(_In_ const XMFLOAT3* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadFloat3A(_In_ const XMFLOAT3A* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadSInt3(_In_ const XMINT3* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadUInt3(_In_ const XMUINT3* pSource);
+    XMVECTOR    XM_CALLCONV     XMLoadInt3(_In_reads_(3) const uint32_t* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadInt3A(_In_reads_(3) const uint32_t* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadFloat3(_In_ const XMFLOAT3* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadFloat3A(_In_ const XMFLOAT3A* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadSInt3(_In_ const XMINT3* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadUInt3(_In_ const XMUINT3* pSource) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMLoadInt4(_In_reads_(4) const uint32_t* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadInt4A(_In_reads_(4) const uint32_t* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadFloat4(_In_ const XMFLOAT4* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadFloat4A(_In_ const XMFLOAT4A* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadSInt4(_In_ const XMINT4* pSource);
-    XMVECTOR    XM_CALLCONV     XMLoadUInt4(_In_ const XMUINT4* pSource);
+    XMVECTOR    XM_CALLCONV     XMLoadInt4(_In_reads_(4) const uint32_t* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadInt4A(_In_reads_(4) const uint32_t* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadFloat4(_In_ const XMFLOAT4* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadFloat4A(_In_ const XMFLOAT4A* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadSInt4(_In_ const XMINT4* pSource) noexcept;
+    XMVECTOR    XM_CALLCONV     XMLoadUInt4(_In_ const XMUINT4* pSource) noexcept;
 
-    XMMATRIX    XM_CALLCONV     XMLoadFloat3x3(_In_ const XMFLOAT3X3* pSource);
-    XMMATRIX    XM_CALLCONV     XMLoadFloat4x3(_In_ const XMFLOAT4X3* pSource);
-    XMMATRIX    XM_CALLCONV     XMLoadFloat4x3A(_In_ const XMFLOAT4X3A* pSource);
-    XMMATRIX    XM_CALLCONV     XMLoadFloat3x4(_In_ const XMFLOAT3X4* pSource);
-    XMMATRIX    XM_CALLCONV     XMLoadFloat3x4A(_In_ const XMFLOAT3X4A* pSource);
-    XMMATRIX    XM_CALLCONV     XMLoadFloat4x4(_In_ const XMFLOAT4X4* pSource);
-    XMMATRIX    XM_CALLCONV     XMLoadFloat4x4A(_In_ const XMFLOAT4X4A* pSource);
+    XMMATRIX    XM_CALLCONV     XMLoadFloat3x3(_In_ const XMFLOAT3X3* pSource) noexcept;
+    XMMATRIX    XM_CALLCONV     XMLoadFloat4x3(_In_ const XMFLOAT4X3* pSource) noexcept;
+    XMMATRIX    XM_CALLCONV     XMLoadFloat4x3A(_In_ const XMFLOAT4X3A* pSource) noexcept;
+    XMMATRIX    XM_CALLCONV     XMLoadFloat3x4(_In_ const XMFLOAT3X4* pSource) noexcept;
+    XMMATRIX    XM_CALLCONV     XMLoadFloat3x4A(_In_ const XMFLOAT3X4A* pSource) noexcept;
+    XMMATRIX    XM_CALLCONV     XMLoadFloat4x4(_In_ const XMFLOAT4X4* pSource) noexcept;
+    XMMATRIX    XM_CALLCONV     XMLoadFloat4x4A(_In_ const XMFLOAT4X4A* pSource) noexcept;
 
     /****************************************************************************
      *
@@ -1016,37 +1016,37 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    void        XM_CALLCONV     XMStoreInt(_Out_ uint32_t* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreFloat(_Out_ float* pDestination, _In_ FXMVECTOR V);
+    void        XM_CALLCONV     XMStoreInt(_Out_ uint32_t* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreFloat(_Out_ float* pDestination, _In_ FXMVECTOR V) noexcept;
 
-    void        XM_CALLCONV     XMStoreInt2(_Out_writes_(2) uint32_t* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreInt2A(_Out_writes_(2) uint32_t* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreFloat2(_Out_ XMFLOAT2* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreFloat2A(_Out_ XMFLOAT2A* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreSInt2(_Out_ XMINT2* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreUInt2(_Out_ XMUINT2* pDestination, _In_ FXMVECTOR V);
+    void        XM_CALLCONV     XMStoreInt2(_Out_writes_(2) uint32_t* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreInt2A(_Out_writes_(2) uint32_t* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreFloat2(_Out_ XMFLOAT2* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreFloat2A(_Out_ XMFLOAT2A* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreSInt2(_Out_ XMINT2* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreUInt2(_Out_ XMUINT2* pDestination, _In_ FXMVECTOR V) noexcept;
 
-    void        XM_CALLCONV     XMStoreInt3(_Out_writes_(3) uint32_t* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreInt3A(_Out_writes_(3) uint32_t* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreFloat3(_Out_ XMFLOAT3* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreFloat3A(_Out_ XMFLOAT3A* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreSInt3(_Out_ XMINT3* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreUInt3(_Out_ XMUINT3* pDestination, _In_ FXMVECTOR V);
+    void        XM_CALLCONV     XMStoreInt3(_Out_writes_(3) uint32_t* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreInt3A(_Out_writes_(3) uint32_t* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreFloat3(_Out_ XMFLOAT3* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreFloat3A(_Out_ XMFLOAT3A* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreSInt3(_Out_ XMINT3* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreUInt3(_Out_ XMUINT3* pDestination, _In_ FXMVECTOR V) noexcept;
 
-    void        XM_CALLCONV     XMStoreInt4(_Out_writes_(4) uint32_t* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreInt4A(_Out_writes_(4) uint32_t* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreFloat4(_Out_ XMFLOAT4* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreFloat4A(_Out_ XMFLOAT4A* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreSInt4(_Out_ XMINT4* pDestination, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMStoreUInt4(_Out_ XMUINT4* pDestination, _In_ FXMVECTOR V);
+    void        XM_CALLCONV     XMStoreInt4(_Out_writes_(4) uint32_t* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreInt4A(_Out_writes_(4) uint32_t* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreFloat4(_Out_ XMFLOAT4* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreFloat4A(_Out_ XMFLOAT4A* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreSInt4(_Out_ XMINT4* pDestination, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMStoreUInt4(_Out_ XMUINT4* pDestination, _In_ FXMVECTOR V) noexcept;
 
-    void        XM_CALLCONV     XMStoreFloat3x3(_Out_ XMFLOAT3X3* pDestination, _In_ FXMMATRIX M);
-    void        XM_CALLCONV     XMStoreFloat4x3(_Out_ XMFLOAT4X3* pDestination, _In_ FXMMATRIX M);
-    void        XM_CALLCONV     XMStoreFloat4x3A(_Out_ XMFLOAT4X3A* pDestination, _In_ FXMMATRIX M);
-    void        XM_CALLCONV     XMStoreFloat3x4(_Out_ XMFLOAT3X4* pDestination, _In_ FXMMATRIX M);
-    void        XM_CALLCONV     XMStoreFloat3x4A(_Out_ XMFLOAT3X4A* pDestination, _In_ FXMMATRIX M);
-    void        XM_CALLCONV     XMStoreFloat4x4(_Out_ XMFLOAT4X4* pDestination, _In_ FXMMATRIX M);
-    void        XM_CALLCONV     XMStoreFloat4x4A(_Out_ XMFLOAT4X4A* pDestination, _In_ FXMMATRIX M);
+    void        XM_CALLCONV     XMStoreFloat3x3(_Out_ XMFLOAT3X3* pDestination, _In_ FXMMATRIX M) noexcept;
+    void        XM_CALLCONV     XMStoreFloat4x3(_Out_ XMFLOAT4X3* pDestination, _In_ FXMMATRIX M) noexcept;
+    void        XM_CALLCONV     XMStoreFloat4x3A(_Out_ XMFLOAT4X3A* pDestination, _In_ FXMMATRIX M) noexcept;
+    void        XM_CALLCONV     XMStoreFloat3x4(_Out_ XMFLOAT3X4* pDestination, _In_ FXMMATRIX M) noexcept;
+    void        XM_CALLCONV     XMStoreFloat3x4A(_Out_ XMFLOAT3X4A* pDestination, _In_ FXMMATRIX M) noexcept;
+    void        XM_CALLCONV     XMStoreFloat4x4(_Out_ XMFLOAT4X4* pDestination, _In_ FXMMATRIX M) noexcept;
+    void        XM_CALLCONV     XMStoreFloat4x4A(_Out_ XMFLOAT4X4A* pDestination, _In_ FXMMATRIX M) noexcept;
 
     /****************************************************************************
      *
@@ -1054,83 +1054,83 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    XMVECTOR    XM_CALLCONV     XMVectorZero();
-    XMVECTOR    XM_CALLCONV     XMVectorSet(float x, float y, float z, float w);
-    XMVECTOR    XM_CALLCONV     XMVectorSetInt(uint32_t x, uint32_t y, uint32_t z, uint32_t w);
-    XMVECTOR    XM_CALLCONV     XMVectorReplicate(float Value);
-    XMVECTOR    XM_CALLCONV     XMVectorReplicatePtr(_In_ const float* pValue);
-    XMVECTOR    XM_CALLCONV     XMVectorReplicateInt(uint32_t Value);
-    XMVECTOR    XM_CALLCONV     XMVectorReplicateIntPtr(_In_ const uint32_t* pValue);
-    XMVECTOR    XM_CALLCONV     XMVectorTrueInt();
-    XMVECTOR    XM_CALLCONV     XMVectorFalseInt();
-    XMVECTOR    XM_CALLCONV     XMVectorSplatX(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorSplatY(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorSplatZ(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorSplatW(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorSplatOne();
-    XMVECTOR    XM_CALLCONV     XMVectorSplatInfinity();
-    XMVECTOR    XM_CALLCONV     XMVectorSplatQNaN();
-    XMVECTOR    XM_CALLCONV     XMVectorSplatEpsilon();
-    XMVECTOR    XM_CALLCONV     XMVectorSplatSignMask();
+    XMVECTOR    XM_CALLCONV     XMVectorZero() noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSet(float x, float y, float z, float w) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetInt(uint32_t x, uint32_t y, uint32_t z, uint32_t w) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorReplicate(float Value) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorReplicatePtr(_In_ const float* pValue) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorReplicateInt(uint32_t Value) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorReplicateIntPtr(_In_ const uint32_t* pValue) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorTrueInt() noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorFalseInt() noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatX(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatY(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatZ(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatW(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatOne() noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatInfinity() noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatQNaN() noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatEpsilon() noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSplatSignMask() noexcept;
 
-    float       XM_CALLCONV     XMVectorGetByIndex(FXMVECTOR V, size_t i);
-    float       XM_CALLCONV     XMVectorGetX(FXMVECTOR V);
-    float       XM_CALLCONV     XMVectorGetY(FXMVECTOR V);
-    float       XM_CALLCONV     XMVectorGetZ(FXMVECTOR V);
-    float       XM_CALLCONV     XMVectorGetW(FXMVECTOR V);
+    float       XM_CALLCONV     XMVectorGetByIndex(FXMVECTOR V, size_t i) noexcept;
+    float       XM_CALLCONV     XMVectorGetX(FXMVECTOR V) noexcept;
+    float       XM_CALLCONV     XMVectorGetY(FXMVECTOR V) noexcept;
+    float       XM_CALLCONV     XMVectorGetZ(FXMVECTOR V) noexcept;
+    float       XM_CALLCONV     XMVectorGetW(FXMVECTOR V) noexcept;
 
-    void        XM_CALLCONV     XMVectorGetByIndexPtr(_Out_ float* f, _In_ FXMVECTOR V, _In_ size_t i);
-    void        XM_CALLCONV     XMVectorGetXPtr(_Out_ float* x, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMVectorGetYPtr(_Out_ float* y, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMVectorGetZPtr(_Out_ float* z, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMVectorGetWPtr(_Out_ float* w, _In_ FXMVECTOR V);
+    void        XM_CALLCONV     XMVectorGetByIndexPtr(_Out_ float* f, _In_ FXMVECTOR V, _In_ size_t i) noexcept;
+    void        XM_CALLCONV     XMVectorGetXPtr(_Out_ float* x, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVectorGetYPtr(_Out_ float* y, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVectorGetZPtr(_Out_ float* z, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVectorGetWPtr(_Out_ float* w, _In_ FXMVECTOR V) noexcept;
 
-    uint32_t    XM_CALLCONV     XMVectorGetIntByIndex(FXMVECTOR V, size_t i);
-    uint32_t    XM_CALLCONV     XMVectorGetIntX(FXMVECTOR V);
-    uint32_t    XM_CALLCONV     XMVectorGetIntY(FXMVECTOR V);
-    uint32_t    XM_CALLCONV     XMVectorGetIntZ(FXMVECTOR V);
-    uint32_t    XM_CALLCONV     XMVectorGetIntW(FXMVECTOR V);
+    uint32_t    XM_CALLCONV     XMVectorGetIntByIndex(FXMVECTOR V, size_t i) noexcept;
+    uint32_t    XM_CALLCONV     XMVectorGetIntX(FXMVECTOR V) noexcept;
+    uint32_t    XM_CALLCONV     XMVectorGetIntY(FXMVECTOR V) noexcept;
+    uint32_t    XM_CALLCONV     XMVectorGetIntZ(FXMVECTOR V) noexcept;
+    uint32_t    XM_CALLCONV     XMVectorGetIntW(FXMVECTOR V) noexcept;
 
-    void        XM_CALLCONV     XMVectorGetIntByIndexPtr(_Out_ uint32_t* x, _In_ FXMVECTOR V, _In_ size_t i);
-    void        XM_CALLCONV     XMVectorGetIntXPtr(_Out_ uint32_t* x, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMVectorGetIntYPtr(_Out_ uint32_t* y, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMVectorGetIntZPtr(_Out_ uint32_t* z, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMVectorGetIntWPtr(_Out_ uint32_t* w, _In_ FXMVECTOR V);
+    void        XM_CALLCONV     XMVectorGetIntByIndexPtr(_Out_ uint32_t* x, _In_ FXMVECTOR V, _In_ size_t i) noexcept;
+    void        XM_CALLCONV     XMVectorGetIntXPtr(_Out_ uint32_t* x, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVectorGetIntYPtr(_Out_ uint32_t* y, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVectorGetIntZPtr(_Out_ uint32_t* z, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVectorGetIntWPtr(_Out_ uint32_t* w, _In_ FXMVECTOR V) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorSetByIndex(FXMVECTOR V, float f, size_t i);
-    XMVECTOR    XM_CALLCONV     XMVectorSetX(FXMVECTOR V, float x);
-    XMVECTOR    XM_CALLCONV     XMVectorSetY(FXMVECTOR V, float y);
-    XMVECTOR    XM_CALLCONV     XMVectorSetZ(FXMVECTOR V, float z);
-    XMVECTOR    XM_CALLCONV     XMVectorSetW(FXMVECTOR V, float w);
+    XMVECTOR    XM_CALLCONV     XMVectorSetByIndex(FXMVECTOR V, float f, size_t i) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetX(FXMVECTOR V, float x) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetY(FXMVECTOR V, float y) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetZ(FXMVECTOR V, float z) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetW(FXMVECTOR V, float w) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorSetByIndexPtr(_In_ FXMVECTOR V, _In_ const float* f, _In_ size_t i);
-    XMVECTOR    XM_CALLCONV     XMVectorSetXPtr(_In_ FXMVECTOR V, _In_ const float* x);
-    XMVECTOR    XM_CALLCONV     XMVectorSetYPtr(_In_ FXMVECTOR V, _In_ const float* y);
-    XMVECTOR    XM_CALLCONV     XMVectorSetZPtr(_In_ FXMVECTOR V, _In_ const float* z);
-    XMVECTOR    XM_CALLCONV     XMVectorSetWPtr(_In_ FXMVECTOR V, _In_ const float* w);
+    XMVECTOR    XM_CALLCONV     XMVectorSetByIndexPtr(_In_ FXMVECTOR V, _In_ const float* f, _In_ size_t i) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetXPtr(_In_ FXMVECTOR V, _In_ const float* x) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetYPtr(_In_ FXMVECTOR V, _In_ const float* y) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetZPtr(_In_ FXMVECTOR V, _In_ const float* z) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetWPtr(_In_ FXMVECTOR V, _In_ const float* w) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntByIndex(FXMVECTOR V, uint32_t x, size_t i);
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntX(FXMVECTOR V, uint32_t x);
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntY(FXMVECTOR V, uint32_t y);
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntZ(FXMVECTOR V, uint32_t z);
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntW(FXMVECTOR V, uint32_t w);
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntByIndex(FXMVECTOR V, uint32_t x, size_t i) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntX(FXMVECTOR V, uint32_t x) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntY(FXMVECTOR V, uint32_t y) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntZ(FXMVECTOR V, uint32_t z) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntW(FXMVECTOR V, uint32_t w) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntByIndexPtr(_In_ FXMVECTOR V, _In_ const uint32_t* x, _In_ size_t i);
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntXPtr(_In_ FXMVECTOR V, _In_ const uint32_t* x);
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntYPtr(_In_ FXMVECTOR V, _In_ const uint32_t* y);
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntZPtr(_In_ FXMVECTOR V, _In_ const uint32_t* z);
-    XMVECTOR    XM_CALLCONV     XMVectorSetIntWPtr(_In_ FXMVECTOR V, _In_ const uint32_t* w);
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntByIndexPtr(_In_ FXMVECTOR V, _In_ const uint32_t* x, _In_ size_t i) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntXPtr(_In_ FXMVECTOR V, _In_ const uint32_t* x) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntYPtr(_In_ FXMVECTOR V, _In_ const uint32_t* y) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntZPtr(_In_ FXMVECTOR V, _In_ const uint32_t* z) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSetIntWPtr(_In_ FXMVECTOR V, _In_ const uint32_t* w) noexcept;
 
 #if defined(__XNAMATH_H__) && defined(XMVectorSwizzle)
 #undef XMVectorSwizzle
 #endif
 
-    XMVECTOR    XM_CALLCONV     XMVectorSwizzle(FXMVECTOR V, uint32_t E0, uint32_t E1, uint32_t E2, uint32_t E3);
-    XMVECTOR    XM_CALLCONV     XMVectorPermute(FXMVECTOR V1, FXMVECTOR V2, uint32_t PermuteX, uint32_t PermuteY, uint32_t PermuteZ, uint32_t PermuteW);
-    XMVECTOR    XM_CALLCONV     XMVectorSelectControl(uint32_t VectorIndex0, uint32_t VectorIndex1, uint32_t VectorIndex2, uint32_t VectorIndex3);
-    XMVECTOR    XM_CALLCONV     XMVectorSelect(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Control);
-    XMVECTOR    XM_CALLCONV     XMVectorMergeXY(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorMergeZW(FXMVECTOR V1, FXMVECTOR V2);
+    XMVECTOR    XM_CALLCONV     XMVectorSwizzle(FXMVECTOR V, uint32_t E0, uint32_t E1, uint32_t E2, uint32_t E3) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorPermute(FXMVECTOR V1, FXMVECTOR V2, uint32_t PermuteX, uint32_t PermuteY, uint32_t PermuteZ, uint32_t PermuteW) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSelectControl(uint32_t VectorIndex0, uint32_t VectorIndex1, uint32_t VectorIndex2, uint32_t VectorIndex3) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSelect(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Control) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorMergeXY(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorMergeZW(FXMVECTOR V1, FXMVECTOR V2) noexcept;
 
 #if defined(__XNAMATH_H__) && defined(XMVectorShiftLeft)
 #undef XMVectorShiftLeft
@@ -1139,100 +1139,100 @@ namespace DirectX
 #undef XMVectorInsert
 #endif
 
-    XMVECTOR    XM_CALLCONV     XMVectorShiftLeft(FXMVECTOR V1, FXMVECTOR V2, uint32_t Elements);
-    XMVECTOR    XM_CALLCONV     XMVectorRotateLeft(FXMVECTOR V, uint32_t Elements);
-    XMVECTOR    XM_CALLCONV     XMVectorRotateRight(FXMVECTOR V, uint32_t Elements);
+    XMVECTOR    XM_CALLCONV     XMVectorShiftLeft(FXMVECTOR V1, FXMVECTOR V2, uint32_t Elements) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorRotateLeft(FXMVECTOR V, uint32_t Elements) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorRotateRight(FXMVECTOR V, uint32_t Elements) noexcept;
     XMVECTOR    XM_CALLCONV     XMVectorInsert(FXMVECTOR VD, FXMVECTOR VS, uint32_t VSLeftRotateElements,
-        uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3);
+        uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorEqual(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorEqualR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorEqualInt(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorEqualIntR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V, _In_ FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorNearEqual(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Epsilon);
-    XMVECTOR    XM_CALLCONV     XMVectorNotEqual(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorNotEqualInt(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorGreater(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorGreaterR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorGreaterOrEqual(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorGreaterOrEqualR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorLess(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorLessOrEqual(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorInBounds(FXMVECTOR V, FXMVECTOR Bounds);
-    XMVECTOR    XM_CALLCONV     XMVectorInBoundsR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V, _In_ FXMVECTOR Bounds);
+    XMVECTOR    XM_CALLCONV     XMVectorEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorEqualR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorEqualInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorEqualIntR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V, _In_ FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorNearEqual(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Epsilon) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorNotEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorNotEqualInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorGreater(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorGreaterR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorGreaterOrEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorGreaterOrEqualR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V1, _In_ FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorLess(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorLessOrEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorInBounds(FXMVECTOR V, FXMVECTOR Bounds) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorInBoundsR(_Out_ uint32_t* pCR, _In_ FXMVECTOR V, _In_ FXMVECTOR Bounds) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorIsNaN(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorIsInfinite(FXMVECTOR V);
+    XMVECTOR    XM_CALLCONV     XMVectorIsNaN(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorIsInfinite(FXMVECTOR V) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorMin(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorMax(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorRound(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorTruncate(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorFloor(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorCeiling(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorClamp(FXMVECTOR V, FXMVECTOR Min, FXMVECTOR Max);
-    XMVECTOR    XM_CALLCONV     XMVectorSaturate(FXMVECTOR V);
+    XMVECTOR    XM_CALLCONV     XMVectorMin(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorMax(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorRound(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorTruncate(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorFloor(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorCeiling(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorClamp(FXMVECTOR V, FXMVECTOR Min, FXMVECTOR Max) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSaturate(FXMVECTOR V) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorAndInt(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorAndCInt(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorOrInt(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorNorInt(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorXorInt(FXMVECTOR V1, FXMVECTOR V2);
+    XMVECTOR    XM_CALLCONV     XMVectorAndInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorAndCInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorOrInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorNorInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorXorInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVectorNegate(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorAdd(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorSum(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorAddAngles(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorSubtract(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorSubtractAngles(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorMultiply(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorMultiplyAdd(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR V3);
-    XMVECTOR    XM_CALLCONV     XMVectorDivide(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorNegativeMultiplySubtract(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR V3);
-    XMVECTOR    XM_CALLCONV     XMVectorScale(FXMVECTOR V, float ScaleFactor);
-    XMVECTOR    XM_CALLCONV     XMVectorReciprocalEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorReciprocal(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorSqrtEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorSqrt(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorReciprocalSqrtEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorReciprocalSqrt(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorExp2(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorExpE(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorExp(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorLog2(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorLogE(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorLog(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorPow(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorAbs(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorMod(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVectorModAngles(FXMVECTOR Angles);
-    XMVECTOR    XM_CALLCONV     XMVectorSin(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorSinEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorCos(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorCosEst(FXMVECTOR V);
-    void        XM_CALLCONV     XMVectorSinCos(_Out_ XMVECTOR* pSin, _Out_ XMVECTOR* pCos, _In_ FXMVECTOR V);
-    void        XM_CALLCONV     XMVectorSinCosEst(_Out_ XMVECTOR* pSin, _Out_ XMVECTOR* pCos, _In_ FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorTan(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorTanEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorSinH(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorCosH(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorTanH(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorASin(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorASinEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorACos(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorACosEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorATan(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorATanEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVectorATan2(FXMVECTOR Y, FXMVECTOR X);
-    XMVECTOR    XM_CALLCONV     XMVectorATan2Est(FXMVECTOR Y, FXMVECTOR X);
-    XMVECTOR    XM_CALLCONV     XMVectorLerp(FXMVECTOR V0, FXMVECTOR V1, float t);
-    XMVECTOR    XM_CALLCONV     XMVectorLerpV(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR T);
-    XMVECTOR    XM_CALLCONV     XMVectorHermite(FXMVECTOR Position0, FXMVECTOR Tangent0, FXMVECTOR Position1, GXMVECTOR Tangent1, float t);
-    XMVECTOR    XM_CALLCONV     XMVectorHermiteV(FXMVECTOR Position0, FXMVECTOR Tangent0, FXMVECTOR Position1, GXMVECTOR Tangent1, HXMVECTOR T);
-    XMVECTOR    XM_CALLCONV     XMVectorCatmullRom(FXMVECTOR Position0, FXMVECTOR Position1, FXMVECTOR Position2, GXMVECTOR Position3, float t);
-    XMVECTOR    XM_CALLCONV     XMVectorCatmullRomV(FXMVECTOR Position0, FXMVECTOR Position1, FXMVECTOR Position2, GXMVECTOR Position3, HXMVECTOR T);
-    XMVECTOR    XM_CALLCONV     XMVectorBaryCentric(FXMVECTOR Position0, FXMVECTOR Position1, FXMVECTOR Position2, float f, float g);
-    XMVECTOR    XM_CALLCONV     XMVectorBaryCentricV(FXMVECTOR Position0, FXMVECTOR Position1, FXMVECTOR Position2, GXMVECTOR F, HXMVECTOR G);
+    XMVECTOR    XM_CALLCONV     XMVectorNegate(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorAdd(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSum(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorAddAngles(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSubtract(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSubtractAngles(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorMultiply(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorMultiplyAdd(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR V3) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorDivide(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorNegativeMultiplySubtract(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR V3) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorScale(FXMVECTOR V, float ScaleFactor) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorReciprocalEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorReciprocal(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSqrtEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSqrt(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorReciprocalSqrtEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorReciprocalSqrt(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorExp2(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorExpE(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorExp(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorLog2(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorLogE(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorLog(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorPow(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorAbs(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorMod(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorModAngles(FXMVECTOR Angles) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSin(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSinEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorCos(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorCosEst(FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVectorSinCos(_Out_ XMVECTOR* pSin, _Out_ XMVECTOR* pCos, _In_ FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVectorSinCosEst(_Out_ XMVECTOR* pSin, _Out_ XMVECTOR* pCos, _In_ FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorTan(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorTanEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorSinH(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorCosH(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorTanH(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorASin(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorASinEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorACos(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorACosEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorATan(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorATanEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorATan2(FXMVECTOR Y, FXMVECTOR X) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorATan2Est(FXMVECTOR Y, FXMVECTOR X) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorLerp(FXMVECTOR V0, FXMVECTOR V1, float t) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorLerpV(FXMVECTOR V0, FXMVECTOR V1, FXMVECTOR T) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorHermite(FXMVECTOR Position0, FXMVECTOR Tangent0, FXMVECTOR Position1, GXMVECTOR Tangent1, float t) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorHermiteV(FXMVECTOR Position0, FXMVECTOR Tangent0, FXMVECTOR Position1, GXMVECTOR Tangent1, HXMVECTOR T) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorCatmullRom(FXMVECTOR Position0, FXMVECTOR Position1, FXMVECTOR Position2, GXMVECTOR Position3, float t) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorCatmullRomV(FXMVECTOR Position0, FXMVECTOR Position1, FXMVECTOR Position2, GXMVECTOR Position3, HXMVECTOR T) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorBaryCentric(FXMVECTOR Position0, FXMVECTOR Position1, FXMVECTOR Position2, float f, float g) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVectorBaryCentricV(FXMVECTOR Position0, FXMVECTOR Position1, FXMVECTOR Position2, GXMVECTOR F, HXMVECTOR G) noexcept;
 
     /****************************************************************************
      *
@@ -1240,59 +1240,59 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    bool        XM_CALLCONV     XMVector2Equal(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector2EqualR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector2EqualInt(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector2EqualIntR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector2NearEqual(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Epsilon);
-    bool        XM_CALLCONV     XMVector2NotEqual(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector2NotEqualInt(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector2Greater(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector2GreaterR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector2GreaterOrEqual(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector2GreaterOrEqualR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector2Less(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector2LessOrEqual(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector2InBounds(FXMVECTOR V, FXMVECTOR Bounds);
+    bool        XM_CALLCONV     XMVector2Equal(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector2EqualR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector2EqualInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector2EqualIntR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector2NearEqual(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Epsilon) noexcept;
+    bool        XM_CALLCONV     XMVector2NotEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector2NotEqualInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector2Greater(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector2GreaterR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector2GreaterOrEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector2GreaterOrEqualR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector2Less(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector2LessOrEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector2InBounds(FXMVECTOR V, FXMVECTOR Bounds) noexcept;
 
-    bool        XM_CALLCONV     XMVector2IsNaN(FXMVECTOR V);
-    bool        XM_CALLCONV     XMVector2IsInfinite(FXMVECTOR V);
+    bool        XM_CALLCONV     XMVector2IsNaN(FXMVECTOR V) noexcept;
+    bool        XM_CALLCONV     XMVector2IsInfinite(FXMVECTOR V) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVector2Dot(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVector2Cross(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVector2LengthSq(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector2ReciprocalLengthEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector2ReciprocalLength(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector2LengthEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector2Length(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector2NormalizeEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector2Normalize(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector2ClampLength(FXMVECTOR V, float LengthMin, float LengthMax);
-    XMVECTOR    XM_CALLCONV     XMVector2ClampLengthV(FXMVECTOR V, FXMVECTOR LengthMin, FXMVECTOR LengthMax);
-    XMVECTOR    XM_CALLCONV     XMVector2Reflect(FXMVECTOR Incident, FXMVECTOR Normal);
-    XMVECTOR    XM_CALLCONV     XMVector2Refract(FXMVECTOR Incident, FXMVECTOR Normal, float RefractionIndex);
-    XMVECTOR    XM_CALLCONV     XMVector2RefractV(FXMVECTOR Incident, FXMVECTOR Normal, FXMVECTOR RefractionIndex);
-    XMVECTOR    XM_CALLCONV     XMVector2Orthogonal(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector2AngleBetweenNormalsEst(FXMVECTOR N1, FXMVECTOR N2);
-    XMVECTOR    XM_CALLCONV     XMVector2AngleBetweenNormals(FXMVECTOR N1, FXMVECTOR N2);
-    XMVECTOR    XM_CALLCONV     XMVector2AngleBetweenVectors(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVector2LinePointDistance(FXMVECTOR LinePoint1, FXMVECTOR LinePoint2, FXMVECTOR Point);
-    XMVECTOR    XM_CALLCONV     XMVector2IntersectLine(FXMVECTOR Line1Point1, FXMVECTOR Line1Point2, FXMVECTOR Line2Point1, GXMVECTOR Line2Point2);
-    XMVECTOR    XM_CALLCONV     XMVector2Transform(FXMVECTOR V, FXMMATRIX M);
+    XMVECTOR    XM_CALLCONV     XMVector2Dot(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2Cross(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2LengthSq(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2ReciprocalLengthEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2ReciprocalLength(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2LengthEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2Length(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2NormalizeEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2Normalize(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2ClampLength(FXMVECTOR V, float LengthMin, float LengthMax) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2ClampLengthV(FXMVECTOR V, FXMVECTOR LengthMin, FXMVECTOR LengthMax) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2Reflect(FXMVECTOR Incident, FXMVECTOR Normal) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2Refract(FXMVECTOR Incident, FXMVECTOR Normal, float RefractionIndex) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2RefractV(FXMVECTOR Incident, FXMVECTOR Normal, FXMVECTOR RefractionIndex) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2Orthogonal(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2AngleBetweenNormalsEst(FXMVECTOR N1, FXMVECTOR N2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2AngleBetweenNormals(FXMVECTOR N1, FXMVECTOR N2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2AngleBetweenVectors(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2LinePointDistance(FXMVECTOR LinePoint1, FXMVECTOR LinePoint2, FXMVECTOR Point) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2IntersectLine(FXMVECTOR Line1Point1, FXMVECTOR Line1Point2, FXMVECTOR Line2Point1, GXMVECTOR Line2Point2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2Transform(FXMVECTOR V, FXMMATRIX M) noexcept;
     XMFLOAT4* XM_CALLCONV     XMVector2TransformStream(_Out_writes_bytes_(sizeof(XMFLOAT4) + OutputStride * (VectorCount - 1)) XMFLOAT4* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT2) + InputStride * (VectorCount - 1)) const XMFLOAT2* pInputStream,
-        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M);
-    XMVECTOR    XM_CALLCONV     XMVector2TransformCoord(FXMVECTOR V, FXMMATRIX M);
+        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2TransformCoord(FXMVECTOR V, FXMMATRIX M) noexcept;
     XMFLOAT2* XM_CALLCONV     XMVector2TransformCoordStream(_Out_writes_bytes_(sizeof(XMFLOAT2) + OutputStride * (VectorCount - 1)) XMFLOAT2* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT2) + InputStride * (VectorCount - 1)) const XMFLOAT2* pInputStream,
-        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M);
-    XMVECTOR    XM_CALLCONV     XMVector2TransformNormal(FXMVECTOR V, FXMMATRIX M);
+        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector2TransformNormal(FXMVECTOR V, FXMMATRIX M) noexcept;
     XMFLOAT2* XM_CALLCONV     XMVector2TransformNormalStream(_Out_writes_bytes_(sizeof(XMFLOAT2) + OutputStride * (VectorCount - 1)) XMFLOAT2* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT2) + InputStride * (VectorCount - 1)) const XMFLOAT2* pInputStream,
-        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M);
+        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M) noexcept;
 
     /****************************************************************************
      *
@@ -1300,77 +1300,77 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    bool        XM_CALLCONV     XMVector3Equal(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector3EqualR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector3EqualInt(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector3EqualIntR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector3NearEqual(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Epsilon);
-    bool        XM_CALLCONV     XMVector3NotEqual(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector3NotEqualInt(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector3Greater(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector3GreaterR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector3GreaterOrEqual(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector3GreaterOrEqualR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector3Less(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector3LessOrEqual(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector3InBounds(FXMVECTOR V, FXMVECTOR Bounds);
+    bool        XM_CALLCONV     XMVector3Equal(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector3EqualR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector3EqualInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector3EqualIntR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector3NearEqual(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Epsilon) noexcept;
+    bool        XM_CALLCONV     XMVector3NotEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector3NotEqualInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector3Greater(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector3GreaterR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector3GreaterOrEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector3GreaterOrEqualR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector3Less(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector3LessOrEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector3InBounds(FXMVECTOR V, FXMVECTOR Bounds) noexcept;
 
-    bool        XM_CALLCONV     XMVector3IsNaN(FXMVECTOR V);
-    bool        XM_CALLCONV     XMVector3IsInfinite(FXMVECTOR V);
+    bool        XM_CALLCONV     XMVector3IsNaN(FXMVECTOR V) noexcept;
+    bool        XM_CALLCONV     XMVector3IsInfinite(FXMVECTOR V) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVector3Dot(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVector3Cross(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVector3LengthSq(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector3ReciprocalLengthEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector3ReciprocalLength(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector3LengthEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector3Length(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector3NormalizeEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector3Normalize(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector3ClampLength(FXMVECTOR V, float LengthMin, float LengthMax);
-    XMVECTOR    XM_CALLCONV     XMVector3ClampLengthV(FXMVECTOR V, FXMVECTOR LengthMin, FXMVECTOR LengthMax);
-    XMVECTOR    XM_CALLCONV     XMVector3Reflect(FXMVECTOR Incident, FXMVECTOR Normal);
-    XMVECTOR    XM_CALLCONV     XMVector3Refract(FXMVECTOR Incident, FXMVECTOR Normal, float RefractionIndex);
-    XMVECTOR    XM_CALLCONV     XMVector3RefractV(FXMVECTOR Incident, FXMVECTOR Normal, FXMVECTOR RefractionIndex);
-    XMVECTOR    XM_CALLCONV     XMVector3Orthogonal(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenNormalsEst(FXMVECTOR N1, FXMVECTOR N2);
-    XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenNormals(FXMVECTOR N1, FXMVECTOR N2);
-    XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenVectors(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVector3LinePointDistance(FXMVECTOR LinePoint1, FXMVECTOR LinePoint2, FXMVECTOR Point);
-    void        XM_CALLCONV     XMVector3ComponentsFromNormal(_Out_ XMVECTOR* pParallel, _Out_ XMVECTOR* pPerpendicular, _In_ FXMVECTOR V, _In_ FXMVECTOR Normal);
-    XMVECTOR    XM_CALLCONV     XMVector3Rotate(FXMVECTOR V, FXMVECTOR RotationQuaternion);
-    XMVECTOR    XM_CALLCONV     XMVector3InverseRotate(FXMVECTOR V, FXMVECTOR RotationQuaternion);
-    XMVECTOR    XM_CALLCONV     XMVector3Transform(FXMVECTOR V, FXMMATRIX M);
+    XMVECTOR    XM_CALLCONV     XMVector3Dot(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3Cross(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3LengthSq(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3ReciprocalLengthEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3ReciprocalLength(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3LengthEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3Length(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3NormalizeEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3Normalize(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3ClampLength(FXMVECTOR V, float LengthMin, float LengthMax) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3ClampLengthV(FXMVECTOR V, FXMVECTOR LengthMin, FXMVECTOR LengthMax) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3Reflect(FXMVECTOR Incident, FXMVECTOR Normal) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3Refract(FXMVECTOR Incident, FXMVECTOR Normal, float RefractionIndex) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3RefractV(FXMVECTOR Incident, FXMVECTOR Normal, FXMVECTOR RefractionIndex) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3Orthogonal(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenNormalsEst(FXMVECTOR N1, FXMVECTOR N2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenNormals(FXMVECTOR N1, FXMVECTOR N2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenVectors(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3LinePointDistance(FXMVECTOR LinePoint1, FXMVECTOR LinePoint2, FXMVECTOR Point) noexcept;
+    void        XM_CALLCONV     XMVector3ComponentsFromNormal(_Out_ XMVECTOR* pParallel, _Out_ XMVECTOR* pPerpendicular, _In_ FXMVECTOR V, _In_ FXMVECTOR Normal) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3Rotate(FXMVECTOR V, FXMVECTOR RotationQuaternion) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3InverseRotate(FXMVECTOR V, FXMVECTOR RotationQuaternion) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3Transform(FXMVECTOR V, FXMMATRIX M) noexcept;
     XMFLOAT4* XM_CALLCONV     XMVector3TransformStream(_Out_writes_bytes_(sizeof(XMFLOAT4) + OutputStride * (VectorCount - 1)) XMFLOAT4* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT3) + InputStride * (VectorCount - 1)) const XMFLOAT3* pInputStream,
-        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M);
-    XMVECTOR    XM_CALLCONV     XMVector3TransformCoord(FXMVECTOR V, FXMMATRIX M);
+        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3TransformCoord(FXMVECTOR V, FXMMATRIX M) noexcept;
     XMFLOAT3* XM_CALLCONV     XMVector3TransformCoordStream(_Out_writes_bytes_(sizeof(XMFLOAT3) + OutputStride * (VectorCount - 1)) XMFLOAT3* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT3) + InputStride * (VectorCount - 1)) const XMFLOAT3* pInputStream,
-        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M);
-    XMVECTOR    XM_CALLCONV     XMVector3TransformNormal(FXMVECTOR V, FXMMATRIX M);
+        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector3TransformNormal(FXMVECTOR V, FXMMATRIX M) noexcept;
     XMFLOAT3* XM_CALLCONV     XMVector3TransformNormalStream(_Out_writes_bytes_(sizeof(XMFLOAT3) + OutputStride * (VectorCount - 1)) XMFLOAT3* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT3) + InputStride * (VectorCount - 1)) const XMFLOAT3* pInputStream,
-        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M);
+        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3Project(FXMVECTOR V, float ViewportX, float ViewportY, float ViewportWidth, float ViewportHeight, float ViewportMinZ, float ViewportMaxZ,
-        FXMMATRIX Projection, CXMMATRIX View, CXMMATRIX World);
+        FXMMATRIX Projection, CXMMATRIX View, CXMMATRIX World) noexcept;
     XMFLOAT3* XM_CALLCONV     XMVector3ProjectStream(_Out_writes_bytes_(sizeof(XMFLOAT3) + OutputStride * (VectorCount - 1)) XMFLOAT3* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT3) + InputStride * (VectorCount - 1)) const XMFLOAT3* pInputStream,
         _In_ size_t InputStride, _In_ size_t VectorCount,
         _In_ float ViewportX, _In_ float ViewportY, _In_ float ViewportWidth, _In_ float ViewportHeight, _In_ float ViewportMinZ, _In_ float ViewportMaxZ,
-        _In_ FXMMATRIX Projection, _In_ CXMMATRIX View, _In_ CXMMATRIX World);
+        _In_ FXMMATRIX Projection, _In_ CXMMATRIX View, _In_ CXMMATRIX World) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3Unproject(FXMVECTOR V, float ViewportX, float ViewportY, float ViewportWidth, float ViewportHeight, float ViewportMinZ, float ViewportMaxZ,
-        FXMMATRIX Projection, CXMMATRIX View, CXMMATRIX World);
+        FXMMATRIX Projection, CXMMATRIX View, CXMMATRIX World) noexcept;
     XMFLOAT3* XM_CALLCONV     XMVector3UnprojectStream(_Out_writes_bytes_(sizeof(XMFLOAT3) + OutputStride * (VectorCount - 1)) XMFLOAT3* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT3) + InputStride * (VectorCount - 1)) const XMFLOAT3* pInputStream,
         _In_ size_t InputStride, _In_ size_t VectorCount,
         _In_ float ViewportX, _In_ float ViewportY, _In_ float ViewportWidth, _In_ float ViewportHeight, _In_ float ViewportMinZ, _In_ float ViewportMaxZ,
-        _In_ FXMMATRIX Projection, _In_ CXMMATRIX View, _In_ CXMMATRIX World);
+        _In_ FXMMATRIX Projection, _In_ CXMMATRIX View, _In_ CXMMATRIX World) noexcept;
 
     /****************************************************************************
      *
@@ -1378,47 +1378,47 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    bool        XM_CALLCONV     XMVector4Equal(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector4EqualR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector4EqualInt(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector4EqualIntR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector4NearEqual(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Epsilon);
-    bool        XM_CALLCONV     XMVector4NotEqual(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector4NotEqualInt(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector4Greater(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector4GreaterR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector4GreaterOrEqual(FXMVECTOR V1, FXMVECTOR V2);
-    uint32_t    XM_CALLCONV     XMVector4GreaterOrEqualR(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector4Less(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector4LessOrEqual(FXMVECTOR V1, FXMVECTOR V2);
-    bool        XM_CALLCONV     XMVector4InBounds(FXMVECTOR V, FXMVECTOR Bounds);
+    bool        XM_CALLCONV     XMVector4Equal(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector4EqualR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector4EqualInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector4EqualIntR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector4NearEqual(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR Epsilon) noexcept;
+    bool        XM_CALLCONV     XMVector4NotEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector4NotEqualInt(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector4Greater(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector4GreaterR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector4GreaterOrEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    uint32_t    XM_CALLCONV     XMVector4GreaterOrEqualR(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector4Less(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector4LessOrEqual(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    bool        XM_CALLCONV     XMVector4InBounds(FXMVECTOR V, FXMVECTOR Bounds) noexcept;
 
-    bool        XM_CALLCONV     XMVector4IsNaN(FXMVECTOR V);
-    bool        XM_CALLCONV     XMVector4IsInfinite(FXMVECTOR V);
+    bool        XM_CALLCONV     XMVector4IsNaN(FXMVECTOR V) noexcept;
+    bool        XM_CALLCONV     XMVector4IsInfinite(FXMVECTOR V) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMVector4Dot(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVector4Cross(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR V3);
-    XMVECTOR    XM_CALLCONV     XMVector4LengthSq(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector4ReciprocalLengthEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector4ReciprocalLength(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector4LengthEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector4Length(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector4NormalizeEst(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector4Normalize(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector4ClampLength(FXMVECTOR V, float LengthMin, float LengthMax);
-    XMVECTOR    XM_CALLCONV     XMVector4ClampLengthV(FXMVECTOR V, FXMVECTOR LengthMin, FXMVECTOR LengthMax);
-    XMVECTOR    XM_CALLCONV     XMVector4Reflect(FXMVECTOR Incident, FXMVECTOR Normal);
-    XMVECTOR    XM_CALLCONV     XMVector4Refract(FXMVECTOR Incident, FXMVECTOR Normal, float RefractionIndex);
-    XMVECTOR    XM_CALLCONV     XMVector4RefractV(FXMVECTOR Incident, FXMVECTOR Normal, FXMVECTOR RefractionIndex);
-    XMVECTOR    XM_CALLCONV     XMVector4Orthogonal(FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMVector4AngleBetweenNormalsEst(FXMVECTOR N1, FXMVECTOR N2);
-    XMVECTOR    XM_CALLCONV     XMVector4AngleBetweenNormals(FXMVECTOR N1, FXMVECTOR N2);
-    XMVECTOR    XM_CALLCONV     XMVector4AngleBetweenVectors(FXMVECTOR V1, FXMVECTOR V2);
-    XMVECTOR    XM_CALLCONV     XMVector4Transform(FXMVECTOR V, FXMMATRIX M);
+    XMVECTOR    XM_CALLCONV     XMVector4Dot(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4Cross(FXMVECTOR V1, FXMVECTOR V2, FXMVECTOR V3) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4LengthSq(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4ReciprocalLengthEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4ReciprocalLength(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4LengthEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4Length(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4NormalizeEst(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4Normalize(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4ClampLength(FXMVECTOR V, float LengthMin, float LengthMax) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4ClampLengthV(FXMVECTOR V, FXMVECTOR LengthMin, FXMVECTOR LengthMax) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4Reflect(FXMVECTOR Incident, FXMVECTOR Normal) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4Refract(FXMVECTOR Incident, FXMVECTOR Normal, float RefractionIndex) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4RefractV(FXMVECTOR Incident, FXMVECTOR Normal, FXMVECTOR RefractionIndex) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4Orthogonal(FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4AngleBetweenNormalsEst(FXMVECTOR N1, FXMVECTOR N2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4AngleBetweenNormals(FXMVECTOR N1, FXMVECTOR N2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4AngleBetweenVectors(FXMVECTOR V1, FXMVECTOR V2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMVector4Transform(FXMVECTOR V, FXMMATRIX M) noexcept;
     XMFLOAT4* XM_CALLCONV     XMVector4TransformStream(_Out_writes_bytes_(sizeof(XMFLOAT4) + OutputStride * (VectorCount - 1)) XMFLOAT4* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT4) + InputStride * (VectorCount - 1)) const XMFLOAT4* pInputStream,
-        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M);
+        _In_ size_t InputStride, _In_ size_t VectorCount, _In_ FXMMATRIX M) noexcept;
 
     /****************************************************************************
      *
@@ -1426,58 +1426,58 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    bool        XM_CALLCONV     XMMatrixIsNaN(FXMMATRIX M);
-    bool        XM_CALLCONV     XMMatrixIsInfinite(FXMMATRIX M);
-    bool        XM_CALLCONV     XMMatrixIsIdentity(FXMMATRIX M);
+    bool        XM_CALLCONV     XMMatrixIsNaN(FXMMATRIX M) noexcept;
+    bool        XM_CALLCONV     XMMatrixIsInfinite(FXMMATRIX M) noexcept;
+    bool        XM_CALLCONV     XMMatrixIsIdentity(FXMMATRIX M) noexcept;
 
-    XMMATRIX    XM_CALLCONV     XMMatrixMultiply(FXMMATRIX M1, CXMMATRIX M2);
-    XMMATRIX    XM_CALLCONV     XMMatrixMultiplyTranspose(FXMMATRIX M1, CXMMATRIX M2);
-    XMMATRIX    XM_CALLCONV     XMMatrixTranspose(FXMMATRIX M);
-    XMMATRIX    XM_CALLCONV     XMMatrixInverse(_Out_opt_ XMVECTOR* pDeterminant, _In_ FXMMATRIX M);
-    XMVECTOR    XM_CALLCONV     XMMatrixDeterminant(FXMMATRIX M);
+    XMMATRIX    XM_CALLCONV     XMMatrixMultiply(FXMMATRIX M1, CXMMATRIX M2) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixMultiplyTranspose(FXMMATRIX M1, CXMMATRIX M2) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixTranspose(FXMMATRIX M) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixInverse(_Out_opt_ XMVECTOR* pDeterminant, _In_ FXMMATRIX M) noexcept;
+    XMVECTOR    XM_CALLCONV     XMMatrixDeterminant(FXMMATRIX M) noexcept;
     _Success_(return)
-        bool        XM_CALLCONV     XMMatrixDecompose(_Out_ XMVECTOR* outScale, _Out_ XMVECTOR* outRotQuat, _Out_ XMVECTOR* outTrans, _In_ FXMMATRIX M);
+        bool        XM_CALLCONV     XMMatrixDecompose(_Out_ XMVECTOR* outScale, _Out_ XMVECTOR* outRotQuat, _Out_ XMVECTOR* outTrans, _In_ FXMMATRIX M) noexcept;
 
-    XMMATRIX    XM_CALLCONV     XMMatrixIdentity();
+    XMMATRIX    XM_CALLCONV     XMMatrixIdentity() noexcept;
     XMMATRIX    XM_CALLCONV     XMMatrixSet(float m00, float m01, float m02, float m03,
         float m10, float m11, float m12, float m13,
         float m20, float m21, float m22, float m23,
-        float m30, float m31, float m32, float m33);
-    XMMATRIX    XM_CALLCONV     XMMatrixTranslation(float OffsetX, float OffsetY, float OffsetZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixTranslationFromVector(FXMVECTOR Offset);
-    XMMATRIX    XM_CALLCONV     XMMatrixScaling(float ScaleX, float ScaleY, float ScaleZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixScalingFromVector(FXMVECTOR Scale);
-    XMMATRIX    XM_CALLCONV     XMMatrixRotationX(float Angle);
-    XMMATRIX    XM_CALLCONV     XMMatrixRotationY(float Angle);
-    XMMATRIX    XM_CALLCONV     XMMatrixRotationZ(float Angle);
-    XMMATRIX    XM_CALLCONV     XMMatrixRotationRollPitchYaw(float Pitch, float Yaw, float Roll);
-    XMMATRIX    XM_CALLCONV     XMMatrixRotationRollPitchYawFromVector(FXMVECTOR Angles);
-    XMMATRIX    XM_CALLCONV     XMMatrixRotationNormal(FXMVECTOR NormalAxis, float Angle);
-    XMMATRIX    XM_CALLCONV     XMMatrixRotationAxis(FXMVECTOR Axis, float Angle);
-    XMMATRIX    XM_CALLCONV     XMMatrixRotationQuaternion(FXMVECTOR Quaternion);
+        float m30, float m31, float m32, float m33) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixTranslation(float OffsetX, float OffsetY, float OffsetZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixTranslationFromVector(FXMVECTOR Offset) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixScaling(float ScaleX, float ScaleY, float ScaleZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixScalingFromVector(FXMVECTOR Scale) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixRotationX(float Angle) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixRotationY(float Angle) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixRotationZ(float Angle) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixRotationRollPitchYaw(float Pitch, float Yaw, float Roll) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixRotationRollPitchYawFromVector(FXMVECTOR Angles) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixRotationNormal(FXMVECTOR NormalAxis, float Angle) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixRotationAxis(FXMVECTOR Axis, float Angle) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixRotationQuaternion(FXMVECTOR Quaternion) noexcept;
     XMMATRIX    XM_CALLCONV     XMMatrixTransformation2D(FXMVECTOR ScalingOrigin, float ScalingOrientation, FXMVECTOR Scaling,
-        FXMVECTOR RotationOrigin, float Rotation, GXMVECTOR Translation);
+        FXMVECTOR RotationOrigin, float Rotation, GXMVECTOR Translation) noexcept;
     XMMATRIX    XM_CALLCONV     XMMatrixTransformation(FXMVECTOR ScalingOrigin, FXMVECTOR ScalingOrientationQuaternion, FXMVECTOR Scaling,
-        GXMVECTOR RotationOrigin, HXMVECTOR RotationQuaternion, HXMVECTOR Translation);
-    XMMATRIX    XM_CALLCONV     XMMatrixAffineTransformation2D(FXMVECTOR Scaling, FXMVECTOR RotationOrigin, float Rotation, FXMVECTOR Translation);
-    XMMATRIX    XM_CALLCONV     XMMatrixAffineTransformation(FXMVECTOR Scaling, FXMVECTOR RotationOrigin, FXMVECTOR RotationQuaternion, GXMVECTOR Translation);
-    XMMATRIX    XM_CALLCONV     XMMatrixReflect(FXMVECTOR ReflectionPlane);
-    XMMATRIX    XM_CALLCONV     XMMatrixShadow(FXMVECTOR ShadowPlane, FXMVECTOR LightPosition);
+        GXMVECTOR RotationOrigin, HXMVECTOR RotationQuaternion, HXMVECTOR Translation) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixAffineTransformation2D(FXMVECTOR Scaling, FXMVECTOR RotationOrigin, float Rotation, FXMVECTOR Translation) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixAffineTransformation(FXMVECTOR Scaling, FXMVECTOR RotationOrigin, FXMVECTOR RotationQuaternion, GXMVECTOR Translation) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixReflect(FXMVECTOR ReflectionPlane) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixShadow(FXMVECTOR ShadowPlane, FXMVECTOR LightPosition) noexcept;
 
-    XMMATRIX    XM_CALLCONV     XMMatrixLookAtLH(FXMVECTOR EyePosition, FXMVECTOR FocusPosition, FXMVECTOR UpDirection);
-    XMMATRIX    XM_CALLCONV     XMMatrixLookAtRH(FXMVECTOR EyePosition, FXMVECTOR FocusPosition, FXMVECTOR UpDirection);
-    XMMATRIX    XM_CALLCONV     XMMatrixLookToLH(FXMVECTOR EyePosition, FXMVECTOR EyeDirection, FXMVECTOR UpDirection);
-    XMMATRIX    XM_CALLCONV     XMMatrixLookToRH(FXMVECTOR EyePosition, FXMVECTOR EyeDirection, FXMVECTOR UpDirection);
-    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveLH(float ViewWidth, float ViewHeight, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveRH(float ViewWidth, float ViewHeight, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveFovLH(float FovAngleY, float AspectRatio, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveFovRH(float FovAngleY, float AspectRatio, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveOffCenterLH(float ViewLeft, float ViewRight, float ViewBottom, float ViewTop, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveOffCenterRH(float ViewLeft, float ViewRight, float ViewBottom, float ViewTop, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixOrthographicLH(float ViewWidth, float ViewHeight, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixOrthographicRH(float ViewWidth, float ViewHeight, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixOrthographicOffCenterLH(float ViewLeft, float ViewRight, float ViewBottom, float ViewTop, float NearZ, float FarZ);
-    XMMATRIX    XM_CALLCONV     XMMatrixOrthographicOffCenterRH(float ViewLeft, float ViewRight, float ViewBottom, float ViewTop, float NearZ, float FarZ);
+    XMMATRIX    XM_CALLCONV     XMMatrixLookAtLH(FXMVECTOR EyePosition, FXMVECTOR FocusPosition, FXMVECTOR UpDirection) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixLookAtRH(FXMVECTOR EyePosition, FXMVECTOR FocusPosition, FXMVECTOR UpDirection) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixLookToLH(FXMVECTOR EyePosition, FXMVECTOR EyeDirection, FXMVECTOR UpDirection) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixLookToRH(FXMVECTOR EyePosition, FXMVECTOR EyeDirection, FXMVECTOR UpDirection) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveLH(float ViewWidth, float ViewHeight, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveRH(float ViewWidth, float ViewHeight, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveFovLH(float FovAngleY, float AspectRatio, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveFovRH(float FovAngleY, float AspectRatio, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveOffCenterLH(float ViewLeft, float ViewRight, float ViewBottom, float ViewTop, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixPerspectiveOffCenterRH(float ViewLeft, float ViewRight, float ViewBottom, float ViewTop, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixOrthographicLH(float ViewWidth, float ViewHeight, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixOrthographicRH(float ViewWidth, float ViewHeight, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixOrthographicOffCenterLH(float ViewLeft, float ViewRight, float ViewBottom, float ViewTop, float NearZ, float FarZ) noexcept;
+    XMMATRIX    XM_CALLCONV     XMMatrixOrthographicOffCenterRH(float ViewLeft, float ViewRight, float ViewBottom, float ViewTop, float NearZ, float FarZ) noexcept;
 
 
     /****************************************************************************
@@ -1486,40 +1486,40 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    bool        XM_CALLCONV     XMQuaternionEqual(FXMVECTOR Q1, FXMVECTOR Q2);
-    bool        XM_CALLCONV     XMQuaternionNotEqual(FXMVECTOR Q1, FXMVECTOR Q2);
+    bool        XM_CALLCONV     XMQuaternionEqual(FXMVECTOR Q1, FXMVECTOR Q2) noexcept;
+    bool        XM_CALLCONV     XMQuaternionNotEqual(FXMVECTOR Q1, FXMVECTOR Q2) noexcept;
 
-    bool        XM_CALLCONV     XMQuaternionIsNaN(FXMVECTOR Q);
-    bool        XM_CALLCONV     XMQuaternionIsInfinite(FXMVECTOR Q);
-    bool        XM_CALLCONV     XMQuaternionIsIdentity(FXMVECTOR Q);
+    bool        XM_CALLCONV     XMQuaternionIsNaN(FXMVECTOR Q) noexcept;
+    bool        XM_CALLCONV     XMQuaternionIsInfinite(FXMVECTOR Q) noexcept;
+    bool        XM_CALLCONV     XMQuaternionIsIdentity(FXMVECTOR Q) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMQuaternionDot(FXMVECTOR Q1, FXMVECTOR Q2);
-    XMVECTOR    XM_CALLCONV     XMQuaternionMultiply(FXMVECTOR Q1, FXMVECTOR Q2);
-    XMVECTOR    XM_CALLCONV     XMQuaternionLengthSq(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionReciprocalLength(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionLength(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionNormalizeEst(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionNormalize(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionConjugate(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionInverse(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionLn(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionExp(FXMVECTOR Q);
-    XMVECTOR    XM_CALLCONV     XMQuaternionSlerp(FXMVECTOR Q0, FXMVECTOR Q1, float t);
-    XMVECTOR    XM_CALLCONV     XMQuaternionSlerpV(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR T);
-    XMVECTOR    XM_CALLCONV     XMQuaternionSquad(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR Q2, GXMVECTOR Q3, float t);
-    XMVECTOR    XM_CALLCONV     XMQuaternionSquadV(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR Q2, GXMVECTOR Q3, HXMVECTOR T);
-    void        XM_CALLCONV     XMQuaternionSquadSetup(_Out_ XMVECTOR* pA, _Out_ XMVECTOR* pB, _Out_ XMVECTOR* pC, _In_ FXMVECTOR Q0, _In_ FXMVECTOR Q1, _In_ FXMVECTOR Q2, _In_ GXMVECTOR Q3);
-    XMVECTOR    XM_CALLCONV     XMQuaternionBaryCentric(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR Q2, float f, float g);
-    XMVECTOR    XM_CALLCONV     XMQuaternionBaryCentricV(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR Q2, GXMVECTOR F, HXMVECTOR G);
+    XMVECTOR    XM_CALLCONV     XMQuaternionDot(FXMVECTOR Q1, FXMVECTOR Q2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionMultiply(FXMVECTOR Q1, FXMVECTOR Q2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionLengthSq(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionReciprocalLength(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionLength(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionNormalizeEst(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionNormalize(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionConjugate(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionInverse(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionLn(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionExp(FXMVECTOR Q) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionSlerp(FXMVECTOR Q0, FXMVECTOR Q1, float t) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionSlerpV(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR T) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionSquad(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR Q2, GXMVECTOR Q3, float t) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionSquadV(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR Q2, GXMVECTOR Q3, HXMVECTOR T) noexcept;
+    void        XM_CALLCONV     XMQuaternionSquadSetup(_Out_ XMVECTOR* pA, _Out_ XMVECTOR* pB, _Out_ XMVECTOR* pC, _In_ FXMVECTOR Q0, _In_ FXMVECTOR Q1, _In_ FXMVECTOR Q2, _In_ GXMVECTOR Q3) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionBaryCentric(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR Q2, float f, float g) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionBaryCentricV(FXMVECTOR Q0, FXMVECTOR Q1, FXMVECTOR Q2, GXMVECTOR F, HXMVECTOR G) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMQuaternionIdentity();
-    XMVECTOR    XM_CALLCONV     XMQuaternionRotationRollPitchYaw(float Pitch, float Yaw, float Roll);
-    XMVECTOR    XM_CALLCONV     XMQuaternionRotationRollPitchYawFromVector(FXMVECTOR Angles);
-    XMVECTOR    XM_CALLCONV     XMQuaternionRotationNormal(FXMVECTOR NormalAxis, float Angle);
-    XMVECTOR    XM_CALLCONV     XMQuaternionRotationAxis(FXMVECTOR Axis, float Angle);
-    XMVECTOR    XM_CALLCONV     XMQuaternionRotationMatrix(FXMMATRIX M);
+    XMVECTOR    XM_CALLCONV     XMQuaternionIdentity() noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionRotationRollPitchYaw(float Pitch, float Yaw, float Roll) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionRotationRollPitchYawFromVector(FXMVECTOR Angles) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionRotationNormal(FXMVECTOR NormalAxis, float Angle) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionRotationAxis(FXMVECTOR Axis, float Angle) noexcept;
+    XMVECTOR    XM_CALLCONV     XMQuaternionRotationMatrix(FXMMATRIX M) noexcept;
 
-    void        XM_CALLCONV     XMQuaternionToAxisAngle(_Out_ XMVECTOR* pAxis, _Out_ float* pAngle, _In_ FXMVECTOR Q);
+    void        XM_CALLCONV     XMQuaternionToAxisAngle(_Out_ XMVECTOR* pAxis, _Out_ float* pAngle, _In_ FXMVECTOR Q) noexcept;
 
     /****************************************************************************
      *
@@ -1527,28 +1527,28 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    bool        XM_CALLCONV     XMPlaneEqual(FXMVECTOR P1, FXMVECTOR P2);
-    bool        XM_CALLCONV     XMPlaneNearEqual(FXMVECTOR P1, FXMVECTOR P2, FXMVECTOR Epsilon);
-    bool        XM_CALLCONV     XMPlaneNotEqual(FXMVECTOR P1, FXMVECTOR P2);
+    bool        XM_CALLCONV     XMPlaneEqual(FXMVECTOR P1, FXMVECTOR P2) noexcept;
+    bool        XM_CALLCONV     XMPlaneNearEqual(FXMVECTOR P1, FXMVECTOR P2, FXMVECTOR Epsilon) noexcept;
+    bool        XM_CALLCONV     XMPlaneNotEqual(FXMVECTOR P1, FXMVECTOR P2) noexcept;
 
-    bool        XM_CALLCONV     XMPlaneIsNaN(FXMVECTOR P);
-    bool        XM_CALLCONV     XMPlaneIsInfinite(FXMVECTOR P);
+    bool        XM_CALLCONV     XMPlaneIsNaN(FXMVECTOR P) noexcept;
+    bool        XM_CALLCONV     XMPlaneIsInfinite(FXMVECTOR P) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMPlaneDot(FXMVECTOR P, FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMPlaneDotCoord(FXMVECTOR P, FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMPlaneDotNormal(FXMVECTOR P, FXMVECTOR V);
-    XMVECTOR    XM_CALLCONV     XMPlaneNormalizeEst(FXMVECTOR P);
-    XMVECTOR    XM_CALLCONV     XMPlaneNormalize(FXMVECTOR P);
-    XMVECTOR    XM_CALLCONV     XMPlaneIntersectLine(FXMVECTOR P, FXMVECTOR LinePoint1, FXMVECTOR LinePoint2);
-    void        XM_CALLCONV     XMPlaneIntersectPlane(_Out_ XMVECTOR* pLinePoint1, _Out_ XMVECTOR* pLinePoint2, _In_ FXMVECTOR P1, _In_ FXMVECTOR P2);
-    XMVECTOR    XM_CALLCONV     XMPlaneTransform(FXMVECTOR P, FXMMATRIX M);
+    XMVECTOR    XM_CALLCONV     XMPlaneDot(FXMVECTOR P, FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMPlaneDotCoord(FXMVECTOR P, FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMPlaneDotNormal(FXMVECTOR P, FXMVECTOR V) noexcept;
+    XMVECTOR    XM_CALLCONV     XMPlaneNormalizeEst(FXMVECTOR P) noexcept;
+    XMVECTOR    XM_CALLCONV     XMPlaneNormalize(FXMVECTOR P) noexcept;
+    XMVECTOR    XM_CALLCONV     XMPlaneIntersectLine(FXMVECTOR P, FXMVECTOR LinePoint1, FXMVECTOR LinePoint2) noexcept;
+    void        XM_CALLCONV     XMPlaneIntersectPlane(_Out_ XMVECTOR* pLinePoint1, _Out_ XMVECTOR* pLinePoint2, _In_ FXMVECTOR P1, _In_ FXMVECTOR P2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMPlaneTransform(FXMVECTOR P, FXMMATRIX M) noexcept;
     XMFLOAT4* XM_CALLCONV     XMPlaneTransformStream(_Out_writes_bytes_(sizeof(XMFLOAT4) + OutputStride * (PlaneCount - 1)) XMFLOAT4* pOutputStream,
         _In_ size_t OutputStride,
         _In_reads_bytes_(sizeof(XMFLOAT4) + InputStride * (PlaneCount - 1)) const XMFLOAT4* pInputStream,
-        _In_ size_t InputStride, _In_ size_t PlaneCount, _In_ FXMMATRIX M);
+        _In_ size_t InputStride, _In_ size_t PlaneCount, _In_ FXMMATRIX M) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMPlaneFromPointNormal(FXMVECTOR Point, FXMVECTOR Normal);
-    XMVECTOR    XM_CALLCONV     XMPlaneFromPoints(FXMVECTOR Point1, FXMVECTOR Point2, FXMVECTOR Point3);
+    XMVECTOR    XM_CALLCONV     XMPlaneFromPointNormal(FXMVECTOR Point, FXMVECTOR Normal) noexcept;
+    XMVECTOR    XM_CALLCONV     XMPlaneFromPoints(FXMVECTOR Point1, FXMVECTOR Point2, FXMVECTOR Point3) noexcept;
 
     /****************************************************************************
      *
@@ -1556,41 +1556,41 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    bool        XM_CALLCONV     XMColorEqual(FXMVECTOR C1, FXMVECTOR C2);
-    bool        XM_CALLCONV     XMColorNotEqual(FXMVECTOR C1, FXMVECTOR C2);
-    bool        XM_CALLCONV     XMColorGreater(FXMVECTOR C1, FXMVECTOR C2);
-    bool        XM_CALLCONV     XMColorGreaterOrEqual(FXMVECTOR C1, FXMVECTOR C2);
-    bool        XM_CALLCONV     XMColorLess(FXMVECTOR C1, FXMVECTOR C2);
-    bool        XM_CALLCONV     XMColorLessOrEqual(FXMVECTOR C1, FXMVECTOR C2);
+    bool        XM_CALLCONV     XMColorEqual(FXMVECTOR C1, FXMVECTOR C2) noexcept;
+    bool        XM_CALLCONV     XMColorNotEqual(FXMVECTOR C1, FXMVECTOR C2) noexcept;
+    bool        XM_CALLCONV     XMColorGreater(FXMVECTOR C1, FXMVECTOR C2) noexcept;
+    bool        XM_CALLCONV     XMColorGreaterOrEqual(FXMVECTOR C1, FXMVECTOR C2) noexcept;
+    bool        XM_CALLCONV     XMColorLess(FXMVECTOR C1, FXMVECTOR C2) noexcept;
+    bool        XM_CALLCONV     XMColorLessOrEqual(FXMVECTOR C1, FXMVECTOR C2) noexcept;
 
-    bool        XM_CALLCONV     XMColorIsNaN(FXMVECTOR C);
-    bool        XM_CALLCONV     XMColorIsInfinite(FXMVECTOR C);
+    bool        XM_CALLCONV     XMColorIsNaN(FXMVECTOR C) noexcept;
+    bool        XM_CALLCONV     XMColorIsInfinite(FXMVECTOR C) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMColorNegative(FXMVECTOR C);
-    XMVECTOR    XM_CALLCONV     XMColorModulate(FXMVECTOR C1, FXMVECTOR C2);
-    XMVECTOR    XM_CALLCONV     XMColorAdjustSaturation(FXMVECTOR C, float Saturation);
-    XMVECTOR    XM_CALLCONV     XMColorAdjustContrast(FXMVECTOR C, float Contrast);
+    XMVECTOR    XM_CALLCONV     XMColorNegative(FXMVECTOR C) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorModulate(FXMVECTOR C1, FXMVECTOR C2) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorAdjustSaturation(FXMVECTOR C, float Saturation) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorAdjustContrast(FXMVECTOR C, float Contrast) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMColorRGBToHSL(FXMVECTOR rgb);
-    XMVECTOR    XM_CALLCONV     XMColorHSLToRGB(FXMVECTOR hsl);
+    XMVECTOR    XM_CALLCONV     XMColorRGBToHSL(FXMVECTOR rgb) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorHSLToRGB(FXMVECTOR hsl) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMColorRGBToHSV(FXMVECTOR rgb);
-    XMVECTOR    XM_CALLCONV     XMColorHSVToRGB(FXMVECTOR hsv);
+    XMVECTOR    XM_CALLCONV     XMColorRGBToHSV(FXMVECTOR rgb) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorHSVToRGB(FXMVECTOR hsv) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMColorRGBToYUV(FXMVECTOR rgb);
-    XMVECTOR    XM_CALLCONV     XMColorYUVToRGB(FXMVECTOR yuv);
+    XMVECTOR    XM_CALLCONV     XMColorRGBToYUV(FXMVECTOR rgb) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorYUVToRGB(FXMVECTOR yuv) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMColorRGBToYUV_HD(FXMVECTOR rgb);
-    XMVECTOR    XM_CALLCONV     XMColorYUVToRGB_HD(FXMVECTOR yuv);
+    XMVECTOR    XM_CALLCONV     XMColorRGBToYUV_HD(FXMVECTOR rgb) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorYUVToRGB_HD(FXMVECTOR yuv) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMColorRGBToXYZ(FXMVECTOR rgb);
-    XMVECTOR    XM_CALLCONV     XMColorXYZToRGB(FXMVECTOR xyz);
+    XMVECTOR    XM_CALLCONV     XMColorRGBToXYZ(FXMVECTOR rgb) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorXYZToRGB(FXMVECTOR xyz) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMColorXYZToSRGB(FXMVECTOR xyz);
-    XMVECTOR    XM_CALLCONV     XMColorSRGBToXYZ(FXMVECTOR srgb);
+    XMVECTOR    XM_CALLCONV     XMColorXYZToSRGB(FXMVECTOR xyz) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorSRGBToXYZ(FXMVECTOR srgb) noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMColorRGBToSRGB(FXMVECTOR rgb);
-    XMVECTOR    XM_CALLCONV     XMColorSRGBToRGB(FXMVECTOR srgb);
+    XMVECTOR    XM_CALLCONV     XMColorRGBToSRGB(FXMVECTOR rgb) noexcept;
+    XMVECTOR    XM_CALLCONV     XMColorSRGBToRGB(FXMVECTOR srgb) noexcept;
 
 
     /****************************************************************************
@@ -1599,27 +1599,27 @@ namespace DirectX
      *
      ****************************************************************************/
 
-    bool            XMVerifyCPUSupport();
+    bool            XMVerifyCPUSupport() noexcept;
 
-    XMVECTOR    XM_CALLCONV     XMFresnelTerm(FXMVECTOR CosIncidentAngle, FXMVECTOR RefractionIndex);
+    XMVECTOR    XM_CALLCONV     XMFresnelTerm(FXMVECTOR CosIncidentAngle, FXMVECTOR RefractionIndex) noexcept;
 
-    bool            XMScalarNearEqual(float S1, float S2, float Epsilon);
-    float           XMScalarModAngle(float Value);
+    bool            XMScalarNearEqual(float S1, float S2, float Epsilon) noexcept;
+    float           XMScalarModAngle(float Value) noexcept;
 
-    float           XMScalarSin(float Value);
-    float           XMScalarSinEst(float Value);
+    float           XMScalarSin(float Value) noexcept;
+    float           XMScalarSinEst(float Value) noexcept;
 
-    float           XMScalarCos(float Value);
-    float           XMScalarCosEst(float Value);
+    float           XMScalarCos(float Value) noexcept;
+    float           XMScalarCosEst(float Value) noexcept;
 
-    void            XMScalarSinCos(_Out_ float* pSin, _Out_ float* pCos, float Value);
-    void            XMScalarSinCosEst(_Out_ float* pSin, _Out_ float* pCos, float Value);
+    void            XMScalarSinCos(_Out_ float* pSin, _Out_ float* pCos, float Value) noexcept;
+    void            XMScalarSinCosEst(_Out_ float* pSin, _Out_ float* pCos, float Value) noexcept;
 
-    float           XMScalarASin(float Value);
-    float           XMScalarASinEst(float Value);
+    float           XMScalarASin(float Value) noexcept;
+    float           XMScalarASinEst(float Value) noexcept;
 
-    float           XMScalarACos(float Value);
-    float           XMScalarACosEst(float Value);
+    float           XMScalarACos(float Value) noexcept;
+    float           XMScalarACosEst(float Value) noexcept;
 
     /****************************************************************************
      *
@@ -1645,7 +1645,7 @@ namespace DirectX
         // Slow path fallback for permutes that do not map to a single SSE shuffle opcode.
         template<uint32_t Shuffle, bool WhichX, bool WhichY, bool WhichZ, bool WhichW> struct PermuteHelper
         {
-            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR v2)
+            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR v2) noexcept
             {
                 static const XMVECTORU32 selectMask =
                 { { {
@@ -1668,25 +1668,25 @@ namespace DirectX
         // Fast path for permutes that only read from the first vector.
         template<uint32_t Shuffle> struct PermuteHelper<Shuffle, false, false, false, false>
         {
-            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR) { return XM_PERMUTE_PS(v1, Shuffle); }
+            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR) noexcept { return XM_PERMUTE_PS(v1, Shuffle); }
         };
 
         // Fast path for permutes that only read from the second vector.
         template<uint32_t Shuffle> struct PermuteHelper<Shuffle, true, true, true, true>
         {
-            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR, FXMVECTOR v2) { return XM_PERMUTE_PS(v2, Shuffle); }
+            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR, FXMVECTOR v2) noexcept { return XM_PERMUTE_PS(v2, Shuffle); }
         };
 
         // Fast path for permutes that read XY from the first vector, ZW from the second.
         template<uint32_t Shuffle> struct PermuteHelper<Shuffle, false, false, true, true>
         {
-            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR v2) { return _mm_shuffle_ps(v1, v2, Shuffle); }
+            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR v2) noexcept { return _mm_shuffle_ps(v1, v2, Shuffle); }
         };
 
         // Fast path for permutes that read XY from the second vector, ZW from the first.
         template<uint32_t Shuffle> struct PermuteHelper<Shuffle, true, true, false, false>
         {
-            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR v2) { return _mm_shuffle_ps(v2, v1, Shuffle); }
+            static XMVECTOR     XM_CALLCONV     Permute(FXMVECTOR v1, FXMVECTOR v2) noexcept { return _mm_shuffle_ps(v2, v1, Shuffle); }
         };
     }
 
@@ -1694,7 +1694,7 @@ namespace DirectX
 
     // General permute template
     template<uint32_t PermuteX, uint32_t PermuteY, uint32_t PermuteZ, uint32_t PermuteW>
-    inline XMVECTOR     XM_CALLCONV     XMVectorPermute(FXMVECTOR V1, FXMVECTOR V2)
+    inline XMVECTOR     XM_CALLCONV     XMVectorPermute(FXMVECTOR V1, FXMVECTOR V2) noexcept
     {
         static_assert(PermuteX <= 7, "PermuteX template parameter out of range");
         static_assert(PermuteY <= 7, "PermuteY template parameter out of range");
@@ -1718,32 +1718,32 @@ namespace DirectX
     }
 
     // Special-case permute templates
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 2, 3>(FXMVECTOR V1, FXMVECTOR) { return V1; }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 5, 6, 7>(FXMVECTOR, FXMVECTOR V2) { return V2; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 2, 3>(FXMVECTOR V1, FXMVECTOR) noexcept { return V1; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 5, 6, 7>(FXMVECTOR, FXMVECTOR V2) noexcept { return V2; }
 
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_movelh_ps(V1, V2); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<6, 7, 2, 3>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_movehl_ps(V1, V2); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 4, 1, 5>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_unpacklo_ps(V1, V2); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 6, 3, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_unpackhi_ps(V1, V2); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_castpd_ps(_mm_unpackhi_pd(_mm_castps_pd(V1), _mm_castps_pd(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_movelh_ps(V1, V2); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<6, 7, 2, 3>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_movehl_ps(V1, V2); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 4, 1, 5>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_unpacklo_ps(V1, V2); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 6, 3, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_unpackhi_ps(V1, V2); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_castpd_ps(_mm_unpackhi_pd(_mm_castps_pd(V1), _mm_castps_pd(V2))); }
 #endif
 
 #if defined(_XM_SSE4_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 1, 2, 3>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x1); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 5, 2, 3>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x2); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 5, 2, 3>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x3); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 6, 3>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x4); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 1, 6, 3>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x5); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 5, 6, 3>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x6); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 5, 6, 3>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x7); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 2, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x8); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 1, 2, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0x9); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 5, 2, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0xA); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 5, 2, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0xB); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0xC); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 1, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0xD); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 5, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) { return _mm_blend_ps(V1, V2, 0xE); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 1, 2, 3>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x1); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 5, 2, 3>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x2); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 5, 2, 3>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x3); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 6, 3>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x4); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 1, 6, 3>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x5); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 5, 6, 3>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x6); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 5, 6, 3>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x7); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 2, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x8); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 1, 2, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0x9); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 5, 2, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0xA); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 5, 2, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0xB); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0xC); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<4, 1, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0xD); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 5, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return _mm_blend_ps(V1, V2, 0xE); }
 #endif
 
 #if defined(_XM_ARM_NEON_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
@@ -1752,37 +1752,37 @@ namespace DirectX
     // The mirror cases are not spelled out here as the programmer can always swap the arguments
     // (i.e. prefer permutes where the X element comes from the V1 vector instead of the V2 vector)
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vget_low_f32(V1), vget_low_f32(V2)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 0, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vrev64_f32(vget_low_f32(V1)), vget_low_f32(V2)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 5, 4>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vget_low_f32(V1), vrev64_f32(vget_low_f32(V2))); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 0, 5, 4>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vrev64_f32(vget_low_f32(V1)), vrev64_f32(vget_low_f32(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vget_low_f32(V1), vget_low_f32(V2)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 0, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vrev64_f32(vget_low_f32(V1)), vget_low_f32(V2)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 5, 4>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vget_low_f32(V1), vrev64_f32(vget_low_f32(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 0, 5, 4>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vrev64_f32(vget_low_f32(V1)), vrev64_f32(vget_low_f32(V2))); }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vget_high_f32(V1), vget_high_f32(V2)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 2, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vrev64_f32(vget_high_f32(V1)), vget_high_f32(V2)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 7, 6>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vget_high_f32(V1), vrev64_f32(vget_high_f32(V2))); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 2, 7, 6>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vrev64_f32(vget_high_f32(V1)), vrev64_f32(vget_high_f32(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vget_high_f32(V1), vget_high_f32(V2)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 2, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vrev64_f32(vget_high_f32(V1)), vget_high_f32(V2)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 7, 6>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vget_high_f32(V1), vrev64_f32(vget_high_f32(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 2, 7, 6>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vrev64_f32(vget_high_f32(V1)), vrev64_f32(vget_high_f32(V2))); }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vget_low_f32(V1), vget_high_f32(V2)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 0, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vrev64_f32(vget_low_f32(V1)), vget_high_f32(V2)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 7, 6>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vget_low_f32(V1), vrev64_f32(vget_high_f32(V2))); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 0, 7, 6>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vrev64_f32(vget_low_f32(V1)), vrev64_f32(vget_high_f32(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vget_low_f32(V1), vget_high_f32(V2)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 0, 6, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vrev64_f32(vget_low_f32(V1)), vget_high_f32(V2)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 1, 7, 6>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vget_low_f32(V1), vrev64_f32(vget_high_f32(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 0, 7, 6>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vrev64_f32(vget_low_f32(V1)), vrev64_f32(vget_high_f32(V2))); }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 2, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vrev64_f32(vget_high_f32(V1)), vget_low_f32(V2)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 5, 4>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vget_high_f32(V1), vrev64_f32(vget_low_f32(V2))); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 2, 5, 4>(FXMVECTOR V1, FXMVECTOR V2) { return vcombine_f32(vrev64_f32(vget_high_f32(V1)), vrev64_f32(vget_low_f32(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 2, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vrev64_f32(vget_high_f32(V1)), vget_low_f32(V2)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 5, 4>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vget_high_f32(V1), vrev64_f32(vget_low_f32(V2))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 2, 5, 4>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vcombine_f32(vrev64_f32(vget_high_f32(V1)), vrev64_f32(vget_low_f32(V2))); }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 4, 2, 6>(FXMVECTOR V1, FXMVECTOR V2) { return vtrnq_f32(V1, V2).val[0]; }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 5, 3, 7>(FXMVECTOR V1, FXMVECTOR V2) { return vtrnq_f32(V1, V2).val[1]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 4, 2, 6>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vtrnq_f32(V1, V2).val[0]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 5, 3, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vtrnq_f32(V1, V2).val[1]; }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 4, 1, 5>(FXMVECTOR V1, FXMVECTOR V2) { return vzipq_f32(V1, V2).val[0]; }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 6, 3, 7>(FXMVECTOR V1, FXMVECTOR V2) { return vzipq_f32(V1, V2).val[1]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 4, 1, 5>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vzipq_f32(V1, V2).val[0]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 6, 3, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vzipq_f32(V1, V2).val[1]; }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 2, 4, 6>(FXMVECTOR V1, FXMVECTOR V2) { return vuzpq_f32(V1, V2).val[0]; }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 3, 5, 7>(FXMVECTOR V1, FXMVECTOR V2) { return vuzpq_f32(V1, V2).val[1]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<0, 2, 4, 6>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vuzpq_f32(V1, V2).val[0]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 3, 5, 7>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vuzpq_f32(V1, V2).val[1]; }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 2, 3, 4>(FXMVECTOR V1, FXMVECTOR V2) { return vextq_f32(V1, V2, 1); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) { return vextq_f32(V1, V2, 2); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 4, 5, 6>(FXMVECTOR V1, FXMVECTOR V2) { return vextq_f32(V1, V2, 3); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<1, 2, 3, 4>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vextq_f32(V1, V2, 1); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<2, 3, 4, 5>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vextq_f32(V1, V2, 2); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorPermute<3, 4, 5, 6>(FXMVECTOR V1, FXMVECTOR V2) noexcept { return vextq_f32(V1, V2, 3); }
 
 #endif // _XM_ARM_NEON_INTRINSICS_ && !_XM_NO_INTRINSICS_
 
@@ -1790,7 +1790,7 @@ namespace DirectX
 
     // General swizzle template
     template<uint32_t SwizzleX, uint32_t SwizzleY, uint32_t SwizzleZ, uint32_t SwizzleW>
-    inline XMVECTOR     XM_CALLCONV     XMVectorSwizzle(FXMVECTOR V)
+    inline XMVECTOR     XM_CALLCONV     XMVectorSwizzle(FXMVECTOR V) noexcept
     {
         static_assert(SwizzleX <= 3, "SwizzleX template parameter out of range");
         static_assert(SwizzleY <= 3, "SwizzleY template parameter out of range");
@@ -1807,84 +1807,84 @@ namespace DirectX
     }
 
     // Specialized swizzles
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 1, 2, 3>(FXMVECTOR V) { return V; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 1, 2, 3>(FXMVECTOR V) noexcept { return V; }
 
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 1, 0, 1>(FXMVECTOR V) { return _mm_movelh_ps(V, V); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 3, 2, 3>(FXMVECTOR V) { return _mm_movehl_ps(V, V); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 1, 1>(FXMVECTOR V) { return _mm_unpacklo_ps(V, V); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 2, 3, 3>(FXMVECTOR V) { return _mm_unpackhi_ps(V, V); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 1, 0, 1>(FXMVECTOR V) noexcept { return _mm_movelh_ps(V, V); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 3, 2, 3>(FXMVECTOR V) noexcept { return _mm_movehl_ps(V, V); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 1, 1>(FXMVECTOR V) noexcept { return _mm_unpacklo_ps(V, V); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 2, 3, 3>(FXMVECTOR V) noexcept { return _mm_unpackhi_ps(V, V); }
 #endif
 
 #if defined(_XM_SSE3_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 2, 2>(FXMVECTOR V) { return _mm_moveldup_ps(V); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 1, 3, 3>(FXMVECTOR V) { return _mm_movehdup_ps(V); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 2, 2>(FXMVECTOR V) noexcept { return _mm_moveldup_ps(V); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 1, 3, 3>(FXMVECTOR V) noexcept { return _mm_movehdup_ps(V); }
 #endif
 
 #if defined(_XM_AVX2_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 0, 0>(FXMVECTOR V) { return _mm_broadcastss_ps(V); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 0, 0>(FXMVECTOR V) noexcept { return _mm_broadcastss_ps(V); }
 #endif
 
 #if defined(_XM_ARM_NEON_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 0, 0>(FXMVECTOR V) { return vdupq_lane_f32(vget_low_f32(V), 0); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 1, 1, 1>(FXMVECTOR V) { return vdupq_lane_f32(vget_low_f32(V), 1); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 2, 2, 2>(FXMVECTOR V) { return vdupq_lane_f32(vget_high_f32(V), 0); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 3, 3, 3>(FXMVECTOR V) { return vdupq_lane_f32(vget_high_f32(V), 1); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 0, 0>(FXMVECTOR V) noexcept { return vdupq_lane_f32(vget_low_f32(V), 0); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 1, 1, 1>(FXMVECTOR V) noexcept { return vdupq_lane_f32(vget_low_f32(V), 1); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 2, 2, 2>(FXMVECTOR V) noexcept { return vdupq_lane_f32(vget_high_f32(V), 0); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 3, 3, 3>(FXMVECTOR V) noexcept { return vdupq_lane_f32(vget_high_f32(V), 1); }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 0, 3, 2>(FXMVECTOR V) { return vrev64q_f32(V); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 0, 3, 2>(FXMVECTOR V) noexcept { return vrev64q_f32(V); }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 1, 0, 1>(FXMVECTOR V) { float32x2_t vt = vget_low_f32(V); return vcombine_f32(vt, vt); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 3, 2, 3>(FXMVECTOR V) { float32x2_t vt = vget_high_f32(V); return vcombine_f32(vt, vt); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 0, 1, 0>(FXMVECTOR V) { float32x2_t vt = vrev64_f32(vget_low_f32(V)); return vcombine_f32(vt, vt); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 2, 3, 2>(FXMVECTOR V) { float32x2_t vt = vrev64_f32(vget_high_f32(V)); return vcombine_f32(vt, vt); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 1, 0, 1>(FXMVECTOR V) noexcept { float32x2_t vt = vget_low_f32(V); return vcombine_f32(vt, vt); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 3, 2, 3>(FXMVECTOR V) noexcept { float32x2_t vt = vget_high_f32(V); return vcombine_f32(vt, vt); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 0, 1, 0>(FXMVECTOR V) noexcept { float32x2_t vt = vrev64_f32(vget_low_f32(V)); return vcombine_f32(vt, vt); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 2, 3, 2>(FXMVECTOR V) noexcept { float32x2_t vt = vrev64_f32(vget_high_f32(V)); return vcombine_f32(vt, vt); }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 1, 3, 2>(FXMVECTOR V) { return vcombine_f32(vget_low_f32(V), vrev64_f32(vget_high_f32(V))); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 0, 2, 3>(FXMVECTOR V) { return vcombine_f32(vrev64_f32(vget_low_f32(V)), vget_high_f32(V)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 3, 1, 0>(FXMVECTOR V) { return vcombine_f32(vget_high_f32(V), vrev64_f32(vget_low_f32(V))); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 2, 0, 1>(FXMVECTOR V) { return vcombine_f32(vrev64_f32(vget_high_f32(V)), vget_low_f32(V)); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 2, 1, 0>(FXMVECTOR V) { return vcombine_f32(vrev64_f32(vget_high_f32(V)), vrev64_f32(vget_low_f32(V))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 1, 3, 2>(FXMVECTOR V) noexcept { return vcombine_f32(vget_low_f32(V), vrev64_f32(vget_high_f32(V))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 0, 2, 3>(FXMVECTOR V) noexcept { return vcombine_f32(vrev64_f32(vget_low_f32(V)), vget_high_f32(V)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 3, 1, 0>(FXMVECTOR V) noexcept { return vcombine_f32(vget_high_f32(V), vrev64_f32(vget_low_f32(V))); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 2, 0, 1>(FXMVECTOR V) noexcept { return vcombine_f32(vrev64_f32(vget_high_f32(V)), vget_low_f32(V)); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 2, 1, 0>(FXMVECTOR V) noexcept { return vcombine_f32(vrev64_f32(vget_high_f32(V)), vrev64_f32(vget_low_f32(V))); }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 2, 2>(FXMVECTOR V) { return vtrnq_f32(V, V).val[0]; }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 1, 3, 3>(FXMVECTOR V) { return vtrnq_f32(V, V).val[1]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 2, 2>(FXMVECTOR V) noexcept { return vtrnq_f32(V, V).val[0]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 1, 3, 3>(FXMVECTOR V) noexcept { return vtrnq_f32(V, V).val[1]; }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 1, 1>(FXMVECTOR V) { return vzipq_f32(V, V).val[0]; }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 2, 3, 3>(FXMVECTOR V) { return vzipq_f32(V, V).val[1]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 0, 1, 1>(FXMVECTOR V) noexcept { return vzipq_f32(V, V).val[0]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 2, 3, 3>(FXMVECTOR V) noexcept { return vzipq_f32(V, V).val[1]; }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 2, 0, 2>(FXMVECTOR V) { return vuzpq_f32(V, V).val[0]; }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 3, 1, 3>(FXMVECTOR V) { return vuzpq_f32(V, V).val[1]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<0, 2, 0, 2>(FXMVECTOR V) noexcept { return vuzpq_f32(V, V).val[0]; }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 3, 1, 3>(FXMVECTOR V) noexcept { return vuzpq_f32(V, V).val[1]; }
 
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 2, 3, 0>(FXMVECTOR V) { return vextq_f32(V, V, 1); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 3, 0, 1>(FXMVECTOR V) { return vextq_f32(V, V, 2); }
-    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 0, 1, 2>(FXMVECTOR V) { return vextq_f32(V, V, 3); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<1, 2, 3, 0>(FXMVECTOR V) noexcept { return vextq_f32(V, V, 1); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<2, 3, 0, 1>(FXMVECTOR V) noexcept { return vextq_f32(V, V, 2); }
+    template<> inline XMVECTOR      XM_CALLCONV     XMVectorSwizzle<3, 0, 1, 2>(FXMVECTOR V) noexcept { return vextq_f32(V, V, 3); }
 
 #endif // _XM_ARM_NEON_INTRINSICS_ && !_XM_NO_INTRINSICS_
 
     //------------------------------------------------------------------------------
 
     template<uint32_t Elements>
-    inline XMVECTOR     XM_CALLCONV     XMVectorShiftLeft(FXMVECTOR V1, FXMVECTOR V2)
+    inline XMVECTOR     XM_CALLCONV     XMVectorShiftLeft(FXMVECTOR V1, FXMVECTOR V2) noexcept
     {
         static_assert(Elements < 4, "Elements template parameter out of range");
         return XMVectorPermute<Elements, (Elements + 1), (Elements + 2), (Elements + 3)>(V1, V2);
     }
 
     template<uint32_t Elements>
-    inline XMVECTOR     XM_CALLCONV     XMVectorRotateLeft(FXMVECTOR V)
+    inline XMVECTOR     XM_CALLCONV     XMVectorRotateLeft(FXMVECTOR V) noexcept
     {
         static_assert(Elements < 4, "Elements template parameter out of range");
         return XMVectorSwizzle<Elements & 3, (Elements + 1) & 3, (Elements + 2) & 3, (Elements + 3) & 3>(V);
     }
 
     template<uint32_t Elements>
-    inline XMVECTOR     XM_CALLCONV     XMVectorRotateRight(FXMVECTOR V)
+    inline XMVECTOR     XM_CALLCONV     XMVectorRotateRight(FXMVECTOR V) noexcept
     {
         static_assert(Elements < 4, "Elements template parameter out of range");
         return XMVectorSwizzle<(4 - Elements) & 3, (5 - Elements) & 3, (6 - Elements) & 3, (7 - Elements) & 3>(V);
     }
 
     template<uint32_t VSLeftRotateElements, uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3>
-    inline XMVECTOR     XM_CALLCONV     XMVectorInsert(FXMVECTOR VD, FXMVECTOR VS)
+    inline XMVECTOR     XM_CALLCONV     XMVectorInsert(FXMVECTOR VD, FXMVECTOR VS) noexcept
     {
         XMVECTOR Control = XMVectorSelectControl(Select0 & 1, Select1 & 1, Select2 & 1, Select3 & 1);
         return XMVectorSelect(VD, XMVectorRotateLeft<VSLeftRotateElements>(VS), Control);
@@ -2075,7 +2075,7 @@ namespace DirectX
 
 //------------------------------------------------------------------------------
 
-    inline XMVECTOR XM_CALLCONV XMVectorSetBinaryConstant(uint32_t C0, uint32_t C1, uint32_t C2, uint32_t C3)
+    inline XMVECTOR XM_CALLCONV XMVectorSetBinaryConstant(uint32_t C0, uint32_t C1, uint32_t C2, uint32_t C3) noexcept
     {
 #if defined(_XM_NO_INTRINSICS_)
         XMVECTORU32 vResult;
@@ -2107,7 +2107,7 @@ namespace DirectX
 
     //------------------------------------------------------------------------------
 
-    inline XMVECTOR XM_CALLCONV XMVectorSplatConstant(int32_t IntConstant, uint32_t DivExponent)
+    inline XMVECTOR XM_CALLCONV XMVectorSplatConstant(int32_t IntConstant, uint32_t DivExponent) noexcept
     {
         assert(IntConstant >= -16 && IntConstant <= 15);
         assert(DivExponent < 32);
@@ -2147,7 +2147,7 @@ namespace DirectX
 
     //------------------------------------------------------------------------------
 
-    inline XMVECTOR XM_CALLCONV XMVectorSplatConstantInt(int32_t IntConstant)
+    inline XMVECTOR XM_CALLCONV XMVectorSplatConstantInt(int32_t IntConstant) noexcept
     {
         assert(IntConstant >= -16 && IntConstant <= 15);
 #if defined(_XM_NO_INTRINSICS_)

--- a/Inc/DirectXMathConvert.inl
+++ b/Inc/DirectXMathConvert.inl
@@ -25,7 +25,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorIntToFloat
 (
     FXMVECTOR    VInt,
     uint32_t     DivExponent
-)
+) noexcept
 {
     assert(DivExponent < 32);
 #if defined(_XM_NO_INTRINSICS_)
@@ -59,7 +59,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorFloatToInt
 (
     FXMVECTOR    VFloat,
     uint32_t     MulExponent
-)
+) noexcept
 {
     assert(MulExponent < 32);
 #if defined(_XM_NO_INTRINSICS_)
@@ -116,7 +116,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorUIntToFloat
 (
     FXMVECTOR     VUInt,
     uint32_t      DivExponent
-)
+) noexcept
 {
     assert(DivExponent < 32);
 #if defined(_XM_NO_INTRINSICS_)
@@ -159,7 +159,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorFloatToUInt
 (
     FXMVECTOR     VFloat,
     uint32_t      MulExponent
-)
+) noexcept
 {
     assert(MulExponent < 32);
 #if defined(_XM_NO_INTRINSICS_)
@@ -228,7 +228,7 @@ inline XMVECTOR XM_CALLCONV XMConvertVectorFloatToUInt
 
  //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadInt(const uint32_t* pSource)
+inline XMVECTOR XM_CALLCONV XMLoadInt(const uint32_t* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -248,7 +248,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt(const uint32_t* pSource)
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat(const float* pSource)
+inline XMVECTOR XM_CALLCONV XMLoadFloat(const float* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -268,10 +268,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat(const float* pSource)
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadInt2
-(
-    const uint32_t* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadInt2(const uint32_t* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -292,10 +289,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadInt2A
-(
-    const uint32_t* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadInt2A(const uint32_t* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -317,10 +311,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt2A
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat2
-(
-    const XMFLOAT2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadFloat2(const XMFLOAT2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -341,10 +332,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat2A
-(
-    const XMFLOAT2A* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadFloat2A(const XMFLOAT2A* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -366,10 +354,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat2A
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadSInt2
-(
-    const XMINT2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadSInt2(const XMINT2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -392,10 +377,7 @@ inline XMVECTOR XM_CALLCONV XMLoadSInt2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUInt2
-(
-    const XMUINT2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUInt2(const XMUINT2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -430,10 +412,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUInt2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadInt3
-(
-    const uint32_t* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadInt3(const uint32_t* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -461,10 +440,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt3
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadInt3A
-(
-    const uint32_t* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadInt3A(const uint32_t* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -492,10 +468,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt3A
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat3
-(
-    const XMFLOAT3* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadFloat3(const XMFLOAT3* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -523,10 +496,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat3
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat3A
-(
-    const XMFLOAT3A* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadFloat3A(const XMFLOAT3A* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -550,10 +520,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat3A
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadSInt3
-(
-    const XMINT3* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadSInt3(const XMINT3* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -581,10 +548,7 @@ inline XMVECTOR XM_CALLCONV XMLoadSInt3
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUInt3
-(
-    const XMUINT3* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUInt3(const XMUINT3* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -622,10 +586,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUInt3
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadInt4
-(
-    const uint32_t* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadInt4(const uint32_t* pSource) noexcept
 {
     assert(pSource);
 
@@ -646,10 +607,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadInt4A
-(
-    const uint32_t* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadInt4A(const uint32_t* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -670,10 +628,7 @@ inline XMVECTOR XM_CALLCONV XMLoadInt4A
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat4
-(
-    const XMFLOAT4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadFloat4(const XMFLOAT4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -692,10 +647,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat4A
-(
-    const XMFLOAT4A* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadFloat4A(const XMFLOAT4A* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -715,10 +667,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat4A
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadSInt4
-(
-    const XMINT4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadSInt4(const XMINT4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -741,10 +690,7 @@ inline XMVECTOR XM_CALLCONV XMLoadSInt4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUInt4
-(
-    const XMUINT4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUInt4(const XMUINT4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -777,10 +723,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUInt4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMMATRIX XM_CALLCONV XMLoadFloat3x3
-(
-    const XMFLOAT3X3* pSource
-)
+inline XMMATRIX XM_CALLCONV XMLoadFloat3x3(const XMFLOAT3X3* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -842,10 +785,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat3x3
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMMATRIX XM_CALLCONV XMLoadFloat4x3
-(
-    const XMFLOAT4X3* pSource
-)
+inline XMMATRIX XM_CALLCONV XMLoadFloat4x3(const XMFLOAT4X3* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -922,10 +862,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat4x3
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMMATRIX XM_CALLCONV XMLoadFloat4x3A
-(
-    const XMFLOAT4X3A* pSource
-)
+inline XMMATRIX XM_CALLCONV XMLoadFloat4x3A(const XMFLOAT4X3A* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -1003,10 +940,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat4x3A
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMMATRIX XM_CALLCONV XMLoadFloat3x4
-(
-    const XMFLOAT3X4* pSource
-)
+inline XMMATRIX XM_CALLCONV XMLoadFloat3x4(const XMFLOAT3X4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1084,10 +1018,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat3x4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMMATRIX XM_CALLCONV XMLoadFloat3x4A
-(
-    const XMFLOAT3X4A* pSource
-)
+inline XMMATRIX XM_CALLCONV XMLoadFloat3x4A(const XMFLOAT3X4A* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -1166,10 +1097,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat3x4A
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMMATRIX XM_CALLCONV XMLoadFloat4x4
-(
-    const XMFLOAT4X4* pSource
-)
+inline XMMATRIX XM_CALLCONV XMLoadFloat4x4(const XMFLOAT4X4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1215,10 +1143,7 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat4x4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMMATRIX XM_CALLCONV XMLoadFloat4x4A
-(
-    const XMFLOAT4X4A* pSource
-)
+inline XMMATRIX XM_CALLCONV XMLoadFloat4x4A(const XMFLOAT4X4A* pSource) noexcept
 {
     assert(pSource);
     assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
@@ -1273,7 +1198,7 @@ inline void XM_CALLCONV XMStoreInt
 (
     uint32_t* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1291,7 +1216,7 @@ inline void XM_CALLCONV XMStoreFloat
 (
     float* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1309,7 +1234,7 @@ inline void XM_CALLCONV XMStoreInt2
 (
     uint32_t* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1329,7 +1254,7 @@ inline void XM_CALLCONV XMStoreInt2A
 (
     uint32_t* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -1350,7 +1275,7 @@ inline void XM_CALLCONV XMStoreFloat2
 (
     XMFLOAT2* pDestination,
     FXMVECTOR  V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1370,7 +1295,7 @@ inline void XM_CALLCONV XMStoreFloat2A
 (
     XMFLOAT2A* pDestination,
     FXMVECTOR     V
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -1391,7 +1316,7 @@ inline void XM_CALLCONV XMStoreSInt2
 (
     XMINT2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1421,7 +1346,7 @@ inline void XM_CALLCONV XMStoreUInt2
 (
     XMUINT2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1460,7 +1385,7 @@ inline void XM_CALLCONV XMStoreInt3
 (
     uint32_t* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1484,7 +1409,7 @@ inline void XM_CALLCONV XMStoreInt3A
 (
     uint32_t* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -1509,7 +1434,7 @@ inline void XM_CALLCONV XMStoreFloat3
 (
     XMFLOAT3* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1537,7 +1462,7 @@ inline void XM_CALLCONV XMStoreFloat3A
 (
     XMFLOAT3A* pDestination,
     FXMVECTOR     V
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -1565,7 +1490,7 @@ inline void XM_CALLCONV XMStoreSInt3
 (
     XMINT3* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1599,7 +1524,7 @@ inline void XM_CALLCONV XMStoreUInt3
 (
     XMUINT3* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1642,7 +1567,7 @@ inline void XM_CALLCONV XMStoreInt4
 (
     uint32_t* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1663,7 +1588,7 @@ inline void XM_CALLCONV XMStoreInt4A
 (
     uint32_t* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -1685,7 +1610,7 @@ inline void XM_CALLCONV XMStoreFloat4
 (
     XMFLOAT4* pDestination,
     FXMVECTOR  V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1706,7 +1631,7 @@ inline void XM_CALLCONV XMStoreFloat4A
 (
     XMFLOAT4A* pDestination,
     FXMVECTOR     V
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -1728,7 +1653,7 @@ inline void XM_CALLCONV XMStoreSInt4
 (
     XMINT4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1758,7 +1683,7 @@ inline void XM_CALLCONV XMStoreUInt4
 (
     XMUINT4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1797,7 +1722,7 @@ inline void XM_CALLCONV XMStoreFloat3x3
 (
     XMFLOAT3X3* pDestination,
     FXMMATRIX   M
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1844,7 +1769,7 @@ inline void XM_CALLCONV XMStoreFloat4x3
 (
     XMFLOAT4X3* pDestination,
     FXMMATRIX M
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1899,7 +1824,7 @@ inline void XM_CALLCONV XMStoreFloat4x3A
 (
     XMFLOAT4X3A* pDestination,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -1965,7 +1890,7 @@ inline void XM_CALLCONV XMStoreFloat3x4
 (
     XMFLOAT3X4* pDestination,
     FXMMATRIX M
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2024,7 +1949,7 @@ inline void XM_CALLCONV XMStoreFloat3x4A
 (
     XMFLOAT3X4A* pDestination,
     FXMMATRIX M
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -2084,7 +2009,7 @@ inline void XM_CALLCONV XMStoreFloat4x4
 (
     XMFLOAT4X4* pDestination,
     FXMMATRIX M
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2128,7 +2053,7 @@ inline void XM_CALLCONV XMStoreFloat4x4A
 (
     XMFLOAT4X4A* pDestination,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pDestination);
     assert((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0);
@@ -2166,4 +2091,3 @@ inline void XM_CALLCONV XMStoreFloat4x4A
     _mm_store_ps(&pDestination->_41, M.r[3]);
 #endif
 }
-

--- a/Inc/DirectXMathMatrix.inl
+++ b/Inc/DirectXMathMatrix.inl
@@ -27,10 +27,7 @@
 #endif
 
 // Return true if any entry in the matrix is NaN
-inline bool XM_CALLCONV XMMatrixIsNaN
-(
-    FXMMATRIX M
-)
+inline bool XM_CALLCONV XMMatrixIsNaN(FXMMATRIX M) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     size_t i = 16;
@@ -97,10 +94,7 @@ inline bool XM_CALLCONV XMMatrixIsNaN
 //------------------------------------------------------------------------------
 
 // Return true if any entry in the matrix is +/-INF
-inline bool XM_CALLCONV XMMatrixIsInfinite
-(
-    FXMMATRIX M
-)
+inline bool XM_CALLCONV XMMatrixIsInfinite(FXMMATRIX M) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     size_t i = 16;
@@ -161,10 +155,7 @@ inline bool XM_CALLCONV XMMatrixIsInfinite
 //------------------------------------------------------------------------------
 
 // Return true if the XMMatrix is equal to identity
-inline bool XM_CALLCONV XMMatrixIsIdentity
-(
-    FXMMATRIX M
-)
+inline bool XM_CALLCONV XMMatrixIsIdentity(FXMMATRIX M) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     // Use the integer pipeline to reduce branching to a minimum
@@ -229,7 +220,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixMultiply
 (
     FXMMATRIX M1,
     CXMMATRIX M2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMMATRIX mResult;
@@ -399,7 +390,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixMultiplyTranspose
 (
     FXMMATRIX M1,
     CXMMATRIX M2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMMATRIX mResult;
@@ -595,10 +586,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixMultiplyTranspose
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixTranspose
-(
-    FXMMATRIX M
-)
+inline XMMATRIX XM_CALLCONV XMMatrixTranspose(FXMMATRIX M) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -665,7 +653,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixInverse
 (
     XMVECTOR* pDeterminant,
     FXMMATRIX  M
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_) || defined(_XM_ARM_NEON_INTRINSICS_)
 
@@ -880,10 +868,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixInverse
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMMatrixDeterminant
-(
-    FXMMATRIX M
-)
+inline XMVECTOR XM_CALLCONV XMMatrixDeterminant(FXMMATRIX M) noexcept
 {
     static const XMVECTORF32 Sign = { { { 1.0f, -1.0f, 1.0f, -1.0f } } };
 
@@ -980,7 +965,7 @@ inline bool XM_CALLCONV XMMatrixDecompose
     XMVECTOR* outRotQuat,
     XMVECTOR* outTrans,
     FXMMATRIX M
-)
+) noexcept
 {
     static const XMVECTOR* pvCanonicalBasis[3] = {
         &g_XMIdentityR0.v,
@@ -1080,7 +1065,7 @@ inline bool XM_CALLCONV XMMatrixDecompose
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixIdentity()
+inline XMMATRIX XM_CALLCONV XMMatrixIdentity() noexcept
 {
     XMMATRIX M;
     M.r[0] = g_XMIdentityR0.v;
@@ -1098,7 +1083,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixSet
     float m10, float m11, float m12, float m13,
     float m20, float m21, float m22, float m23,
     float m30, float m31, float m32, float m33
-)
+) noexcept
 {
     XMMATRIX M;
 #if defined(_XM_NO_INTRINSICS_)
@@ -1122,7 +1107,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixTranslation
     float OffsetX,
     float OffsetY,
     float OffsetZ
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1161,10 +1146,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixTranslation
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixTranslationFromVector
-(
-    FXMVECTOR Offset
-)
+inline XMMATRIX XM_CALLCONV XMMatrixTranslationFromVector(FXMVECTOR Offset) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1207,7 +1189,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixScaling
     float ScaleX,
     float ScaleY,
     float ScaleZ
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1253,10 +1235,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixScaling
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixScalingFromVector
-(
-    FXMVECTOR Scale
-)
+inline XMMATRIX XM_CALLCONV XMMatrixScalingFromVector(FXMVECTOR Scale) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1301,10 +1280,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixScalingFromVector
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixRotationX
-(
-    float Angle
-)
+inline XMMATRIX XM_CALLCONV XMMatrixRotationX(float Angle) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1377,10 +1353,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixRotationX
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixRotationY
-(
-    float Angle
-)
+inline XMMATRIX XM_CALLCONV XMMatrixRotationY(float Angle) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1453,10 +1426,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixRotationY
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixRotationZ
-(
-    float Angle
-)
+inline XMMATRIX XM_CALLCONV XMMatrixRotationZ(float Angle) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1534,7 +1504,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixRotationRollPitchYaw
     float Pitch,
     float Yaw,
     float Roll
-)
+) noexcept
 {
     XMVECTOR Angles = XMVectorSet(Pitch, Yaw, Roll, 0.0f);
     return XMMatrixRotationRollPitchYawFromVector(Angles);
@@ -1545,7 +1515,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixRotationRollPitchYaw
 inline XMMATRIX XM_CALLCONV XMMatrixRotationRollPitchYawFromVector
 (
     FXMVECTOR Angles // <Pitch, Yaw, Roll, undefined>
-)
+) noexcept
 {
     XMVECTOR Q = XMQuaternionRotationRollPitchYawFromVector(Angles);
     return XMMatrixRotationQuaternion(Q);
@@ -1557,7 +1527,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixRotationNormal
 (
     FXMVECTOR NormalAxis,
     float     Angle
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_) || defined(_XM_ARM_NEON_INTRINSICS_)
 
@@ -1647,7 +1617,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixRotationAxis
 (
     FXMVECTOR Axis,
     float     Angle
-)
+) noexcept
 {
     assert(!XMVector3Equal(Axis, XMVectorZero()));
     assert(!XMVector3IsInfinite(Axis));
@@ -1658,10 +1628,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixRotationAxis
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixRotationQuaternion
-(
-    FXMVECTOR Quaternion
-)
+inline XMMATRIX XM_CALLCONV XMMatrixRotationQuaternion(FXMVECTOR Quaternion) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_) || defined(_XM_ARM_NEON_INTRINSICS_)
 
@@ -1752,7 +1719,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixTransformation2D
     FXMVECTOR RotationOrigin,
     float     Rotation,
     GXMVECTOR Translation
-)
+) noexcept
 {
     // M = Inverse(MScalingOrigin) * Transpose(MScalingOrientation) * MScaling * MScalingOrientation *
     //         MScalingOrigin * Inverse(MRotationOrigin) * MRotation * MRotationOrigin * MTranslation;
@@ -1791,7 +1758,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixTransformation
     GXMVECTOR RotationOrigin,
     HXMVECTOR RotationQuaternion,
     HXMVECTOR Translation
-)
+) noexcept
 {
     // M = Inverse(MScalingOrigin) * Transpose(MScalingOrientation) * MScaling * MScalingOrientation *
     //         MScalingOrigin * Inverse(MRotationOrigin) * MRotation * MRotationOrigin * MTranslation;
@@ -1827,7 +1794,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixAffineTransformation2D
     FXMVECTOR RotationOrigin,
     float     Rotation,
     FXMVECTOR Translation
-)
+) noexcept
 {
     // M = MScaling * Inverse(MRotationOrigin) * MRotation * MRotationOrigin * MTranslation;
 
@@ -1854,7 +1821,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixAffineTransformation
     FXMVECTOR RotationOrigin,
     FXMVECTOR RotationQuaternion,
     GXMVECTOR Translation
-)
+) noexcept
 {
     // M = MScaling * Inverse(MRotationOrigin) * MRotation * MRotationOrigin * MTranslation;
 
@@ -1874,10 +1841,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixAffineTransformation
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMatrixReflect
-(
-    FXMVECTOR ReflectionPlane
-)
+inline XMMATRIX XM_CALLCONV XMMatrixReflect(FXMVECTOR ReflectionPlane) noexcept
 {
     assert(!XMVector3Equal(ReflectionPlane, XMVectorZero()));
     assert(!XMPlaneIsInfinite(ReflectionPlane));
@@ -1906,7 +1870,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixShadow
 (
     FXMVECTOR ShadowPlane,
     FXMVECTOR LightPosition
-)
+) noexcept
 {
     static const XMVECTORU32 Select0001 = { { { XM_SELECT_0, XM_SELECT_0, XM_SELECT_0, XM_SELECT_1 } } };
 
@@ -1942,7 +1906,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixLookAtLH
     FXMVECTOR EyePosition,
     FXMVECTOR FocusPosition,
     FXMVECTOR UpDirection
-)
+) noexcept
 {
     XMVECTOR EyeDirection = XMVectorSubtract(FocusPosition, EyePosition);
     return XMMatrixLookToLH(EyePosition, EyeDirection, UpDirection);
@@ -1955,7 +1919,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixLookAtRH
     FXMVECTOR EyePosition,
     FXMVECTOR FocusPosition,
     FXMVECTOR UpDirection
-)
+) noexcept
 {
     XMVECTOR NegEyeDirection = XMVectorSubtract(EyePosition, FocusPosition);
     return XMMatrixLookToLH(EyePosition, NegEyeDirection, UpDirection);
@@ -1968,7 +1932,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixLookToLH
     FXMVECTOR EyePosition,
     FXMVECTOR EyeDirection,
     FXMVECTOR UpDirection
-)
+) noexcept
 {
     assert(!XMVector3Equal(EyeDirection, XMVectorZero()));
     assert(!XMVector3IsInfinite(EyeDirection));
@@ -2006,7 +1970,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixLookToRH
     FXMVECTOR EyePosition,
     FXMVECTOR EyeDirection,
     FXMVECTOR UpDirection
-)
+) noexcept
 {
     XMVECTOR NegEyeDirection = XMVectorNegate(EyeDirection);
     return XMMatrixLookToLH(EyePosition, NegEyeDirection, UpDirection);
@@ -2025,7 +1989,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixPerspectiveLH
     float ViewHeight,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(NearZ > 0.f && FarZ > 0.f);
     assert(!XMScalarNearEqual(ViewWidth, 0.0f, 0.00001f));
@@ -2112,7 +2076,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixPerspectiveRH
     float ViewHeight,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(NearZ > 0.f && FarZ > 0.f);
     assert(!XMScalarNearEqual(ViewWidth, 0.0f, 0.00001f));
@@ -2200,7 +2164,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixPerspectiveFovLH
     float AspectRatio,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(NearZ > 0.f && FarZ > 0.f);
     assert(!XMScalarNearEqual(FovAngleY, 0.0f, 0.00001f * 2.0f));
@@ -2302,7 +2266,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixPerspectiveFovRH
     float AspectRatio,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(NearZ > 0.f && FarZ > 0.f);
     assert(!XMScalarNearEqual(FovAngleY, 0.0f, 0.00001f * 2.0f));
@@ -2404,7 +2368,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixPerspectiveOffCenterLH
     float ViewTop,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(NearZ > 0.f && FarZ > 0.f);
     assert(!XMScalarNearEqual(ViewRight, ViewLeft, 0.00001f));
@@ -2502,7 +2466,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixPerspectiveOffCenterRH
     float ViewTop,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(NearZ > 0.f && FarZ > 0.f);
     assert(!XMScalarNearEqual(ViewRight, ViewLeft, 0.00001f));
@@ -2598,7 +2562,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixOrthographicLH
     float ViewHeight,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(!XMScalarNearEqual(ViewWidth, 0.0f, 0.00001f));
     assert(!XMScalarNearEqual(ViewHeight, 0.0f, 0.00001f));
@@ -2682,7 +2646,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixOrthographicRH
     float ViewHeight,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(!XMScalarNearEqual(ViewWidth, 0.0f, 0.00001f));
     assert(!XMScalarNearEqual(ViewHeight, 0.0f, 0.00001f));
@@ -2768,7 +2732,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixOrthographicOffCenterLH
     float ViewTop,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(!XMScalarNearEqual(ViewRight, ViewLeft, 0.00001f));
     assert(!XMScalarNearEqual(ViewTop, ViewBottom, 0.00001f));
@@ -2868,7 +2832,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixOrthographicOffCenterRH
     float ViewTop,
     float NearZ,
     float FarZ
-)
+) noexcept
 {
     assert(!XMScalarNearEqual(ViewRight, ViewLeft, 0.00001f));
     assert(!XMScalarNearEqual(ViewTop, ViewBottom, 0.00001f));
@@ -2976,7 +2940,7 @@ inline XMMATRIX::XMMATRIX
     float m10, float m11, float m12, float m13,
     float m20, float m21, float m22, float m23,
     float m30, float m31, float m32, float m33
-)
+) noexcept
 {
     r[0] = XMVectorSet(m00, m01, m02, m03);
     r[1] = XMVectorSet(m10, m11, m12, m13);
@@ -2986,10 +2950,7 @@ inline XMMATRIX::XMMATRIX
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMMATRIX::XMMATRIX
-(
-    const float* pArray
-)
+inline XMMATRIX::XMMATRIX(const float* pArray) noexcept
 {
     assert(pArray != nullptr);
     r[0] = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray));
@@ -3000,7 +2961,7 @@ inline XMMATRIX::XMMATRIX
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XMMATRIX::operator- () const
+inline XMMATRIX XMMATRIX::operator- () const noexcept
 {
     XMMATRIX R;
     R.r[0] = XMVectorNegate(r[0]);
@@ -3012,7 +2973,7 @@ inline XMMATRIX XMMATRIX::operator- () const
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX& XM_CALLCONV XMMATRIX::operator+= (FXMMATRIX M)
+inline XMMATRIX& XM_CALLCONV XMMATRIX::operator+= (FXMMATRIX M) noexcept
 {
     r[0] = XMVectorAdd(r[0], M.r[0]);
     r[1] = XMVectorAdd(r[1], M.r[1]);
@@ -3023,7 +2984,7 @@ inline XMMATRIX& XM_CALLCONV XMMATRIX::operator+= (FXMMATRIX M)
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX& XM_CALLCONV XMMATRIX::operator-= (FXMMATRIX M)
+inline XMMATRIX& XM_CALLCONV XMMATRIX::operator-= (FXMMATRIX M) noexcept
 {
     r[0] = XMVectorSubtract(r[0], M.r[0]);
     r[1] = XMVectorSubtract(r[1], M.r[1]);
@@ -3034,7 +2995,7 @@ inline XMMATRIX& XM_CALLCONV XMMATRIX::operator-= (FXMMATRIX M)
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX& XM_CALLCONV XMMATRIX::operator*=(FXMMATRIX M)
+inline XMMATRIX& XM_CALLCONV XMMATRIX::operator*=(FXMMATRIX M) noexcept
 {
     *this = XMMatrixMultiply(*this, M);
     return *this;
@@ -3042,7 +3003,7 @@ inline XMMATRIX& XM_CALLCONV XMMATRIX::operator*=(FXMMATRIX M)
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX& XMMATRIX::operator*= (float S)
+inline XMMATRIX& XMMATRIX::operator*= (float S) noexcept
 {
     r[0] = XMVectorScale(r[0], S);
     r[1] = XMVectorScale(r[1], S);
@@ -3053,7 +3014,7 @@ inline XMMATRIX& XMMATRIX::operator*= (float S)
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX& XMMATRIX::operator/= (float S)
+inline XMMATRIX& XMMATRIX::operator/= (float S) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR vS = XMVectorReplicate(S);
@@ -3096,7 +3057,7 @@ inline XMMATRIX& XMMATRIX::operator/= (float S)
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMATRIX::operator+ (FXMMATRIX M) const
+inline XMMATRIX XM_CALLCONV XMMATRIX::operator+ (FXMMATRIX M) const noexcept
 {
     XMMATRIX R;
     R.r[0] = XMVectorAdd(r[0], M.r[0]);
@@ -3108,7 +3069,7 @@ inline XMMATRIX XM_CALLCONV XMMATRIX::operator+ (FXMMATRIX M) const
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMATRIX::operator- (FXMMATRIX M) const
+inline XMMATRIX XM_CALLCONV XMMATRIX::operator- (FXMMATRIX M) const noexcept
 {
     XMMATRIX R;
     R.r[0] = XMVectorSubtract(r[0], M.r[0]);
@@ -3120,14 +3081,14 @@ inline XMMATRIX XM_CALLCONV XMMATRIX::operator- (FXMMATRIX M) const
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XM_CALLCONV XMMATRIX::operator*(FXMMATRIX M) const
+inline XMMATRIX XM_CALLCONV XMMATRIX::operator*(FXMMATRIX M) const noexcept
 {
     return XMMatrixMultiply(*this, M);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XMMATRIX::operator* (float S) const
+inline XMMATRIX XMMATRIX::operator* (float S) const noexcept
 {
     XMMATRIX R;
     R.r[0] = XMVectorScale(r[0], S);
@@ -3139,7 +3100,7 @@ inline XMMATRIX XMMATRIX::operator* (float S) const
 
 //------------------------------------------------------------------------------
 
-inline XMMATRIX XMMATRIX::operator/ (float S) const
+inline XMMATRIX XMMATRIX::operator/ (float S) const noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR vS = XMVectorReplicate(S);
@@ -3190,7 +3151,7 @@ inline XMMATRIX XM_CALLCONV operator*
 (
     float S,
     FXMMATRIX M
-    )
+) noexcept
 {
     XMMATRIX R;
     R.r[0] = XMVectorScale(M.r[0], S);
@@ -3208,10 +3169,7 @@ inline XMMATRIX XM_CALLCONV operator*
 
  //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMFLOAT3X3::XMFLOAT3X3
-(
-    const float* pArray
-)
+inline XMFLOAT3X3::XMFLOAT3X3(const float* pArray) noexcept
 {
     assert(pArray != nullptr);
     for (size_t Row = 0; Row < 3; Row++)
@@ -3231,10 +3189,7 @@ inline XMFLOAT3X3::XMFLOAT3X3
 
  //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMFLOAT4X3::XMFLOAT4X3
-(
-    const float* pArray
-)
+inline XMFLOAT4X3::XMFLOAT4X3(const float* pArray) noexcept
 {
     assert(pArray != nullptr);
 
@@ -3263,10 +3218,7 @@ inline XMFLOAT4X3::XMFLOAT4X3
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMFLOAT3X4::XMFLOAT3X4
-(
-    const float* pArray
-)
+inline XMFLOAT3X4::XMFLOAT3X4(const float* pArray) noexcept
 {
     assert(pArray != nullptr);
 
@@ -3294,10 +3246,7 @@ inline XMFLOAT3X4::XMFLOAT3X4
 
  //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMFLOAT4X4::XMFLOAT4X4
-(
-    const float* pArray
-)
+inline XMFLOAT4X4::XMFLOAT4X4(const float* pArray) noexcept
 {
     assert(pArray != nullptr);
 
@@ -3321,4 +3270,3 @@ inline XMFLOAT4X4::XMFLOAT4X4
     m[3][2] = pArray[14];
     m[3][3] = pArray[15];
 }
-

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -25,7 +25,7 @@ inline bool XM_CALLCONV XMQuaternionEqual
 (
     FXMVECTOR Q1,
     FXMVECTOR Q2
-)
+) noexcept
 {
     return XMVector4Equal(Q1, Q2);
 }
@@ -36,37 +36,28 @@ inline bool XM_CALLCONV XMQuaternionNotEqual
 (
     FXMVECTOR Q1,
     FXMVECTOR Q2
-)
+) noexcept
 {
     return XMVector4NotEqual(Q1, Q2);
 }
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMQuaternionIsNaN
-(
-    FXMVECTOR Q
-)
+inline bool XM_CALLCONV XMQuaternionIsNaN(FXMVECTOR Q) noexcept
 {
     return XMVector4IsNaN(Q);
 }
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMQuaternionIsInfinite
-(
-    FXMVECTOR Q
-)
+inline bool XM_CALLCONV XMQuaternionIsInfinite(FXMVECTOR Q) noexcept
 {
     return XMVector4IsInfinite(Q);
 }
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMQuaternionIsIdentity
-(
-    FXMVECTOR Q
-)
+inline bool XM_CALLCONV XMQuaternionIsIdentity(FXMVECTOR Q) noexcept
 {
     return XMVector4Equal(Q, g_XMIdentityR3.v);
 }
@@ -81,7 +72,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionDot
 (
     FXMVECTOR Q1,
     FXMVECTOR Q2
-)
+) noexcept
 {
     return XMVector4Dot(Q1, Q2);
 }
@@ -92,7 +83,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionMultiply
 (
     FXMVECTOR Q1,
     FXMVECTOR Q2
-)
+) noexcept
 {
     // Returns the product Q2*Q1 (which is the concatenation of a rotation Q1 followed by the rotation Q2)
 
@@ -181,60 +172,42 @@ inline XMVECTOR XM_CALLCONV XMQuaternionMultiply
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionLengthSq
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionLengthSq(FXMVECTOR Q) noexcept
 {
     return XMVector4LengthSq(Q);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionReciprocalLength
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionReciprocalLength(FXMVECTOR Q) noexcept
 {
     return XMVector4ReciprocalLength(Q);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionLength
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionLength(FXMVECTOR Q) noexcept
 {
     return XMVector4Length(Q);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionNormalizeEst
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionNormalizeEst(FXMVECTOR Q) noexcept
 {
     return XMVector4NormalizeEst(Q);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionNormalize
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionNormalize(FXMVECTOR Q) noexcept
 {
     return XMVector4Normalize(Q);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionConjugate
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionConjugate(FXMVECTOR Q) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -255,10 +228,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionConjugate
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionInverse
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionInverse(FXMVECTOR Q) noexcept
 {
     const XMVECTOR  Zero = XMVectorZero();
 
@@ -276,10 +246,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionInverse
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionLn
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionLn(FXMVECTOR Q) noexcept
 {
     static const XMVECTORF32 OneMinusEpsilon = { { { 1.0f - 0.00001f, 1.0f - 0.00001f, 1.0f - 0.00001f, 1.0f - 0.00001f } } };
 
@@ -301,10 +268,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionLn
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionExp
-(
-    FXMVECTOR Q
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionExp(FXMVECTOR Q) noexcept
 {
     XMVECTOR Theta = XMVector3Length(Q);
 
@@ -331,7 +295,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionSlerp
     FXMVECTOR Q0,
     FXMVECTOR Q1,
     float    t
-)
+) noexcept
 {
     XMVECTOR T = XMVectorReplicate(t);
     return XMQuaternionSlerpV(Q0, Q1, T);
@@ -344,7 +308,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionSlerpV
     FXMVECTOR Q0,
     FXMVECTOR Q1,
     FXMVECTOR T
-)
+) noexcept
 {
     assert((XMVectorGetY(T) == XMVectorGetX(T)) && (XMVectorGetZ(T) == XMVectorGetX(T)) && (XMVectorGetW(T) == XMVectorGetX(T)));
 
@@ -444,7 +408,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionSquad
     FXMVECTOR Q2,
     GXMVECTOR Q3,
     float    t
-)
+) noexcept
 {
     XMVECTOR T = XMVectorReplicate(t);
     return XMQuaternionSquadV(Q0, Q1, Q2, Q3, T);
@@ -459,7 +423,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionSquadV
     FXMVECTOR Q2,
     GXMVECTOR Q3,
     HXMVECTOR T
-)
+) noexcept
 {
     assert((XMVectorGetY(T) == XMVectorGetX(T)) && (XMVectorGetZ(T) == XMVectorGetX(T)) && (XMVectorGetW(T) == XMVectorGetX(T)));
 
@@ -488,7 +452,7 @@ inline void XM_CALLCONV XMQuaternionSquadSetup
     FXMVECTOR  Q1,
     FXMVECTOR  Q2,
     GXMVECTOR  Q3
-)
+) noexcept
 {
     assert(pA);
     assert(pB);
@@ -544,7 +508,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionBaryCentric
     FXMVECTOR Q2,
     float    f,
     float    g
-)
+) noexcept
 {
     float s = f + g;
 
@@ -573,7 +537,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionBaryCentricV
     FXMVECTOR Q2,
     GXMVECTOR F,
     HXMVECTOR G
-)
+) noexcept
 {
     assert((XMVectorGetY(F) == XMVectorGetX(F)) && (XMVectorGetZ(F) == XMVectorGetX(F)) && (XMVectorGetW(F) == XMVectorGetX(F)));
     assert((XMVectorGetY(G) == XMVectorGetX(G)) && (XMVectorGetZ(G) == XMVectorGetX(G)) && (XMVectorGetW(G) == XMVectorGetX(G)));
@@ -606,7 +570,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionBaryCentricV
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionIdentity()
+inline XMVECTOR XM_CALLCONV XMQuaternionIdentity() noexcept
 {
     return g_XMIdentityR3.v;
 }
@@ -618,7 +582,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionRotationRollPitchYaw
     float Pitch,
     float Yaw,
     float Roll
-)
+) noexcept
 {
     XMVECTOR Angles = XMVectorSet(Pitch, Yaw, Roll, 0.0f);
     XMVECTOR Q = XMQuaternionRotationRollPitchYawFromVector(Angles);
@@ -630,7 +594,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionRotationRollPitchYaw
 inline XMVECTOR XM_CALLCONV XMQuaternionRotationRollPitchYawFromVector
 (
     FXMVECTOR Angles // <Pitch, Yaw, Roll, 0>
-)
+) noexcept
 {
     static const XMVECTORF32  Sign = { { { 1.0f, -1.0f, -1.0f, 1.0f } } };
 
@@ -661,7 +625,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionRotationNormal
 (
     FXMVECTOR NormalAxis,
     float    Angle
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_) || defined(_XM_ARM_NEON_INTRINSICS_)
 
@@ -693,7 +657,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionRotationAxis
 (
     FXMVECTOR Axis,
     float    Angle
-)
+) noexcept
 {
     assert(!XMVector3Equal(Axis, XMVectorZero()));
     assert(!XMVector3IsInfinite(Axis));
@@ -705,10 +669,7 @@ inline XMVECTOR XM_CALLCONV XMQuaternionRotationAxis
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMQuaternionRotationMatrix
-(
-    FXMMATRIX M
-)
+inline XMVECTOR XM_CALLCONV XMQuaternionRotationMatrix(FXMMATRIX M) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -958,7 +919,7 @@ inline void XM_CALLCONV XMQuaternionToAxisAngle
     XMVECTOR* pAxis,
     float* pAngle,
     FXMVECTOR  Q
-)
+) noexcept
 {
     assert(pAxis);
     assert(pAngle);
@@ -984,7 +945,7 @@ inline bool XM_CALLCONV XMPlaneEqual
 (
     FXMVECTOR P1,
     FXMVECTOR P2
-)
+) noexcept
 {
     return XMVector4Equal(P1, P2);
 }
@@ -996,7 +957,7 @@ inline bool XM_CALLCONV XMPlaneNearEqual
     FXMVECTOR P1,
     FXMVECTOR P2,
     FXMVECTOR Epsilon
-)
+) noexcept
 {
     XMVECTOR NP1 = XMPlaneNormalize(P1);
     XMVECTOR NP2 = XMPlaneNormalize(P2);
@@ -1009,27 +970,21 @@ inline bool XM_CALLCONV XMPlaneNotEqual
 (
     FXMVECTOR P1,
     FXMVECTOR P2
-)
+) noexcept
 {
     return XMVector4NotEqual(P1, P2);
 }
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMPlaneIsNaN
-(
-    FXMVECTOR P
-)
+inline bool XM_CALLCONV XMPlaneIsNaN(FXMVECTOR P) noexcept
 {
     return XMVector4IsNaN(P);
 }
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMPlaneIsInfinite
-(
-    FXMVECTOR P
-)
+inline bool XM_CALLCONV XMPlaneIsInfinite(FXMVECTOR P) noexcept
 {
     return XMVector4IsInfinite(P);
 }
@@ -1044,7 +999,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneDot
 (
     FXMVECTOR P,
     FXMVECTOR V
-)
+) noexcept
 {
     return XMVector4Dot(P, V);
 }
@@ -1055,7 +1010,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneDotCoord
 (
     FXMVECTOR P,
     FXMVECTOR V
-)
+) noexcept
 {
     // Result = P[0] * V[0] + P[1] * V[1] + P[2] * V[2] + P[3]
 
@@ -1070,7 +1025,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneDotNormal
 (
     FXMVECTOR P,
     FXMVECTOR V
-)
+) noexcept
 {
     return XMVector3Dot(P, V);
 }
@@ -1079,10 +1034,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneDotNormal
 // XMPlaneNormalizeEst uses a reciprocal estimate and
 // returns QNaN on zero and infinite vectors.
 
-inline XMVECTOR XM_CALLCONV XMPlaneNormalizeEst
-(
-    FXMVECTOR P
-)
+inline XMVECTOR XM_CALLCONV XMPlaneNormalizeEst(FXMVECTOR P) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_) || defined(_XM_ARM_NEON_INTRINSICS_)
 
@@ -1116,10 +1068,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneNormalizeEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMPlaneNormalize
-(
-    FXMVECTOR P
-)
+inline XMVECTOR XM_CALLCONV XMPlaneNormalize(FXMVECTOR P) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float fLengthSq = sqrtf((P.vector4_f32[0] * P.vector4_f32[0]) + (P.vector4_f32[1] * P.vector4_f32[1]) + (P.vector4_f32[2] * P.vector4_f32[2]));
@@ -1178,7 +1127,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneIntersectLine
     FXMVECTOR P,
     FXMVECTOR LinePoint1,
     FXMVECTOR LinePoint2
-)
+) noexcept
 {
     XMVECTOR V1 = XMVector3Dot(P, LinePoint1);
     XMVECTOR V2 = XMVector3Dot(P, LinePoint2);
@@ -1204,7 +1153,7 @@ inline void XM_CALLCONV XMPlaneIntersectPlane
     XMVECTOR* pLinePoint2,
     FXMVECTOR  P1,
     FXMVECTOR  P2
-)
+) noexcept
 {
     assert(pLinePoint1);
     assert(pLinePoint2);
@@ -1238,7 +1187,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneTransform
 (
     FXMVECTOR P,
     FXMMATRIX M
-)
+) noexcept
 {
     XMVECTOR W = XMVectorSplatW(P);
     XMVECTOR Z = XMVectorSplatZ(P);
@@ -1262,7 +1211,7 @@ inline XMFLOAT4* XM_CALLCONV XMPlaneTransformStream
     size_t          InputStride,
     size_t          PlaneCount,
     FXMMATRIX       M
-)
+) noexcept
 {
     return XMVector4TransformStream(pOutputStream,
         OutputStride,
@@ -1282,7 +1231,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneFromPointNormal
 (
     FXMVECTOR Point,
     FXMVECTOR Normal
-)
+) noexcept
 {
     XMVECTOR W = XMVector3Dot(Point, Normal);
     W = XMVectorNegate(W);
@@ -1296,7 +1245,7 @@ inline XMVECTOR XM_CALLCONV XMPlaneFromPoints
     FXMVECTOR Point1,
     FXMVECTOR Point2,
     FXMVECTOR Point3
-)
+) noexcept
 {
     XMVECTOR V21 = XMVectorSubtract(Point1, Point2);
     XMVECTOR V31 = XMVectorSubtract(Point1, Point3);
@@ -1328,7 +1277,7 @@ inline bool XM_CALLCONV XMColorEqual
 (
     FXMVECTOR C1,
     FXMVECTOR C2
-)
+) noexcept
 {
     return XMVector4Equal(C1, C2);
 }
@@ -1339,7 +1288,7 @@ inline bool XM_CALLCONV XMColorNotEqual
 (
     FXMVECTOR C1,
     FXMVECTOR C2
-)
+) noexcept
 {
     return XMVector4NotEqual(C1, C2);
 }
@@ -1350,7 +1299,7 @@ inline bool XM_CALLCONV XMColorGreater
 (
     FXMVECTOR C1,
     FXMVECTOR C2
-)
+) noexcept
 {
     return XMVector4Greater(C1, C2);
 }
@@ -1361,7 +1310,7 @@ inline bool XM_CALLCONV XMColorGreaterOrEqual
 (
     FXMVECTOR C1,
     FXMVECTOR C2
-)
+) noexcept
 {
     return XMVector4GreaterOrEqual(C1, C2);
 }
@@ -1372,7 +1321,7 @@ inline bool XM_CALLCONV XMColorLess
 (
     FXMVECTOR C1,
     FXMVECTOR C2
-)
+) noexcept
 {
     return XMVector4Less(C1, C2);
 }
@@ -1383,27 +1332,21 @@ inline bool XM_CALLCONV XMColorLessOrEqual
 (
     FXMVECTOR C1,
     FXMVECTOR C2
-)
+) noexcept
 {
     return XMVector4LessOrEqual(C1, C2);
 }
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMColorIsNaN
-(
-    FXMVECTOR C
-)
+inline bool XM_CALLCONV XMColorIsNaN(FXMVECTOR C) noexcept
 {
     return XMVector4IsNaN(C);
 }
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMColorIsInfinite
-(
-    FXMVECTOR C
-)
+inline bool XM_CALLCONV XMColorIsInfinite(FXMVECTOR C) noexcept
 {
     return XMVector4IsInfinite(C);
 }
@@ -1414,10 +1357,7 @@ inline bool XM_CALLCONV XMColorIsInfinite
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorNegative
-(
-    FXMVECTOR vColor
-)
+inline XMVECTOR XM_CALLCONV XMColorNegative(FXMVECTOR vColor) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult = { { {
@@ -1444,7 +1384,7 @@ inline XMVECTOR XM_CALLCONV XMColorModulate
 (
     FXMVECTOR C1,
     FXMVECTOR C2
-)
+) noexcept
 {
     return XMVectorMultiply(C1, C2);
 }
@@ -1455,7 +1395,7 @@ inline XMVECTOR XM_CALLCONV XMColorAdjustSaturation
 (
     FXMVECTOR vColor,
     float    fSaturation
-)
+) noexcept
 {
     // Luminance = 0.2125f * C[0] + 0.7154f * C[1] + 0.0721f * C[2];
     // Result = (C - Luminance) * Saturation + Luminance;
@@ -1495,7 +1435,7 @@ inline XMVECTOR XM_CALLCONV XMColorAdjustContrast
 (
     FXMVECTOR vColor,
     float    fContrast
-)
+) noexcept
 {
     // Result = (vColor - 0.5f) * fContrast + 0.5f;
 
@@ -1525,7 +1465,7 @@ inline XMVECTOR XM_CALLCONV XMColorAdjustContrast
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorRGBToHSL(FXMVECTOR rgb)
+inline XMVECTOR XM_CALLCONV XMColorRGBToHSL(FXMVECTOR rgb) noexcept
 {
     XMVECTOR r = XMVectorSplatX(rgb);
     XMVECTOR g = XMVectorSplatY(rgb);
@@ -1595,7 +1535,7 @@ inline XMVECTOR XM_CALLCONV XMColorRGBToHSL(FXMVECTOR rgb)
 namespace Internal
 {
 
-    inline XMVECTOR XM_CALLCONV XMColorHue2Clr(FXMVECTOR p, FXMVECTOR q, FXMVECTOR h)
+    inline XMVECTOR XM_CALLCONV XMColorHue2Clr(FXMVECTOR p, FXMVECTOR q, FXMVECTOR h) noexcept
     {
         static const XMVECTORF32 oneSixth = { { { 1.0f / 6.0f, 1.0f / 6.0f, 1.0f / 6.0f, 1.0f / 6.0f } } };
         static const XMVECTORF32 twoThirds = { { { 2.0f / 3.0f, 2.0f / 3.0f, 2.0f / 3.0f, 2.0f / 3.0f } } };
@@ -1632,7 +1572,7 @@ namespace Internal
 
 } // namespace Internal
 
-inline XMVECTOR XM_CALLCONV XMColorHSLToRGB(FXMVECTOR hsl)
+inline XMVECTOR XM_CALLCONV XMColorHSLToRGB(FXMVECTOR hsl) noexcept
 {
     static const XMVECTORF32 oneThird = { { { 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f } } };
 
@@ -1673,7 +1613,7 @@ inline XMVECTOR XM_CALLCONV XMColorHSLToRGB(FXMVECTOR hsl)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorRGBToHSV(FXMVECTOR rgb)
+inline XMVECTOR XM_CALLCONV XMColorRGBToHSV(FXMVECTOR rgb) noexcept
 {
     XMVECTOR r = XMVectorSplatX(rgb);
     XMVECTOR g = XMVectorSplatY(rgb);
@@ -1728,7 +1668,7 @@ inline XMVECTOR XM_CALLCONV XMColorRGBToHSV(FXMVECTOR rgb)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorHSVToRGB(FXMVECTOR hsv)
+inline XMVECTOR XM_CALLCONV XMColorHSVToRGB(FXMVECTOR hsv) noexcept
 {
     XMVECTOR h = XMVectorSplatX(hsv);
     XMVECTOR s = XMVectorSplatY(hsv);
@@ -1797,7 +1737,7 @@ inline XMVECTOR XM_CALLCONV XMColorHSVToRGB(FXMVECTOR hsv)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorRGBToYUV(FXMVECTOR rgb)
+inline XMVECTOR XM_CALLCONV XMColorRGBToYUV(FXMVECTOR rgb) noexcept
 {
     static const XMVECTORF32 Scale0 = { { { 0.299f, -0.147f, 0.615f, 0.0f } } };
     static const XMVECTORF32 Scale1 = { { { 0.587f, -0.289f, -0.515f, 0.0f } } };
@@ -1811,7 +1751,7 @@ inline XMVECTOR XM_CALLCONV XMColorRGBToYUV(FXMVECTOR rgb)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorYUVToRGB(FXMVECTOR yuv)
+inline XMVECTOR XM_CALLCONV XMColorYUVToRGB(FXMVECTOR yuv) noexcept
 {
     static const XMVECTORF32 Scale1 = { { { 0.0f, -0.395f, 2.032f, 0.0f } } };
     static const XMVECTORF32 Scale2 = { { { 1.140f, -0.581f, 0.0f, 0.0f } } };
@@ -1824,7 +1764,7 @@ inline XMVECTOR XM_CALLCONV XMColorYUVToRGB(FXMVECTOR yuv)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorRGBToYUV_HD(FXMVECTOR rgb)
+inline XMVECTOR XM_CALLCONV XMColorRGBToYUV_HD(FXMVECTOR rgb) noexcept
 {
     static const XMVECTORF32 Scale0 = { { { 0.2126f, -0.0997f, 0.6150f, 0.0f } } };
     static const XMVECTORF32 Scale1 = { { { 0.7152f, -0.3354f, -0.5586f, 0.0f } } };
@@ -1838,7 +1778,7 @@ inline XMVECTOR XM_CALLCONV XMColorRGBToYUV_HD(FXMVECTOR rgb)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorYUVToRGB_HD(FXMVECTOR yuv)
+inline XMVECTOR XM_CALLCONV XMColorYUVToRGB_HD(FXMVECTOR yuv) noexcept
 {
     static const XMVECTORF32 Scale1 = { { { 0.0f, -0.2153f, 2.1324f, 0.0f } } };
     static const XMVECTORF32 Scale2 = { { { 1.2803f, -0.3806f, 0.0f, 0.0f } } };
@@ -1851,7 +1791,7 @@ inline XMVECTOR XM_CALLCONV XMColorYUVToRGB_HD(FXMVECTOR yuv)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorRGBToXYZ(FXMVECTOR rgb)
+inline XMVECTOR XM_CALLCONV XMColorRGBToXYZ(FXMVECTOR rgb) noexcept
 {
     static const XMVECTORF32 Scale0 = { { { 0.4887180f, 0.1762044f, 0.0000000f, 0.0f } } };
     static const XMVECTORF32 Scale1 = { { { 0.3106803f, 0.8129847f, 0.0102048f, 0.0f } } };
@@ -1864,7 +1804,7 @@ inline XMVECTOR XM_CALLCONV XMColorRGBToXYZ(FXMVECTOR rgb)
     return XMVectorSelect(rgb, clr, g_XMSelect1110);
 }
 
-inline XMVECTOR XM_CALLCONV XMColorXYZToRGB(FXMVECTOR xyz)
+inline XMVECTOR XM_CALLCONV XMColorXYZToRGB(FXMVECTOR xyz) noexcept
 {
     static const XMVECTORF32 Scale0 = { { { 2.3706743f, -0.5138850f, 0.0052982f, 0.0f } } };
     static const XMVECTORF32 Scale1 = { { { -0.9000405f, 1.4253036f, -0.0146949f, 0.0f } } };
@@ -1879,7 +1819,7 @@ inline XMVECTOR XM_CALLCONV XMColorXYZToRGB(FXMVECTOR xyz)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorXYZToSRGB(FXMVECTOR xyz)
+inline XMVECTOR XM_CALLCONV XMColorXYZToSRGB(FXMVECTOR xyz) noexcept
 {
     static const XMVECTORF32 Scale0 = { { { 3.2406f, -0.9689f, 0.0557f, 0.0f } } };
     static const XMVECTORF32 Scale1 = { { { -1.5372f, 1.8758f, -0.2040f, 0.0f } } };
@@ -1905,7 +1845,7 @@ inline XMVECTOR XM_CALLCONV XMColorXYZToSRGB(FXMVECTOR xyz)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorSRGBToXYZ(FXMVECTOR srgb)
+inline XMVECTOR XM_CALLCONV XMColorSRGBToXYZ(FXMVECTOR srgb) noexcept
 {
     static const XMVECTORF32 Scale0 = { { { 0.4124f, 0.2126f, 0.0193f, 0.0f } } };
     static const XMVECTORF32 Scale1 = { { { 0.3576f, 0.7152f, 0.1192f, 0.0f } } };
@@ -1931,7 +1871,7 @@ inline XMVECTOR XM_CALLCONV XMColorSRGBToXYZ(FXMVECTOR srgb)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorRGBToSRGB(FXMVECTOR rgb)
+inline XMVECTOR XM_CALLCONV XMColorRGBToSRGB(FXMVECTOR rgb) noexcept
 {
     static const XMVECTORF32 Cutoff = { { { 0.0031308f, 0.0031308f, 0.0031308f, 1.f } } };
     static const XMVECTORF32 Linear = { { { 12.92f, 12.92f, 12.92f, 1.f } } };
@@ -1949,7 +1889,7 @@ inline XMVECTOR XM_CALLCONV XMColorRGBToSRGB(FXMVECTOR rgb)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMColorSRGBToRGB(FXMVECTOR srgb)
+inline XMVECTOR XM_CALLCONV XMColorSRGBToRGB(FXMVECTOR srgb) noexcept
 {
     static const XMVECTORF32 Cutoff = { { { 0.04045f, 0.04045f, 0.04045f, 1.f } } };
     static const XMVECTORF32 ILinear = { { { 1.f / 12.92f, 1.f / 12.92f, 1.f / 12.92f, 1.f } } };
@@ -1973,7 +1913,7 @@ inline XMVECTOR XM_CALLCONV XMColorSRGBToRGB(FXMVECTOR srgb)
 
  //------------------------------------------------------------------------------
 
-inline bool XMVerifyCPUSupport()
+inline bool XMVerifyCPUSupport() noexcept
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     int CPUInfo[4] = { -1 };
@@ -2051,7 +1991,7 @@ inline XMVECTOR XM_CALLCONV XMFresnelTerm
 (
     FXMVECTOR CosIncidentAngle,
     FXMVECTOR RefractionIndex
-)
+) noexcept
 {
     assert(!XMVector4IsInfinite(CosIncidentAngle));
 
@@ -2135,7 +2075,7 @@ inline bool XMScalarNearEqual
     float S1,
     float S2,
     float Epsilon
-)
+) noexcept
 {
     float Delta = S1 - S2;
     return (fabsf(Delta) <= Epsilon);
@@ -2143,10 +2083,7 @@ inline bool XMScalarNearEqual
 
 //------------------------------------------------------------------------------
 // Modulo the range of the given angle such that -XM_PI <= Angle < XM_PI
-inline float XMScalarModAngle
-(
-    float Angle
-)
+inline float XMScalarModAngle(float Angle) noexcept
 {
     // Note: The modulo is performed with unsigned math only to work
     // around a precision error on numbers that are close to PI
@@ -2168,10 +2105,7 @@ inline float XMScalarModAngle
 
 //------------------------------------------------------------------------------
 
-inline float XMScalarSin
-(
-    float Value
-)
+inline float XMScalarSin(float Value) noexcept
 {
     // Map Value to y in [-pi,pi], x = 2*pi*quotient + remainder.
     float quotient = XM_1DIV2PI * Value;
@@ -2202,10 +2136,7 @@ inline float XMScalarSin
 
 //------------------------------------------------------------------------------
 
-inline float XMScalarSinEst
-(
-    float Value
-)
+inline float XMScalarSinEst(float Value) noexcept
 {
     // Map Value to y in [-pi,pi], x = 2*pi*quotient + remainder.
     float quotient = XM_1DIV2PI * Value;
@@ -2236,10 +2167,7 @@ inline float XMScalarSinEst
 
 //------------------------------------------------------------------------------
 
-inline float XMScalarCos
-(
-    float Value
-)
+inline float XMScalarCos(float Value) noexcept
 {
     // Map Value to y in [-pi,pi], x = 2*pi*quotient + remainder.
     float quotient = XM_1DIV2PI * Value;
@@ -2278,10 +2206,7 @@ inline float XMScalarCos
 
 //------------------------------------------------------------------------------
 
-inline float XMScalarCosEst
-(
-    float Value
-)
+inline float XMScalarCosEst(float Value) noexcept
 {
     // Map Value to y in [-pi,pi], x = 2*pi*quotient + remainder.
     float quotient = XM_1DIV2PI * Value;
@@ -2326,7 +2251,7 @@ inline void XMScalarSinCos
     float* pSin,
     float* pCos,
     float  Value
-)
+) noexcept
 {
     assert(pSin);
     assert(pCos);
@@ -2378,7 +2303,7 @@ inline void XMScalarSinCosEst
     float* pSin,
     float* pCos,
     float  Value
-)
+) noexcept
 {
     assert(pSin);
     assert(pCos);
@@ -2424,10 +2349,7 @@ inline void XMScalarSinCosEst
 
 //------------------------------------------------------------------------------
 
-inline float XMScalarASin
-(
-    float Value
-)
+inline float XMScalarASin(float Value) noexcept
 {
     // Clamp input to [-1,1].
     bool nonnegative = (Value >= 0.0f);
@@ -2449,10 +2371,7 @@ inline float XMScalarASin
 
 //------------------------------------------------------------------------------
 
-inline float XMScalarASinEst
-(
-    float Value
-)
+inline float XMScalarASinEst(float Value) noexcept
 {
     // Clamp input to [-1,1].
     bool nonnegative = (Value >= 0.0f);
@@ -2474,10 +2393,7 @@ inline float XMScalarASinEst
 
 //------------------------------------------------------------------------------
 
-inline float XMScalarACos
-(
-    float Value
-)
+inline float XMScalarACos(float Value) noexcept
 {
     // Clamp input to [-1,1].
     bool nonnegative = (Value >= 0.0f);
@@ -2499,10 +2415,7 @@ inline float XMScalarACos
 
 //------------------------------------------------------------------------------
 
-inline float XMScalarACosEst
-(
-    float Value
-)
+inline float XMScalarACosEst(float Value) noexcept
 {
     // Clamp input to [-1,1].
     bool nonnegative = (Value >= 0.0f);
@@ -2521,4 +2434,3 @@ inline float XMScalarACosEst
     // acos(x) = pi - acos(-x) when x < 0
     return (nonnegative ? result : XM_PI - result);
 }
-

--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -43,7 +43,7 @@
 
  //------------------------------------------------------------------------------
  // Return a vector with all elements equaling zero
-inline XMVECTOR XM_CALLCONV XMVectorZero()
+inline XMVECTOR XM_CALLCONV XMVectorZero() noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult = { { { 0.0f, 0.0f, 0.0f, 0.0f } } };
@@ -63,7 +63,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSet
     float y,
     float z,
     float w
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult = { { { x, y, z, w } } };
@@ -89,7 +89,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetInt
     uint32_t y,
     uint32_t z,
     uint32_t w
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 vResult = { { { x, y, z, w } } };
@@ -106,10 +106,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetInt
 
 //------------------------------------------------------------------------------
 // Initialize a vector with a replicated floating point value
-inline XMVECTOR XM_CALLCONV XMVectorReplicate
-(
-    float Value
-)
+inline XMVECTOR XM_CALLCONV XMVectorReplicate(float Value) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult;
@@ -128,10 +125,7 @@ inline XMVECTOR XM_CALLCONV XMVectorReplicate
 //------------------------------------------------------------------------------
 // Initialize a vector with a replicated floating point value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorReplicatePtr
-(
-    const float* pValue
-)
+inline XMVECTOR XM_CALLCONV XMVectorReplicatePtr(const float* pValue) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float Value = pValue[0];
@@ -152,10 +146,7 @@ inline XMVECTOR XM_CALLCONV XMVectorReplicatePtr
 
 //------------------------------------------------------------------------------
 // Initialize a vector with a replicated integer value
-inline XMVECTOR XM_CALLCONV XMVectorReplicateInt
-(
-    uint32_t Value
-)
+inline XMVECTOR XM_CALLCONV XMVectorReplicateInt(uint32_t Value) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 vResult;
@@ -175,10 +166,7 @@ inline XMVECTOR XM_CALLCONV XMVectorReplicateInt
 //------------------------------------------------------------------------------
 // Initialize a vector with a replicated integer value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorReplicateIntPtr
-(
-    const uint32_t* pValue
-)
+inline XMVECTOR XM_CALLCONV XMVectorReplicateIntPtr(const uint32_t* pValue) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     uint32_t Value = pValue[0];
@@ -197,7 +185,7 @@ inline XMVECTOR XM_CALLCONV XMVectorReplicateIntPtr
 
 //------------------------------------------------------------------------------
 // Initialize a vector with all bits set (true mask)
-inline XMVECTOR XM_CALLCONV XMVectorTrueInt()
+inline XMVECTOR XM_CALLCONV XMVectorTrueInt() noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 vResult = { { { 0xFFFFFFFFU, 0xFFFFFFFFU, 0xFFFFFFFFU, 0xFFFFFFFFU } } };
@@ -212,7 +200,7 @@ inline XMVECTOR XM_CALLCONV XMVectorTrueInt()
 
 //------------------------------------------------------------------------------
 // Initialize a vector with all bits clear (false mask)
-inline XMVECTOR XM_CALLCONV XMVectorFalseInt()
+inline XMVECTOR XM_CALLCONV XMVectorFalseInt() noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult = { { { 0.0f, 0.0f, 0.0f, 0.0f } } };
@@ -226,10 +214,7 @@ inline XMVECTOR XM_CALLCONV XMVectorFalseInt()
 
 //------------------------------------------------------------------------------
 // Replicate the x component of the vector
-inline XMVECTOR XM_CALLCONV XMVectorSplatX
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSplatX(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult;
@@ -249,10 +234,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatX
 
 //------------------------------------------------------------------------------
 // Replicate the y component of the vector
-inline XMVECTOR XM_CALLCONV XMVectorSplatY
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSplatY(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult;
@@ -270,10 +252,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatY
 
 //------------------------------------------------------------------------------
 // Replicate the z component of the vector
-inline XMVECTOR XM_CALLCONV XMVectorSplatZ
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSplatZ(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult;
@@ -291,10 +270,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatZ
 
 //------------------------------------------------------------------------------
 // Replicate the w component of the vector
-inline XMVECTOR XM_CALLCONV XMVectorSplatW
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSplatW(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult;
@@ -312,7 +288,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatW
 
 //------------------------------------------------------------------------------
 // Return a vector of 1.0f,1.0f,1.0f,1.0f
-inline XMVECTOR XM_CALLCONV XMVectorSplatOne()
+inline XMVECTOR XM_CALLCONV XMVectorSplatOne() noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult;
@@ -330,7 +306,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatOne()
 
 //------------------------------------------------------------------------------
 // Return a vector of INF,INF,INF,INF
-inline XMVECTOR XM_CALLCONV XMVectorSplatInfinity()
+inline XMVECTOR XM_CALLCONV XMVectorSplatInfinity() noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 vResult;
@@ -348,7 +324,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatInfinity()
 
 //------------------------------------------------------------------------------
 // Return a vector of Q_NAN,Q_NAN,Q_NAN,Q_NAN
-inline XMVECTOR XM_CALLCONV XMVectorSplatQNaN()
+inline XMVECTOR XM_CALLCONV XMVectorSplatQNaN() noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 vResult;
@@ -366,7 +342,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatQNaN()
 
 //------------------------------------------------------------------------------
 // Return a vector of 1.192092896e-7f,1.192092896e-7f,1.192092896e-7f,1.192092896e-7f
-inline XMVECTOR XM_CALLCONV XMVectorSplatEpsilon()
+inline XMVECTOR XM_CALLCONV XMVectorSplatEpsilon() noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 vResult;
@@ -384,7 +360,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatEpsilon()
 
 //------------------------------------------------------------------------------
 // Return a vector of -0.0f (0x80000000),-0.0f,-0.0f,-0.0f
-inline XMVECTOR XM_CALLCONV XMVectorSplatSignMask()
+inline XMVECTOR XM_CALLCONV XMVectorSplatSignMask() noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 vResult;
@@ -404,7 +380,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSplatSignMask()
 //------------------------------------------------------------------------------
 // Return a floating point value via an index. This is not a recommended
 // function to use due to performance loss.
-inline float XM_CALLCONV XMVectorGetByIndex(FXMVECTOR V, size_t i)
+inline float XM_CALLCONV XMVectorGetByIndex(FXMVECTOR V, size_t i) noexcept
 {
     assert(i < 4);
     _Analysis_assume_(i < 4);
@@ -419,7 +395,7 @@ inline float XM_CALLCONV XMVectorGetByIndex(FXMVECTOR V, size_t i)
 
 //------------------------------------------------------------------------------
 // Return the X component in an FPU register.
-inline float XM_CALLCONV XMVectorGetX(FXMVECTOR V)
+inline float XM_CALLCONV XMVectorGetX(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return V.vector4_f32[0];
@@ -431,7 +407,7 @@ inline float XM_CALLCONV XMVectorGetX(FXMVECTOR V)
 }
 
 // Return the Y component in an FPU register.
-inline float XM_CALLCONV XMVectorGetY(FXMVECTOR V)
+inline float XM_CALLCONV XMVectorGetY(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return V.vector4_f32[1];
@@ -444,7 +420,7 @@ inline float XM_CALLCONV XMVectorGetY(FXMVECTOR V)
 }
 
 // Return the Z component in an FPU register.
-inline float XM_CALLCONV XMVectorGetZ(FXMVECTOR V)
+inline float XM_CALLCONV XMVectorGetZ(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return V.vector4_f32[2];
@@ -457,7 +433,7 @@ inline float XM_CALLCONV XMVectorGetZ(FXMVECTOR V)
 }
 
 // Return the W component in an FPU register.
-inline float XM_CALLCONV XMVectorGetW(FXMVECTOR V)
+inline float XM_CALLCONV XMVectorGetW(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return V.vector4_f32[3];
@@ -473,7 +449,7 @@ inline float XM_CALLCONV XMVectorGetW(FXMVECTOR V)
 
 // Store a component indexed by i into a 32 bit float location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetByIndexPtr(float* f, FXMVECTOR V, size_t i)
+inline void XM_CALLCONV XMVectorGetByIndexPtr(float* f, FXMVECTOR V, size_t i) noexcept
 {
     assert(f != nullptr);
     assert(i < 4);
@@ -491,7 +467,7 @@ inline void XM_CALLCONV XMVectorGetByIndexPtr(float* f, FXMVECTOR V, size_t i)
 
 // Store the X component into a 32 bit float location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetXPtr(float* x, FXMVECTOR V)
+inline void XM_CALLCONV XMVectorGetXPtr(float* x, FXMVECTOR V) noexcept
 {
     assert(x != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -505,7 +481,7 @@ inline void XM_CALLCONV XMVectorGetXPtr(float* x, FXMVECTOR V)
 
 // Store the Y component into a 32 bit float location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetYPtr(float* y, FXMVECTOR V)
+inline void XM_CALLCONV XMVectorGetYPtr(float* y, FXMVECTOR V) noexcept
 {
     assert(y != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -522,7 +498,7 @@ inline void XM_CALLCONV XMVectorGetYPtr(float* y, FXMVECTOR V)
 
 // Store the Z component into a 32 bit float location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetZPtr(float* z, FXMVECTOR V)
+inline void XM_CALLCONV XMVectorGetZPtr(float* z, FXMVECTOR V) noexcept
 {
     assert(z != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -539,7 +515,7 @@ inline void XM_CALLCONV XMVectorGetZPtr(float* z, FXMVECTOR V)
 
 // Store the W component into a 32 bit float location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetWPtr(float* w, FXMVECTOR V)
+inline void XM_CALLCONV XMVectorGetWPtr(float* w, FXMVECTOR V) noexcept
 {
     assert(w != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -558,7 +534,7 @@ inline void XM_CALLCONV XMVectorGetWPtr(float* w, FXMVECTOR V)
 
 // Return an integer value via an index. This is not a recommended
 // function to use due to performance loss.
-inline uint32_t XM_CALLCONV XMVectorGetIntByIndex(FXMVECTOR V, size_t i)
+inline uint32_t XM_CALLCONV XMVectorGetIntByIndex(FXMVECTOR V, size_t i) noexcept
 {
     assert(i < 4);
     _Analysis_assume_(i < 4);
@@ -574,7 +550,7 @@ inline uint32_t XM_CALLCONV XMVectorGetIntByIndex(FXMVECTOR V, size_t i)
 //------------------------------------------------------------------------------
 
 // Return the X component in an integer register.
-inline uint32_t XM_CALLCONV XMVectorGetIntX(FXMVECTOR V)
+inline uint32_t XM_CALLCONV XMVectorGetIntX(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return V.vector4_u32[0];
@@ -586,7 +562,7 @@ inline uint32_t XM_CALLCONV XMVectorGetIntX(FXMVECTOR V)
 }
 
 // Return the Y component in an integer register.
-inline uint32_t XM_CALLCONV XMVectorGetIntY(FXMVECTOR V)
+inline uint32_t XM_CALLCONV XMVectorGetIntY(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return V.vector4_u32[1];
@@ -602,7 +578,7 @@ inline uint32_t XM_CALLCONV XMVectorGetIntY(FXMVECTOR V)
 }
 
 // Return the Z component in an integer register.
-inline uint32_t XM_CALLCONV XMVectorGetIntZ(FXMVECTOR V)
+inline uint32_t XM_CALLCONV XMVectorGetIntZ(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return V.vector4_u32[2];
@@ -618,7 +594,7 @@ inline uint32_t XM_CALLCONV XMVectorGetIntZ(FXMVECTOR V)
 }
 
 // Return the W component in an integer register.
-inline uint32_t XM_CALLCONV XMVectorGetIntW(FXMVECTOR V)
+inline uint32_t XM_CALLCONV XMVectorGetIntW(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return V.vector4_u32[3];
@@ -637,7 +613,7 @@ inline uint32_t XM_CALLCONV XMVectorGetIntW(FXMVECTOR V)
 
 // Store a component indexed by i into a 32 bit integer location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetIntByIndexPtr(uint32_t* x, FXMVECTOR V, size_t i)
+inline void XM_CALLCONV XMVectorGetIntByIndexPtr(uint32_t* x, FXMVECTOR V, size_t i) noexcept
 {
     assert(x != nullptr);
     assert(i < 4);
@@ -655,7 +631,7 @@ inline void XM_CALLCONV XMVectorGetIntByIndexPtr(uint32_t* x, FXMVECTOR V, size_
 
 // Store the X component into a 32 bit integer location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetIntXPtr(uint32_t* x, FXMVECTOR V)
+inline void XM_CALLCONV XMVectorGetIntXPtr(uint32_t* x, FXMVECTOR V) noexcept
 {
     assert(x != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -669,7 +645,7 @@ inline void XM_CALLCONV XMVectorGetIntXPtr(uint32_t* x, FXMVECTOR V)
 
 // Store the Y component into a 32 bit integer location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetIntYPtr(uint32_t* y, FXMVECTOR V)
+inline void XM_CALLCONV XMVectorGetIntYPtr(uint32_t* y, FXMVECTOR V) noexcept
 {
     assert(y != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -687,7 +663,7 @@ inline void XM_CALLCONV XMVectorGetIntYPtr(uint32_t* y, FXMVECTOR V)
 
 // Store the Z component into a 32 bit integer locaCantion in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetIntZPtr(uint32_t* z, FXMVECTOR V)
+inline void XM_CALLCONV XMVectorGetIntZPtr(uint32_t* z, FXMVECTOR V) noexcept
 {
     assert(z != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -705,7 +681,7 @@ inline void XM_CALLCONV XMVectorGetIntZPtr(uint32_t* z, FXMVECTOR V)
 
 // Store the W component into a 32 bit integer location in memory.
 _Use_decl_annotations_
-inline void XM_CALLCONV XMVectorGetIntWPtr(uint32_t* w, FXMVECTOR V)
+inline void XM_CALLCONV XMVectorGetIntWPtr(uint32_t* w, FXMVECTOR V) noexcept
 {
     assert(w != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -724,7 +700,7 @@ inline void XM_CALLCONV XMVectorGetIntWPtr(uint32_t* w, FXMVECTOR V)
 //------------------------------------------------------------------------------
 
 // Set a single indexed floating point component
-inline XMVECTOR XM_CALLCONV XMVectorSetByIndex(FXMVECTOR V, float f, size_t i)
+inline XMVECTOR XM_CALLCONV XMVectorSetByIndex(FXMVECTOR V, float f, size_t i) noexcept
 {
     assert(i < 4);
     _Analysis_assume_(i < 4);
@@ -737,7 +713,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetByIndex(FXMVECTOR V, float f, size_t i)
 //------------------------------------------------------------------------------
 
 // Sets the X component of a vector to a passed floating point value
-inline XMVECTOR XM_CALLCONV XMVectorSetX(FXMVECTOR V, float x)
+inline XMVECTOR XM_CALLCONV XMVectorSetX(FXMVECTOR V, float x) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 U = { { {
@@ -757,7 +733,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetX(FXMVECTOR V, float x)
 }
 
 // Sets the Y component of a vector to a passed floating point value
-inline XMVECTOR XM_CALLCONV XMVectorSetY(FXMVECTOR V, float y)
+inline XMVECTOR XM_CALLCONV XMVectorSetY(FXMVECTOR V, float y) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 U = { { {
@@ -786,7 +762,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetY(FXMVECTOR V, float y)
 #endif
 }
 // Sets the Z component of a vector to a passed floating point value
-inline XMVECTOR XM_CALLCONV XMVectorSetZ(FXMVECTOR V, float z)
+inline XMVECTOR XM_CALLCONV XMVectorSetZ(FXMVECTOR V, float z) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 U = { { {
@@ -816,7 +792,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetZ(FXMVECTOR V, float z)
 }
 
 // Sets the W component of a vector to a passed floating point value
-inline XMVECTOR XM_CALLCONV XMVectorSetW(FXMVECTOR V, float w)
+inline XMVECTOR XM_CALLCONV XMVectorSetW(FXMVECTOR V, float w) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 U = { { {
@@ -849,7 +825,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetW(FXMVECTOR V, float w)
 
 // Sets a component of a vector to a floating point value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetByIndexPtr(FXMVECTOR V, const float* f, size_t i)
+inline XMVECTOR XM_CALLCONV XMVectorSetByIndexPtr(FXMVECTOR V, const float* f, size_t i) noexcept
 {
     assert(f != nullptr);
     assert(i < 4);
@@ -864,7 +840,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetByIndexPtr(FXMVECTOR V, const float* f, s
 
 // Sets the X component of a vector to a floating point value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetXPtr(FXMVECTOR V, const float* x)
+inline XMVECTOR XM_CALLCONV XMVectorSetXPtr(FXMVECTOR V, const float* x) noexcept
 {
     assert(x != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -886,7 +862,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetXPtr(FXMVECTOR V, const float* x)
 
 // Sets the Y component of a vector to a floating point value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetYPtr(FXMVECTOR V, const float* y)
+inline XMVECTOR XM_CALLCONV XMVectorSetYPtr(FXMVECTOR V, const float* y) noexcept
 {
     assert(y != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -914,7 +890,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetYPtr(FXMVECTOR V, const float* y)
 
 // Sets the Z component of a vector to a floating point value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetZPtr(FXMVECTOR V, const float* z)
+inline XMVECTOR XM_CALLCONV XMVectorSetZPtr(FXMVECTOR V, const float* z) noexcept
 {
     assert(z != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -942,7 +918,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetZPtr(FXMVECTOR V, const float* z)
 
 // Sets the W component of a vector to a floating point value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetWPtr(FXMVECTOR V, const float* w)
+inline XMVECTOR XM_CALLCONV XMVectorSetWPtr(FXMVECTOR V, const float* w) noexcept
 {
     assert(w != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -971,7 +947,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetWPtr(FXMVECTOR V, const float* w)
 //------------------------------------------------------------------------------
 
 // Sets a component of a vector to an integer passed by value
-inline XMVECTOR XM_CALLCONV XMVectorSetIntByIndex(FXMVECTOR V, uint32_t x, size_t i)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntByIndex(FXMVECTOR V, uint32_t x, size_t i) noexcept
 {
     assert(i < 4);
     _Analysis_assume_(i < 4);
@@ -984,7 +960,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntByIndex(FXMVECTOR V, uint32_t x, size_
 //------------------------------------------------------------------------------
 
 // Sets the X component of a vector to an integer passed by value
-inline XMVECTOR XM_CALLCONV XMVectorSetIntX(FXMVECTOR V, uint32_t x)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntX(FXMVECTOR V, uint32_t x) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 U = { { {
@@ -1004,7 +980,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntX(FXMVECTOR V, uint32_t x)
 }
 
 // Sets the Y component of a vector to an integer passed by value
-inline XMVECTOR XM_CALLCONV XMVectorSetIntY(FXMVECTOR V, uint32_t y)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntY(FXMVECTOR V, uint32_t y) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 U = { { {
@@ -1034,7 +1010,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntY(FXMVECTOR V, uint32_t y)
 }
 
 // Sets the Z component of a vector to an integer passed by value
-inline XMVECTOR XM_CALLCONV XMVectorSetIntZ(FXMVECTOR V, uint32_t z)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntZ(FXMVECTOR V, uint32_t z) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 U = { { {
@@ -1064,7 +1040,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntZ(FXMVECTOR V, uint32_t z)
 }
 
 // Sets the W component of a vector to an integer passed by value
-inline XMVECTOR XM_CALLCONV XMVectorSetIntW(FXMVECTOR V, uint32_t w)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntW(FXMVECTOR V, uint32_t w) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORU32 U = { { {
@@ -1097,7 +1073,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntW(FXMVECTOR V, uint32_t w)
 
 // Sets a component of a vector to an integer value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetIntByIndexPtr(FXMVECTOR V, const uint32_t* x, size_t i)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntByIndexPtr(FXMVECTOR V, const uint32_t* x, size_t i) noexcept
 {
     assert(x != nullptr);
     assert(i < 4);
@@ -1112,7 +1088,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntByIndexPtr(FXMVECTOR V, const uint32_t
 
 // Sets the X component of a vector to an integer value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetIntXPtr(FXMVECTOR V, const uint32_t* x)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntXPtr(FXMVECTOR V, const uint32_t* x) noexcept
 {
     assert(x != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1134,7 +1110,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntXPtr(FXMVECTOR V, const uint32_t* x)
 
 // Sets the Y component of a vector to an integer value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetIntYPtr(FXMVECTOR V, const uint32_t* y)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntYPtr(FXMVECTOR V, const uint32_t* y) noexcept
 {
     assert(y != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1162,7 +1138,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntYPtr(FXMVECTOR V, const uint32_t* y)
 
 // Sets the Z component of a vector to an integer value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetIntZPtr(FXMVECTOR V, const uint32_t* z)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntZPtr(FXMVECTOR V, const uint32_t* z) noexcept
 {
     assert(z != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1190,7 +1166,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSetIntZPtr(FXMVECTOR V, const uint32_t* z)
 
 // Sets the W component of a vector to an integer value passed by pointer
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMVectorSetIntWPtr(FXMVECTOR V, const uint32_t* w)
+inline XMVECTOR XM_CALLCONV XMVectorSetIntWPtr(FXMVECTOR V, const uint32_t* w) noexcept
 {
     assert(w != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1225,7 +1201,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSwizzle
     uint32_t E1,
     uint32_t E2,
     uint32_t E3
-)
+) noexcept
 {
     assert((E0 < 4) && (E1 < 4) && (E2 < 4) && (E3 < 4));
     _Analysis_assume_((E0 < 4) && (E1 < 4) && (E2 < 4) && (E3 < 4));
@@ -1287,7 +1263,7 @@ inline XMVECTOR XM_CALLCONV XMVectorPermute
     uint32_t PermuteY,
     uint32_t PermuteZ,
     uint32_t PermuteW
-)
+) noexcept
 {
     assert(PermuteX <= 7 && PermuteY <= 7 && PermuteZ <= 7 && PermuteW <= 7);
     _Analysis_assume_(PermuteX <= 7 && PermuteY <= 7 && PermuteZ <= 7 && PermuteW <= 7);
@@ -1380,7 +1356,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSelectControl
     uint32_t VectorIndex1,
     uint32_t VectorIndex2,
     uint32_t VectorIndex3
-)
+) noexcept
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     // x=Index0,y=Index1,z=Index2,w=Index3
@@ -1428,7 +1404,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSelect
     FXMVECTOR V1,
     FXMVECTOR V2,
     FXMVECTOR Control
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1455,7 +1431,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMergeXY
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1480,7 +1456,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMergeZW
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1501,7 +1477,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMergeZW
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorShiftLeft(FXMVECTOR V1, FXMVECTOR V2, uint32_t Elements)
+inline XMVECTOR XM_CALLCONV XMVectorShiftLeft(FXMVECTOR V1, FXMVECTOR V2, uint32_t Elements) noexcept
 {
     assert(Elements < 4);
     _Analysis_assume_(Elements < 4);
@@ -1510,7 +1486,7 @@ inline XMVECTOR XM_CALLCONV XMVectorShiftLeft(FXMVECTOR V1, FXMVECTOR V2, uint32
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorRotateLeft(FXMVECTOR V, uint32_t Elements)
+inline XMVECTOR XM_CALLCONV XMVectorRotateLeft(FXMVECTOR V, uint32_t Elements) noexcept
 {
     assert(Elements < 4);
     _Analysis_assume_(Elements < 4);
@@ -1519,7 +1495,7 @@ inline XMVECTOR XM_CALLCONV XMVectorRotateLeft(FXMVECTOR V, uint32_t Elements)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorRotateRight(FXMVECTOR V, uint32_t Elements)
+inline XMVECTOR XM_CALLCONV XMVectorRotateRight(FXMVECTOR V, uint32_t Elements) noexcept
 {
     assert(Elements < 4);
     _Analysis_assume_(Elements < 4);
@@ -1528,8 +1504,10 @@ inline XMVECTOR XM_CALLCONV XMVectorRotateRight(FXMVECTOR V, uint32_t Elements)
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorInsert(FXMVECTOR VD, FXMVECTOR VS, uint32_t VSLeftRotateElements,
-    uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3)
+inline XMVECTOR XM_CALLCONV XMVectorInsert(
+    FXMVECTOR VD, FXMVECTOR VS,
+    uint32_t VSLeftRotateElements,
+    uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3) noexcept
 {
     XMVECTOR Control = XMVectorSelectControl(Select0 & 1, Select1 & 1, Select2 & 1, Select3 & 1);
     return XMVectorSelect(VD, XMVectorRotateLeft(VS, VSLeftRotateElements), Control);
@@ -1545,7 +1523,7 @@ inline XMVECTOR XM_CALLCONV XMVectorEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1572,7 +1550,7 @@ inline XMVECTOR XM_CALLCONV XMVectorEqualR
     uint32_t* pCR,
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     assert(pCR != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1642,7 +1620,7 @@ inline XMVECTOR XM_CALLCONV XMVectorEqualInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1670,7 +1648,7 @@ inline XMVECTOR XM_CALLCONV XMVectorEqualIntR
     uint32_t* pCR,
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     assert(pCR != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1732,7 +1710,7 @@ inline XMVECTOR XM_CALLCONV XMVectorNearEqual
     FXMVECTOR V1,
     FXMVECTOR V2,
     FXMVECTOR Epsilon
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1775,7 +1753,7 @@ inline XMVECTOR XM_CALLCONV XMVectorNotEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1800,7 +1778,7 @@ inline XMVECTOR XM_CALLCONV XMVectorNotEqualInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1826,7 +1804,7 @@ inline XMVECTOR XM_CALLCONV XMVectorGreater
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1853,7 +1831,7 @@ inline XMVECTOR XM_CALLCONV XMVectorGreaterR
     uint32_t* pCR,
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     assert(pCR != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1920,7 +1898,7 @@ inline XMVECTOR XM_CALLCONV XMVectorGreaterOrEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -1947,7 +1925,7 @@ inline XMVECTOR XM_CALLCONV XMVectorGreaterOrEqualR
     uint32_t* pCR,
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     assert(pCR != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2014,7 +1992,7 @@ inline XMVECTOR XM_CALLCONV XMVectorLess
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2039,7 +2017,7 @@ inline XMVECTOR XM_CALLCONV XMVectorLessOrEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2064,7 +2042,7 @@ inline XMVECTOR XM_CALLCONV XMVectorInBounds
 (
     FXMVECTOR V,
     FXMVECTOR Bounds
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2107,7 +2085,7 @@ inline XMVECTOR XM_CALLCONV XMVectorInBoundsR
     uint32_t* pCR,
     FXMVECTOR V,
     FXMVECTOR Bounds
-)
+) noexcept
 {
     assert(pCR != nullptr);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2176,10 +2154,7 @@ inline XMVECTOR XM_CALLCONV XMVectorInBoundsR
 #pragma float_control(precise, on)
 #endif
 
-inline XMVECTOR XM_CALLCONV XMVectorIsNaN
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorIsNaN(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2208,10 +2183,7 @@ inline XMVECTOR XM_CALLCONV XMVectorIsNaN
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorIsInfinite
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorIsInfinite(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2250,7 +2222,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMin
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2275,7 +2247,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMax
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2324,10 +2296,7 @@ namespace Internal
 #pragma float_control(precise, on)
 #endif
 
-inline XMVECTOR XM_CALLCONV XMVectorRound
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorRound(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2374,10 +2343,7 @@ inline XMVECTOR XM_CALLCONV XMVectorRound
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorTruncate
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorTruncate(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTOR Result;
@@ -2440,10 +2406,7 @@ inline XMVECTOR XM_CALLCONV XMVectorTruncate
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorFloor
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorFloor(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -2494,10 +2457,7 @@ inline XMVECTOR XM_CALLCONV XMVectorFloor
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorCeiling
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorCeiling(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -2553,7 +2513,7 @@ inline XMVECTOR XM_CALLCONV XMVectorClamp
     FXMVECTOR V,
     FXMVECTOR Min,
     FXMVECTOR Max
-)
+) noexcept
 {
     assert(XMVector4LessOrEqual(Min, Max));
 
@@ -2579,10 +2539,7 @@ inline XMVECTOR XM_CALLCONV XMVectorClamp
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorSaturate
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSaturate(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2611,7 +2568,7 @@ inline XMVECTOR XM_CALLCONV XMVectorAndInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2636,7 +2593,7 @@ inline XMVECTOR XM_CALLCONV XMVectorAndCInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2662,7 +2619,7 @@ inline XMVECTOR XM_CALLCONV XMVectorOrInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2688,7 +2645,7 @@ inline XMVECTOR XM_CALLCONV XMVectorNorInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2717,7 +2674,7 @@ inline XMVECTOR XM_CALLCONV XMVectorXorInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2743,10 +2700,7 @@ inline XMVECTOR XM_CALLCONV XMVectorXorInt
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorNegate
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorNegate(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2775,7 +2729,7 @@ inline XMVECTOR XM_CALLCONV XMVectorAdd
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2796,10 +2750,7 @@ inline XMVECTOR XM_CALLCONV XMVectorAdd
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorSum
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSum(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2838,7 +2789,7 @@ inline XMVECTOR XM_CALLCONV XMVectorAddAngles
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2897,7 +2848,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSubtract
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2922,7 +2873,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSubtractAngles
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -2981,7 +2932,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMultiply
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3005,7 +2956,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMultiplyAdd
     FXMVECTOR V1,
     FXMVECTOR V2,
     FXMVECTOR V3
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3035,7 +2986,7 @@ inline XMVECTOR XM_CALLCONV XMVectorDivide
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3069,7 +3020,7 @@ inline XMVECTOR XM_CALLCONV XMVectorNegativeMultiplySubtract
     FXMVECTOR V1,
     FXMVECTOR V2,
     FXMVECTOR V3
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3099,7 +3050,7 @@ inline XMVECTOR XM_CALLCONV XMVectorScale
 (
     FXMVECTOR V,
     float    ScaleFactor
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3119,10 +3070,7 @@ inline XMVECTOR XM_CALLCONV XMVectorScale
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorReciprocalEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorReciprocalEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3141,10 +3089,7 @@ inline XMVECTOR XM_CALLCONV XMVectorReciprocalEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorReciprocal
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorReciprocal(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3173,10 +3118,7 @@ inline XMVECTOR XM_CALLCONV XMVectorReciprocal
 
 //------------------------------------------------------------------------------
 // Return an estimated square root
-inline XMVECTOR XM_CALLCONV XMVectorSqrtEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSqrtEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3205,10 +3147,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSqrtEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorSqrt
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSqrt(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3243,10 +3182,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSqrt
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorReciprocalSqrtEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorReciprocalSqrtEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3265,10 +3201,7 @@ inline XMVECTOR XM_CALLCONV XMVectorReciprocalSqrtEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorReciprocalSqrt
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorReciprocalSqrt(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -3299,10 +3232,7 @@ inline XMVECTOR XM_CALLCONV XMVectorReciprocalSqrt
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorExp2
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorExp2(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -3444,10 +3374,7 @@ inline XMVECTOR XM_CALLCONV XMVectorExp2
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorExpE
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorExpE(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -3596,10 +3523,7 @@ inline XMVECTOR XM_CALLCONV XMVectorExpE
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorExp
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorExp(FXMVECTOR V) noexcept
 {
     return XMVectorExp2(V);
 }
@@ -3763,10 +3687,7 @@ namespace Internal
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorLog2
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorLog2(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -3933,10 +3854,7 @@ inline XMVECTOR XM_CALLCONV XMVectorLog2
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorLogE
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorLogE(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -4105,10 +4023,7 @@ inline XMVECTOR XM_CALLCONV XMVectorLogE
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorLog
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorLog(FXMVECTOR V) noexcept
 {
     return XMVectorLog2(V);
 }
@@ -4119,7 +4034,7 @@ inline XMVECTOR XM_CALLCONV XMVectorPow
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -4155,10 +4070,7 @@ inline XMVECTOR XM_CALLCONV XMVectorPow
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorAbs
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorAbs(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 vResult = { { {
@@ -4184,7 +4096,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMod
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     // V1 % V2 = V1 - V2 * truncate(V1 / V2)
 
@@ -4210,10 +4122,7 @@ inline XMVECTOR XM_CALLCONV XMVectorMod
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorModAngles
-(
-    FXMVECTOR Angles
-)
+inline XMVECTOR XM_CALLCONV XMVectorModAngles(FXMVECTOR Angles) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -4245,10 +4154,7 @@ inline XMVECTOR XM_CALLCONV XMVectorModAngles
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorSin
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSin(FXMVECTOR V) noexcept
 {
     // 11-degree minimax approximation
 
@@ -4337,10 +4243,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSin
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorCos
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorCos(FXMVECTOR V) noexcept
 {
     // 10-degree minimax approximation
 
@@ -4439,7 +4342,7 @@ inline void XM_CALLCONV XMVectorSinCos
     XMVECTOR* pSin,
     XMVECTOR* pCos,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pSin != nullptr);
     assert(pCos != nullptr);
@@ -4586,10 +4489,7 @@ inline void XM_CALLCONV XMVectorSinCos
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorTan
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorTan(FXMVECTOR V) noexcept
 {
     // Cody and Waite algorithm to compute tangent.
 
@@ -4681,10 +4581,7 @@ inline XMVECTOR XM_CALLCONV XMVectorTan
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorSinH
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSinH(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -4719,10 +4616,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSinH
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorCosH
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorCosH(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -4755,10 +4649,7 @@ inline XMVECTOR XM_CALLCONV XMVectorCosH
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorTanH
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorTanH(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -4790,10 +4681,7 @@ inline XMVECTOR XM_CALLCONV XMVectorTanH
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorASin
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorASin(FXMVECTOR V) noexcept
 {
     // 7-degree minimax approximation
 
@@ -4898,10 +4786,7 @@ inline XMVECTOR XM_CALLCONV XMVectorASin
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorACos
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorACos(FXMVECTOR V) noexcept
 {
     // 7-degree minimax approximation
 
@@ -5004,10 +4889,7 @@ inline XMVECTOR XM_CALLCONV XMVectorACos
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorATan
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorATan(FXMVECTOR V) noexcept
 {
     // 17-degree minimax approximation
 
@@ -5132,7 +5014,7 @@ inline XMVECTOR XM_CALLCONV XMVectorATan2
 (
     FXMVECTOR Y,
     FXMVECTOR X
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -5201,10 +5083,7 @@ inline XMVECTOR XM_CALLCONV XMVectorATan2
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorSinEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorSinEst(FXMVECTOR V) noexcept
 {
     // 7-degree minimax approximation
 
@@ -5278,10 +5157,7 @@ inline XMVECTOR XM_CALLCONV XMVectorSinEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorCosEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorCosEst(FXMVECTOR V) noexcept
 {
     // 6-degree minimax approximation
 
@@ -5365,7 +5241,7 @@ inline void XM_CALLCONV XMVectorSinCosEst
     XMVECTOR* pSin,
     XMVECTOR* pCos,
     FXMVECTOR  V
-)
+) noexcept
 {
     assert(pSin != nullptr);
     assert(pCos != nullptr);
@@ -5482,10 +5358,7 @@ inline void XM_CALLCONV XMVectorSinCosEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorTanEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorTanEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -5523,10 +5396,7 @@ inline XMVECTOR XM_CALLCONV XMVectorTanEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorASinEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorASinEst(FXMVECTOR V) noexcept
 {
     // 3-degree minimax approximation
 
@@ -5600,10 +5470,7 @@ inline XMVECTOR XM_CALLCONV XMVectorASinEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorACosEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorACosEst(FXMVECTOR V) noexcept
 {
     // 3-degree minimax approximation
 
@@ -5676,10 +5543,7 @@ inline XMVECTOR XM_CALLCONV XMVectorACosEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVectorATanEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVectorATanEst(FXMVECTOR V) noexcept
 {
     // 9-degree minimax approximation
 
@@ -5777,7 +5641,7 @@ inline XMVECTOR XM_CALLCONV XMVectorATan2Est
 (
     FXMVECTOR Y,
     FXMVECTOR X
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     XMVECTORF32 Result = { { {
@@ -5841,7 +5705,7 @@ inline XMVECTOR XM_CALLCONV XMVectorLerp
     FXMVECTOR V0,
     FXMVECTOR V1,
     float    t
-)
+) noexcept
 {
     // V0 + t * (V1 - V0)
 
@@ -5869,7 +5733,7 @@ inline XMVECTOR XM_CALLCONV XMVectorLerpV
     FXMVECTOR V0,
     FXMVECTOR V1,
     FXMVECTOR T
-)
+) noexcept
 {
     // V0 + T * (V1 - V0)
 
@@ -5897,7 +5761,7 @@ inline XMVECTOR XM_CALLCONV XMVectorHermite
     FXMVECTOR Position1,
     GXMVECTOR Tangent1,
     float    t
-)
+) noexcept
 {
     // Result = (2 * t^3 - 3 * t^2 + 1) * Position0 +
     //          (t^3 - 2 * t^2 + t) * Tangent0 +
@@ -5964,7 +5828,7 @@ inline XMVECTOR XM_CALLCONV XMVectorHermiteV
     FXMVECTOR Position1,
     GXMVECTOR Tangent1,
     HXMVECTOR T
-)
+) noexcept
 {
     // Result = (2 * t^3 - 3 * t^2 + 1) * Position0 +
     //          (t^3 - 2 * t^2 + t) * Tangent0 +
@@ -6060,7 +5924,7 @@ inline XMVECTOR XM_CALLCONV XMVectorCatmullRom
     FXMVECTOR Position2,
     GXMVECTOR Position3,
     float    t
-)
+) noexcept
 {
     // Result = ((-t^3 + 2 * t^2 - t) * Position0 +
     //           (3 * t^3 - 5 * t^2 + 2) * Position1 +
@@ -6128,7 +5992,7 @@ inline XMVECTOR XM_CALLCONV XMVectorCatmullRomV
     FXMVECTOR Position2,
     GXMVECTOR Position3,
     HXMVECTOR T
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float fx = T.vector4_f32[0];
@@ -6232,7 +6096,7 @@ inline XMVECTOR XM_CALLCONV XMVectorBaryCentric
     FXMVECTOR Position2,
     float    f,
     float    g
-)
+) noexcept
 {
     // Result = Position0 + f * (Position1 - Position0) + g * (Position2 - Position0)
 
@@ -6276,7 +6140,7 @@ inline XMVECTOR XM_CALLCONV XMVectorBaryCentricV
     FXMVECTOR Position2,
     GXMVECTOR F,
     HXMVECTOR G
-)
+) noexcept
 {
     // Result = Position0 + f * (Position1 - Position0) + g * (Position2 - Position0)
 
@@ -6322,7 +6186,7 @@ inline bool XM_CALLCONV XMVector2Equal
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] == V2.vector4_f32[0]) && (V1.vector4_f32[1] == V2.vector4_f32[1])) != 0);
@@ -6343,7 +6207,7 @@ inline uint32_t XM_CALLCONV XMVector2EqualR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -6396,7 +6260,7 @@ inline bool XM_CALLCONV XMVector2EqualInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_u32[0] == V2.vector4_u32[0]) && (V1.vector4_u32[1] == V2.vector4_u32[1])) != 0);
@@ -6415,7 +6279,7 @@ inline uint32_t XM_CALLCONV XMVector2EqualIntR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -6468,7 +6332,7 @@ inline bool XM_CALLCONV XMVector2NearEqual
     FXMVECTOR V1,
     FXMVECTOR V2,
     FXMVECTOR Epsilon
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float dx = fabsf(V1.vector4_f32[0] - V2.vector4_f32[0]);
@@ -6499,7 +6363,7 @@ inline bool XM_CALLCONV XMVector2NotEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] != V2.vector4_f32[0]) || (V1.vector4_f32[1] != V2.vector4_f32[1])) != 0);
@@ -6519,7 +6383,7 @@ inline bool XM_CALLCONV XMVector2NotEqualInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_u32[0] != V2.vector4_u32[0]) || (V1.vector4_u32[1] != V2.vector4_u32[1])) != 0);
@@ -6538,7 +6402,7 @@ inline bool XM_CALLCONV XMVector2Greater
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] > V2.vector4_f32[0]) && (V1.vector4_f32[1] > V2.vector4_f32[1])) != 0);
@@ -6558,7 +6422,7 @@ inline uint32_t XM_CALLCONV XMVector2GreaterR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -6610,7 +6474,7 @@ inline bool XM_CALLCONV XMVector2GreaterOrEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] >= V2.vector4_f32[0]) && (V1.vector4_f32[1] >= V2.vector4_f32[1])) != 0);
@@ -6629,7 +6493,7 @@ inline uint32_t XM_CALLCONV XMVector2GreaterOrEqualR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -6681,7 +6545,7 @@ inline bool XM_CALLCONV XMVector2Less
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] < V2.vector4_f32[0]) && (V1.vector4_f32[1] < V2.vector4_f32[1])) != 0);
@@ -6700,7 +6564,7 @@ inline bool XM_CALLCONV XMVector2LessOrEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] <= V2.vector4_f32[0]) && (V1.vector4_f32[1] <= V2.vector4_f32[1])) != 0);
@@ -6719,7 +6583,7 @@ inline bool XM_CALLCONV XMVector2InBounds
 (
     FXMVECTOR V,
     FXMVECTOR Bounds
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V.vector4_f32[0] <= Bounds.vector4_f32[0] && V.vector4_f32[0] >= -Bounds.vector4_f32[0]) &&
@@ -6758,10 +6622,7 @@ inline bool XM_CALLCONV XMVector2InBounds
 #pragma float_control(precise, on)
 #endif
 
-inline bool XM_CALLCONV XMVector2IsNaN
-(
-    FXMVECTOR V
-)
+inline bool XM_CALLCONV XMVector2IsNaN(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (XMISNAN(V.vector4_f32[0]) ||
@@ -6786,10 +6647,7 @@ inline bool XM_CALLCONV XMVector2IsNaN
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMVector2IsInfinite
-(
-    FXMVECTOR V
-)
+inline bool XM_CALLCONV XMVector2IsInfinite(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -6822,7 +6680,7 @@ inline XMVECTOR XM_CALLCONV XMVector2Dot
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -6863,7 +6721,7 @@ inline XMVECTOR XM_CALLCONV XMVector2Cross
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     // [ V1.x*V2.y - V1.y*V2.x, V1.x*V2.y - V1.y*V2.x ]
 
@@ -6899,20 +6757,14 @@ inline XMVECTOR XM_CALLCONV XMVector2Cross
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector2LengthSq
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector2LengthSq(FXMVECTOR V) noexcept
 {
     return XMVector2Dot(V, V);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector2ReciprocalLengthEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector2ReciprocalLengthEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -6953,10 +6805,7 @@ inline XMVECTOR XM_CALLCONV XMVector2ReciprocalLengthEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector2ReciprocalLength
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector2ReciprocalLength(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -7006,10 +6855,7 @@ inline XMVECTOR XM_CALLCONV XMVector2ReciprocalLength
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector2LengthEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector2LengthEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -7054,10 +6900,7 @@ inline XMVECTOR XM_CALLCONV XMVector2LengthEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector2Length
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector2Length(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -7110,10 +6953,7 @@ inline XMVECTOR XM_CALLCONV XMVector2Length
 // XMVector2NormalizeEst uses a reciprocal estimate and
 // returns QNaN on zero and infinite vectors.
 
-inline XMVECTOR XM_CALLCONV XMVector2NormalizeEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector2NormalizeEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -7159,10 +6999,7 @@ inline XMVECTOR XM_CALLCONV XMVector2NormalizeEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector2Normalize
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector2Normalize(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -7278,7 +7115,7 @@ inline XMVECTOR XM_CALLCONV XMVector2ClampLength
     FXMVECTOR V,
     float    LengthMin,
     float    LengthMax
-)
+) noexcept
 {
     XMVECTOR ClampMax = XMVectorReplicate(LengthMax);
     XMVECTOR ClampMin = XMVectorReplicate(LengthMin);
@@ -7292,7 +7129,7 @@ inline XMVECTOR XM_CALLCONV XMVector2ClampLengthV
     FXMVECTOR V,
     FXMVECTOR LengthMin,
     FXMVECTOR LengthMax
-)
+) noexcept
 {
     assert((XMVectorGetY(LengthMin) == XMVectorGetX(LengthMin)));
     assert((XMVectorGetY(LengthMax) == XMVectorGetX(LengthMax)));
@@ -7338,7 +7175,7 @@ inline XMVECTOR XM_CALLCONV XMVector2Reflect
 (
     FXMVECTOR Incident,
     FXMVECTOR Normal
-)
+) noexcept
 {
     // Result = Incident - (2 * dot(Incident, Normal)) * Normal
 
@@ -7356,7 +7193,7 @@ inline XMVECTOR XM_CALLCONV XMVector2Refract
     FXMVECTOR Incident,
     FXMVECTOR Normal,
     float    RefractionIndex
-)
+) noexcept
 {
     XMVECTOR Index = XMVectorReplicate(RefractionIndex);
     return XMVector2RefractV(Incident, Normal, Index);
@@ -7370,7 +7207,7 @@ inline XMVECTOR XM_CALLCONV XMVector2RefractV
     FXMVECTOR Incident,
     FXMVECTOR Normal,
     FXMVECTOR RefractionIndex
-)
+) noexcept
 {
     // Result = RefractionIndex * Incident - Normal * (RefractionIndex * dot(Incident, Normal) +
     // sqrt(1 - RefractionIndex * RefractionIndex * (1 - dot(Incident, Normal) * dot(Incident, Normal))))
@@ -7463,10 +7300,7 @@ inline XMVECTOR XM_CALLCONV XMVector2RefractV
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector2Orthogonal
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector2Orthogonal(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -7498,7 +7332,7 @@ inline XMVECTOR XM_CALLCONV XMVector2AngleBetweenNormalsEst
 (
     FXMVECTOR N1,
     FXMVECTOR N2
-)
+) noexcept
 {
     XMVECTOR Result = XMVector2Dot(N1, N2);
     Result = XMVectorClamp(Result, g_XMNegativeOne.v, g_XMOne.v);
@@ -7512,7 +7346,7 @@ inline XMVECTOR XM_CALLCONV XMVector2AngleBetweenNormals
 (
     FXMVECTOR N1,
     FXMVECTOR N2
-)
+) noexcept
 {
     XMVECTOR Result = XMVector2Dot(N1, N2);
     Result = XMVectorClamp(Result, g_XMNegativeOne, g_XMOne);
@@ -7526,7 +7360,7 @@ inline XMVECTOR XM_CALLCONV XMVector2AngleBetweenVectors
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     XMVECTOR L1 = XMVector2ReciprocalLength(V1);
     XMVECTOR L2 = XMVector2ReciprocalLength(V2);
@@ -7548,7 +7382,7 @@ inline XMVECTOR XM_CALLCONV XMVector2LinePointDistance
     FXMVECTOR LinePoint1,
     FXMVECTOR LinePoint2,
     FXMVECTOR Point
-)
+) noexcept
 {
     // Given a vector PointVector from LinePoint1 to Point and a vector
     // LineVector from LinePoint1 to LinePoint2, the scaled distance
@@ -7579,7 +7413,7 @@ inline XMVECTOR XM_CALLCONV XMVector2IntersectLine
     FXMVECTOR Line1Point2,
     FXMVECTOR Line2Point1,
     GXMVECTOR Line2Point2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_) || defined(_XM_ARM_NEON_INTRINSICS_)
 
@@ -7655,7 +7489,7 @@ inline XMVECTOR XM_CALLCONV XMVector2Transform
 (
     FXMVECTOR V,
     FXMMATRIX M
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -7693,7 +7527,7 @@ inline XMFLOAT4* XM_CALLCONV XMVector2TransformStream
     size_t          InputStride,
     size_t          VectorCount,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -7970,7 +7804,7 @@ inline XMVECTOR XM_CALLCONV XMVector2TransformCoord
 (
     FXMVECTOR V,
     FXMMATRIX M
-)
+) noexcept
 {
     XMVECTOR Y = XMVectorSplatY(V);
     XMVECTOR X = XMVectorSplatX(V);
@@ -7993,7 +7827,7 @@ inline XMFLOAT2* XM_CALLCONV XMVector2TransformCoordStream
     size_t          InputStride,
     size_t          VectorCount,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -8348,7 +8182,7 @@ inline XMVECTOR XM_CALLCONV XMVector2TransformNormal
 (
     FXMVECTOR V,
     FXMMATRIX M
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -8385,7 +8219,7 @@ inline XMFLOAT2* XM_CALLCONV XMVector2TransformNormalStream
     size_t          InputStride,
     size_t          VectorCount,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -8664,7 +8498,7 @@ inline bool XM_CALLCONV XMVector3Equal
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] == V2.vector4_f32[0]) && (V1.vector4_f32[1] == V2.vector4_f32[1]) && (V1.vector4_f32[2] == V2.vector4_f32[2])) != 0);
@@ -8685,7 +8519,7 @@ inline uint32_t XM_CALLCONV XMVector3EqualR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     uint32_t CR = 0;
@@ -8740,7 +8574,7 @@ inline bool XM_CALLCONV XMVector3EqualInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_u32[0] == V2.vector4_u32[0]) && (V1.vector4_u32[1] == V2.vector4_u32[1]) && (V1.vector4_u32[2] == V2.vector4_u32[2])) != 0);
@@ -8761,7 +8595,7 @@ inline uint32_t XM_CALLCONV XMVector3EqualIntR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     uint32_t CR = 0;
@@ -8817,7 +8651,7 @@ inline bool XM_CALLCONV XMVector3NearEqual
     FXMVECTOR V1,
     FXMVECTOR V2,
     FXMVECTOR Epsilon
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float dx, dy, dz;
@@ -8853,7 +8687,7 @@ inline bool XM_CALLCONV XMVector3NotEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] != V2.vector4_f32[0]) || (V1.vector4_f32[1] != V2.vector4_f32[1]) || (V1.vector4_f32[2] != V2.vector4_f32[2])) != 0);
@@ -8874,7 +8708,7 @@ inline bool XM_CALLCONV XMVector3NotEqualInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_u32[0] != V2.vector4_u32[0]) || (V1.vector4_u32[1] != V2.vector4_u32[1]) || (V1.vector4_u32[2] != V2.vector4_u32[2])) != 0);
@@ -8895,7 +8729,7 @@ inline bool XM_CALLCONV XMVector3Greater
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] > V2.vector4_f32[0]) && (V1.vector4_f32[1] > V2.vector4_f32[1]) && (V1.vector4_f32[2] > V2.vector4_f32[2])) != 0);
@@ -8916,7 +8750,7 @@ inline uint32_t XM_CALLCONV XMVector3GreaterR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     uint32_t CR = 0;
@@ -8972,7 +8806,7 @@ inline bool XM_CALLCONV XMVector3GreaterOrEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] >= V2.vector4_f32[0]) && (V1.vector4_f32[1] >= V2.vector4_f32[1]) && (V1.vector4_f32[2] >= V2.vector4_f32[2])) != 0);
@@ -8993,7 +8827,7 @@ inline uint32_t XM_CALLCONV XMVector3GreaterOrEqualR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -9050,7 +8884,7 @@ inline bool XM_CALLCONV XMVector3Less
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] < V2.vector4_f32[0]) && (V1.vector4_f32[1] < V2.vector4_f32[1]) && (V1.vector4_f32[2] < V2.vector4_f32[2])) != 0);
@@ -9071,7 +8905,7 @@ inline bool XM_CALLCONV XMVector3LessOrEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] <= V2.vector4_f32[0]) && (V1.vector4_f32[1] <= V2.vector4_f32[1]) && (V1.vector4_f32[2] <= V2.vector4_f32[2])) != 0);
@@ -9092,7 +8926,7 @@ inline bool XM_CALLCONV XMVector3InBounds
 (
     FXMVECTOR V,
     FXMVECTOR Bounds
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V.vector4_f32[0] <= Bounds.vector4_f32[0] && V.vector4_f32[0] >= -Bounds.vector4_f32[0]) &&
@@ -9134,10 +8968,7 @@ inline bool XM_CALLCONV XMVector3InBounds
 #pragma float_control(precise, on)
 #endif
 
-inline bool XM_CALLCONV XMVector3IsNaN
-(
-    FXMVECTOR V
-)
+inline bool XM_CALLCONV XMVector3IsNaN(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -9166,10 +8997,7 @@ inline bool XM_CALLCONV XMVector3IsNaN
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMVector3IsInfinite
-(
-    FXMVECTOR V
-)
+inline bool XM_CALLCONV XMVector3IsInfinite(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (XMISINF(V.vector4_f32[0]) ||
@@ -9204,7 +9032,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Dot
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float fValue = V1.vector4_f32[0] * V2.vector4_f32[0] + V1.vector4_f32[1] * V2.vector4_f32[1] + V1.vector4_f32[2] * V2.vector4_f32[2];
@@ -9251,7 +9079,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Cross
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     // [ V1.y*V2.z - V1.z*V2.y, V1.z*V2.x - V1.x*V2.z, V1.x*V2.y - V1.y*V2.x ]
 
@@ -9299,20 +9127,14 @@ inline XMVECTOR XM_CALLCONV XMVector3Cross
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector3LengthSq
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector3LengthSq(FXMVECTOR V) noexcept
 {
     return XMVector3Dot(V, V);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector3ReciprocalLengthEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector3ReciprocalLengthEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -9365,10 +9187,7 @@ inline XMVECTOR XM_CALLCONV XMVector3ReciprocalLengthEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector3ReciprocalLength
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector3ReciprocalLength(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -9431,10 +9250,7 @@ inline XMVECTOR XM_CALLCONV XMVector3ReciprocalLength
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector3LengthEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector3LengthEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -9491,10 +9307,7 @@ inline XMVECTOR XM_CALLCONV XMVector3LengthEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector3Length
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector3Length(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -9559,10 +9372,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Length
 // XMVector3NormalizeEst uses a reciprocal estimate and
 // returns QNaN on zero and infinite vectors.
 
-inline XMVECTOR XM_CALLCONV XMVector3NormalizeEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector3NormalizeEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -9618,10 +9428,7 @@ inline XMVECTOR XM_CALLCONV XMVector3NormalizeEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector3Normalize
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector3Normalize(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float fLength;
@@ -9744,7 +9551,7 @@ inline XMVECTOR XM_CALLCONV XMVector3ClampLength
     FXMVECTOR V,
     float    LengthMin,
     float    LengthMax
-)
+) noexcept
 {
     XMVECTOR ClampMax = XMVectorReplicate(LengthMax);
     XMVECTOR ClampMin = XMVectorReplicate(LengthMin);
@@ -9759,7 +9566,7 @@ inline XMVECTOR XM_CALLCONV XMVector3ClampLengthV
     FXMVECTOR V,
     FXMVECTOR LengthMin,
     FXMVECTOR LengthMax
-)
+) noexcept
 {
     assert((XMVectorGetY(LengthMin) == XMVectorGetX(LengthMin)) && (XMVectorGetZ(LengthMin) == XMVectorGetX(LengthMin)));
     assert((XMVectorGetY(LengthMax) == XMVectorGetX(LengthMax)) && (XMVectorGetZ(LengthMax) == XMVectorGetX(LengthMax)));
@@ -9805,7 +9612,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Reflect
 (
     FXMVECTOR Incident,
     FXMVECTOR Normal
-)
+) noexcept
 {
     // Result = Incident - (2 * dot(Incident, Normal)) * Normal
 
@@ -9823,7 +9630,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Refract
     FXMVECTOR Incident,
     FXMVECTOR Normal,
     float    RefractionIndex
-)
+) noexcept
 {
     XMVECTOR Index = XMVectorReplicate(RefractionIndex);
     return XMVector3RefractV(Incident, Normal, Index);
@@ -9836,7 +9643,7 @@ inline XMVECTOR XM_CALLCONV XMVector3RefractV
     FXMVECTOR Incident,
     FXMVECTOR Normal,
     FXMVECTOR RefractionIndex
-)
+) noexcept
 {
     // Result = RefractionIndex * Incident - Normal * (RefractionIndex * dot(Incident, Normal) +
     // sqrt(1 - RefractionIndex * RefractionIndex * (1 - dot(Incident, Normal) * dot(Incident, Normal))))
@@ -9938,10 +9745,7 @@ inline XMVECTOR XM_CALLCONV XMVector3RefractV
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector3Orthogonal
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector3Orthogonal(FXMVECTOR V) noexcept
 {
     XMVECTOR Zero = XMVectorZero();
     XMVECTOR Z = XMVectorSplatZ(V);
@@ -9969,7 +9773,7 @@ inline XMVECTOR XM_CALLCONV XMVector3AngleBetweenNormalsEst
 (
     FXMVECTOR N1,
     FXMVECTOR N2
-)
+) noexcept
 {
     XMVECTOR Result = XMVector3Dot(N1, N2);
     Result = XMVectorClamp(Result, g_XMNegativeOne.v, g_XMOne.v);
@@ -9983,7 +9787,7 @@ inline XMVECTOR XM_CALLCONV XMVector3AngleBetweenNormals
 (
     FXMVECTOR N1,
     FXMVECTOR N2
-)
+) noexcept
 {
     XMVECTOR Result = XMVector3Dot(N1, N2);
     Result = XMVectorClamp(Result, g_XMNegativeOne.v, g_XMOne.v);
@@ -9997,7 +9801,7 @@ inline XMVECTOR XM_CALLCONV XMVector3AngleBetweenVectors
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     XMVECTOR L1 = XMVector3ReciprocalLength(V1);
     XMVECTOR L2 = XMVector3ReciprocalLength(V2);
@@ -10019,7 +9823,7 @@ inline XMVECTOR XM_CALLCONV XMVector3LinePointDistance
     FXMVECTOR LinePoint1,
     FXMVECTOR LinePoint2,
     FXMVECTOR Point
-)
+) noexcept
 {
     // Given a vector PointVector from LinePoint1 to Point and a vector
     // LineVector from LinePoint1 to LinePoint2, the scaled distance
@@ -10051,7 +9855,7 @@ inline void XM_CALLCONV XMVector3ComponentsFromNormal
     XMVECTOR* pPerpendicular,
     FXMVECTOR  V,
     FXMVECTOR  Normal
-)
+) noexcept
 {
     assert(pParallel != nullptr);
     assert(pPerpendicular != nullptr);
@@ -10071,7 +9875,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Rotate
 (
     FXMVECTOR V,
     FXMVECTOR RotationQuaternion
-)
+) noexcept
 {
     XMVECTOR A = XMVectorSelect(g_XMSelect1110.v, V, g_XMSelect1110.v);
     XMVECTOR Q = XMQuaternionConjugate(RotationQuaternion);
@@ -10086,7 +9890,7 @@ inline XMVECTOR XM_CALLCONV XMVector3InverseRotate
 (
     FXMVECTOR V,
     FXMVECTOR RotationQuaternion
-)
+) noexcept
 {
     XMVECTOR A = XMVectorSelect(g_XMSelect1110.v, V, g_XMSelect1110.v);
     XMVECTOR Result = XMQuaternionMultiply(RotationQuaternion, A);
@@ -10100,7 +9904,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Transform
 (
     FXMVECTOR V,
     FXMMATRIX M
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -10149,7 +9953,7 @@ inline XMFLOAT4* XM_CALLCONV XMVector3TransformStream
     size_t          InputStride,
     size_t          VectorCount,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -10502,7 +10306,7 @@ inline XMVECTOR XM_CALLCONV XMVector3TransformCoord
 (
     FXMVECTOR V,
     FXMMATRIX M
-)
+) noexcept
 {
     XMVECTOR Z = XMVectorSplatZ(V);
     XMVECTOR Y = XMVectorSplatY(V);
@@ -10532,7 +10336,7 @@ inline XMFLOAT3* XM_CALLCONV XMVector3TransformCoordStream
     size_t          InputStride,
     size_t          VectorCount,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -11014,7 +10818,7 @@ inline XMVECTOR XM_CALLCONV XMVector3TransformNormal
 (
     FXMVECTOR V,
     FXMMATRIX M
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -11062,7 +10866,7 @@ inline XMFLOAT3* XM_CALLCONV XMVector3TransformNormalStream
     size_t          InputStride,
     size_t          VectorCount,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -11450,7 +11254,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Project
     FXMMATRIX Projection,
     CXMMATRIX View,
     CXMMATRIX World
-)
+) noexcept
 {
     const float HalfViewportWidth = ViewportWidth * 0.5f;
     const float HalfViewportHeight = ViewportHeight * 0.5f;
@@ -11492,7 +11296,7 @@ inline XMFLOAT3* XM_CALLCONV XMVector3ProjectStream
     FXMMATRIX     Projection,
     CXMMATRIX     View,
     CXMMATRIX     World
-)
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -12033,7 +11837,7 @@ inline XMVECTOR XM_CALLCONV XMVector3Unproject
     FXMMATRIX Projection,
     CXMMATRIX View,
     CXMMATRIX World
-)
+) noexcept
 {
     static const XMVECTORF32 D = { { { -1.0f, 1.0f, 0.0f, 0.0f } } };
 
@@ -12075,7 +11879,8 @@ inline XMFLOAT3* XM_CALLCONV XMVector3UnprojectStream
     float           ViewportMaxZ,
     FXMMATRIX       Projection,
     CXMMATRIX       View,
-    CXMMATRIX       World)
+    CXMMATRIX       World
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -12640,7 +12445,7 @@ inline bool XM_CALLCONV XMVector4Equal
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] == V2.vector4_f32[0]) && (V1.vector4_f32[1] == V2.vector4_f32[1]) && (V1.vector4_f32[2] == V2.vector4_f32[2]) && (V1.vector4_f32[3] == V2.vector4_f32[3])) != 0);
@@ -12663,7 +12468,7 @@ inline uint32_t XM_CALLCONV XMVector4EqualR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -12723,7 +12528,7 @@ inline bool XM_CALLCONV XMVector4EqualInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_u32[0] == V2.vector4_u32[0]) && (V1.vector4_u32[1] == V2.vector4_u32[1]) && (V1.vector4_u32[2] == V2.vector4_u32[2]) && (V1.vector4_u32[3] == V2.vector4_u32[3])) != 0);
@@ -12746,7 +12551,7 @@ inline uint32_t XM_CALLCONV XMVector4EqualIntR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     uint32_t CR = 0;
@@ -12803,7 +12608,7 @@ inline bool XM_CALLCONV XMVector4NearEqual
     FXMVECTOR V1,
     FXMVECTOR V2,
     FXMVECTOR Epsilon
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float dx, dy, dz, dw;
@@ -12840,7 +12645,7 @@ inline bool XM_CALLCONV XMVector4NotEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] != V2.vector4_f32[0]) || (V1.vector4_f32[1] != V2.vector4_f32[1]) || (V1.vector4_f32[2] != V2.vector4_f32[2]) || (V1.vector4_f32[3] != V2.vector4_f32[3])) != 0);
@@ -12863,7 +12668,7 @@ inline bool XM_CALLCONV XMVector4NotEqualInt
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_u32[0] != V2.vector4_u32[0]) || (V1.vector4_u32[1] != V2.vector4_u32[1]) || (V1.vector4_u32[2] != V2.vector4_u32[2]) || (V1.vector4_u32[3] != V2.vector4_u32[3])) != 0);
@@ -12886,7 +12691,7 @@ inline bool XM_CALLCONV XMVector4Greater
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] > V2.vector4_f32[0]) && (V1.vector4_f32[1] > V2.vector4_f32[1]) && (V1.vector4_f32[2] > V2.vector4_f32[2]) && (V1.vector4_f32[3] > V2.vector4_f32[3])) != 0);
@@ -12909,7 +12714,7 @@ inline uint32_t XM_CALLCONV XMVector4GreaterR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     uint32_t CR = 0;
@@ -12967,7 +12772,7 @@ inline bool XM_CALLCONV XMVector4GreaterOrEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] >= V2.vector4_f32[0]) && (V1.vector4_f32[1] >= V2.vector4_f32[1]) && (V1.vector4_f32[2] >= V2.vector4_f32[2]) && (V1.vector4_f32[3] >= V2.vector4_f32[3])) != 0);
@@ -12990,7 +12795,7 @@ inline uint32_t XM_CALLCONV XMVector4GreaterOrEqualR
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     uint32_t CR = 0;
@@ -13048,7 +12853,7 @@ inline bool XM_CALLCONV XMVector4Less
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] < V2.vector4_f32[0]) && (V1.vector4_f32[1] < V2.vector4_f32[1]) && (V1.vector4_f32[2] < V2.vector4_f32[2]) && (V1.vector4_f32[3] < V2.vector4_f32[3])) != 0);
@@ -13071,7 +12876,7 @@ inline bool XM_CALLCONV XMVector4LessOrEqual
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V1.vector4_f32[0] <= V2.vector4_f32[0]) && (V1.vector4_f32[1] <= V2.vector4_f32[1]) && (V1.vector4_f32[2] <= V2.vector4_f32[2]) && (V1.vector4_f32[3] <= V2.vector4_f32[3])) != 0);
@@ -13094,7 +12899,7 @@ inline bool XM_CALLCONV XMVector4InBounds
 (
     FXMVECTOR V,
     FXMVECTOR Bounds
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (((V.vector4_f32[0] <= Bounds.vector4_f32[0] && V.vector4_f32[0] >= -Bounds.vector4_f32[0]) &&
@@ -13137,10 +12942,7 @@ inline bool XM_CALLCONV XMVector4InBounds
 #pragma float_control(precise, on)
 #endif
 
-inline bool XM_CALLCONV XMVector4IsNaN
-(
-    FXMVECTOR V
-)
+inline bool XM_CALLCONV XMVector4IsNaN(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     return (XMISNAN(V.vector4_f32[0]) ||
@@ -13168,10 +12970,7 @@ inline bool XM_CALLCONV XMVector4IsNaN
 
 //------------------------------------------------------------------------------
 
-inline bool XM_CALLCONV XMVector4IsInfinite
-(
-    FXMVECTOR V
-)
+inline bool XM_CALLCONV XMVector4IsInfinite(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -13209,7 +13008,7 @@ inline XMVECTOR XM_CALLCONV XMVector4Dot
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -13251,7 +13050,7 @@ inline XMVECTOR XM_CALLCONV XMVector4Cross
     FXMVECTOR V1,
     FXMVECTOR V2,
     FXMVECTOR V3
-)
+) noexcept
 {
     // [ ((v2.z*v3.w-v2.w*v3.z)*v1.y)-((v2.y*v3.w-v2.w*v3.y)*v1.z)+((v2.y*v3.z-v2.z*v3.y)*v1.w),
     //   ((v2.w*v3.z-v2.z*v3.w)*v1.x)-((v2.w*v3.x-v2.x*v3.w)*v1.z)+((v2.z*v3.x-v2.x*v3.z)*v1.w),
@@ -13396,20 +13195,14 @@ inline XMVECTOR XM_CALLCONV XMVector4Cross
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector4LengthSq
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector4LengthSq(FXMVECTOR V) noexcept
 {
     return XMVector4Dot(V, V);
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector4ReciprocalLengthEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector4ReciprocalLengthEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -13462,10 +13255,7 @@ inline XMVECTOR XM_CALLCONV XMVector4ReciprocalLengthEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector4ReciprocalLength
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector4ReciprocalLength(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -13528,10 +13318,7 @@ inline XMVECTOR XM_CALLCONV XMVector4ReciprocalLength
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector4LengthEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector4LengthEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -13588,10 +13375,7 @@ inline XMVECTOR XM_CALLCONV XMVector4LengthEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector4Length
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector4Length(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -13656,10 +13440,7 @@ inline XMVECTOR XM_CALLCONV XMVector4Length
 // XMVector4NormalizeEst uses a reciprocal estimate and
 // returns QNaN on zero and infinite vectors.
 
-inline XMVECTOR XM_CALLCONV XMVector4NormalizeEst
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector4NormalizeEst(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -13715,10 +13496,7 @@ inline XMVECTOR XM_CALLCONV XMVector4NormalizeEst
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector4Normalize
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector4Normalize(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
     float fLength;
@@ -13846,7 +13624,7 @@ inline XMVECTOR XM_CALLCONV XMVector4ClampLength
     FXMVECTOR V,
     float    LengthMin,
     float    LengthMax
-)
+) noexcept
 {
     XMVECTOR ClampMax = XMVectorReplicate(LengthMax);
     XMVECTOR ClampMin = XMVectorReplicate(LengthMin);
@@ -13861,7 +13639,7 @@ inline XMVECTOR XM_CALLCONV XMVector4ClampLengthV
     FXMVECTOR V,
     FXMVECTOR LengthMin,
     FXMVECTOR LengthMax
-)
+) noexcept
 {
     assert((XMVectorGetY(LengthMin) == XMVectorGetX(LengthMin)) && (XMVectorGetZ(LengthMin) == XMVectorGetX(LengthMin)) && (XMVectorGetW(LengthMin) == XMVectorGetX(LengthMin)));
     assert((XMVectorGetY(LengthMax) == XMVectorGetX(LengthMax)) && (XMVectorGetZ(LengthMax) == XMVectorGetX(LengthMax)) && (XMVectorGetW(LengthMax) == XMVectorGetX(LengthMax)));
@@ -13907,7 +13685,7 @@ inline XMVECTOR XM_CALLCONV XMVector4Reflect
 (
     FXMVECTOR Incident,
     FXMVECTOR Normal
-)
+) noexcept
 {
     // Result = Incident - (2 * dot(Incident, Normal)) * Normal
 
@@ -13925,7 +13703,7 @@ inline XMVECTOR XM_CALLCONV XMVector4Refract
     FXMVECTOR Incident,
     FXMVECTOR Normal,
     float    RefractionIndex
-)
+) noexcept
 {
     XMVECTOR Index = XMVectorReplicate(RefractionIndex);
     return XMVector4RefractV(Incident, Normal, Index);
@@ -13938,7 +13716,7 @@ inline XMVECTOR XM_CALLCONV XMVector4RefractV
     FXMVECTOR Incident,
     FXMVECTOR Normal,
     FXMVECTOR RefractionIndex
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -14043,10 +13821,7 @@ inline XMVECTOR XM_CALLCONV XMVector4RefractV
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV XMVector4Orthogonal
-(
-    FXMVECTOR V
-)
+inline XMVECTOR XM_CALLCONV XMVector4Orthogonal(FXMVECTOR V) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -14077,7 +13852,7 @@ inline XMVECTOR XM_CALLCONV XMVector4AngleBetweenNormalsEst
 (
     FXMVECTOR N1,
     FXMVECTOR N2
-)
+) noexcept
 {
     XMVECTOR Result = XMVector4Dot(N1, N2);
     Result = XMVectorClamp(Result, g_XMNegativeOne.v, g_XMOne.v);
@@ -14091,7 +13866,7 @@ inline XMVECTOR XM_CALLCONV XMVector4AngleBetweenNormals
 (
     FXMVECTOR N1,
     FXMVECTOR N2
-)
+) noexcept
 {
     XMVECTOR Result = XMVector4Dot(N1, N2);
     Result = XMVectorClamp(Result, g_XMNegativeOne.v, g_XMOne.v);
@@ -14105,7 +13880,7 @@ inline XMVECTOR XM_CALLCONV XMVector4AngleBetweenVectors
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-)
+) noexcept
 {
     XMVECTOR L1 = XMVector4ReciprocalLength(V1);
     XMVECTOR L2 = XMVector4ReciprocalLength(V2);
@@ -14126,7 +13901,7 @@ inline XMVECTOR XM_CALLCONV XMVector4Transform
 (
     FXMVECTOR V,
     FXMMATRIX M
-)
+) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)
 
@@ -14173,7 +13948,7 @@ inline XMFLOAT4* XM_CALLCONV XMVector4TransformStream
     size_t          InputStride,
     size_t          VectorCount,
     FXMMATRIX       M
-)
+) noexcept
 {
     assert(pOutputStream != nullptr);
     assert(pInputStream != nullptr);
@@ -14458,14 +14233,14 @@ inline XMFLOAT4* XM_CALLCONV XMVector4TransformStream
 
  //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV operator+ (FXMVECTOR V)
+inline XMVECTOR XM_CALLCONV operator+ (FXMVECTOR V) noexcept
 {
     return V;
 }
 
 //------------------------------------------------------------------------------
 
-inline XMVECTOR XM_CALLCONV operator- (FXMVECTOR V)
+inline XMVECTOR XM_CALLCONV operator- (FXMVECTOR V) noexcept
 {
     return XMVectorNegate(V);
 }
@@ -14476,7 +14251,7 @@ inline XMVECTOR& XM_CALLCONV operator+=
 (
     XMVECTOR& V1,
     FXMVECTOR       V2
-    )
+) noexcept
 {
     V1 = XMVectorAdd(V1, V2);
     return V1;
@@ -14488,7 +14263,7 @@ inline XMVECTOR& XM_CALLCONV operator-=
 (
     XMVECTOR& V1,
     FXMVECTOR       V2
-    )
+) noexcept
 {
     V1 = XMVectorSubtract(V1, V2);
     return V1;
@@ -14500,7 +14275,7 @@ inline XMVECTOR& XM_CALLCONV operator*=
 (
     XMVECTOR& V1,
     FXMVECTOR       V2
-    )
+) noexcept
 {
     V1 = XMVectorMultiply(V1, V2);
     return V1;
@@ -14512,7 +14287,7 @@ inline XMVECTOR& XM_CALLCONV operator/=
 (
     XMVECTOR& V1,
     FXMVECTOR       V2
-    )
+) noexcept
 {
     V1 = XMVectorDivide(V1, V2);
     return V1;
@@ -14524,7 +14299,7 @@ inline XMVECTOR& operator*=
 (
     XMVECTOR& V,
     const float S
-    )
+) noexcept
 {
     V = XMVectorScale(V, S);
     return V;
@@ -14536,7 +14311,7 @@ inline XMVECTOR& operator/=
 (
     XMVECTOR& V,
     const float S
-    )
+) noexcept
 {
     XMVECTOR vS = XMVectorReplicate(S);
     V = XMVectorDivide(V, vS);
@@ -14549,7 +14324,7 @@ inline XMVECTOR XM_CALLCONV operator+
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-    )
+) noexcept
 {
     return XMVectorAdd(V1, V2);
 }
@@ -14560,7 +14335,7 @@ inline XMVECTOR XM_CALLCONV operator-
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-    )
+) noexcept
 {
     return XMVectorSubtract(V1, V2);
 }
@@ -14571,7 +14346,7 @@ inline XMVECTOR XM_CALLCONV operator*
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-    )
+) noexcept
 {
     return XMVectorMultiply(V1, V2);
 }
@@ -14582,7 +14357,7 @@ inline XMVECTOR XM_CALLCONV operator/
 (
     FXMVECTOR V1,
     FXMVECTOR V2
-    )
+) noexcept
 {
     return XMVectorDivide(V1, V2);
 }
@@ -14593,7 +14368,7 @@ inline XMVECTOR XM_CALLCONV operator*
 (
     FXMVECTOR      V,
     const float    S
-    )
+) noexcept
 {
     return XMVectorScale(V, S);
 }
@@ -14604,7 +14379,7 @@ inline XMVECTOR XM_CALLCONV operator/
 (
     FXMVECTOR      V,
     const float    S
-    )
+) noexcept
 {
     XMVECTOR vS = XMVectorReplicate(S);
     return XMVectorDivide(V, vS);
@@ -14616,7 +14391,7 @@ inline XMVECTOR XM_CALLCONV operator*
 (
     float           S,
     FXMVECTOR       V
-    )
+) noexcept
 {
     return XMVectorScale(V, S);
 }

--- a/Inc/DirectXPackedVector.h
+++ b/Inc/DirectXPackedVector.h
@@ -53,9 +53,9 @@ namespace DirectX
             XMCOLOR(XMCOLOR&&) = default;
             XMCOLOR& operator=(XMCOLOR&&) = default;
 
-            XM_CONSTEXPR XMCOLOR(uint32_t Color) : c(Color) {}
-            XMCOLOR(float _r, float _g, float _b, float _a);
-            explicit XMCOLOR(_In_reads_(4) const float* pArray);
+            XM_CONSTEXPR XMCOLOR(uint32_t Color) noexcept : c(Color) {}
+            XMCOLOR(float _r, float _g, float _b, float _a) noexcept;
+            explicit XMCOLOR(_In_reads_(4) const float* pArray) noexcept;
 
             operator uint32_t () const { return c; }
 
@@ -89,13 +89,13 @@ namespace DirectX
             XMHALF2(XMHALF2&&) = default;
             XMHALF2& operator=(XMHALF2&&) = default;
 
-            explicit XM_CONSTEXPR XMHALF2(uint32_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMHALF2(HALF _x, HALF _y) : x(_x), y(_y) {}
-            explicit XMHALF2(_In_reads_(2) const HALF* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMHALF2(float _x, float _y);
-            explicit XMHALF2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMHALF2(uint32_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMHALF2(HALF _x, HALF _y) noexcept : x(_x), y(_y) {}
+            explicit XMHALF2(_In_reads_(2) const HALF* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMHALF2(float _x, float _y) noexcept;
+            explicit XMHALF2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMHALF2& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMHALF2& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -120,13 +120,13 @@ namespace DirectX
             XMSHORTN2(XMSHORTN2&&) = default;
             XMSHORTN2& operator=(XMSHORTN2&&) = default;
 
-            explicit XM_CONSTEXPR XMSHORTN2(uint32_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMSHORTN2(int16_t _x, int16_t _y) : x(_x), y(_y) {}
-            explicit XMSHORTN2(_In_reads_(2) const int16_t* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMSHORTN2(float _x, float _y);
-            explicit XMSHORTN2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMSHORTN2(uint32_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMSHORTN2(int16_t _x, int16_t _y) noexcept : x(_x), y(_y) {}
+            explicit XMSHORTN2(_In_reads_(2) const int16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMSHORTN2(float _x, float _y) noexcept;
+            explicit XMSHORTN2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMSHORTN2& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMSHORTN2& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 2D Vector; 16 bit signed integer components
@@ -150,13 +150,13 @@ namespace DirectX
             XMSHORT2(XMSHORT2&&) = default;
             XMSHORT2& operator=(XMSHORT2&&) = default;
 
-            explicit XM_CONSTEXPR XMSHORT2(uint32_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMSHORT2(int16_t _x, int16_t _y) : x(_x), y(_y) {}
-            explicit XMSHORT2(_In_reads_(2) const int16_t* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMSHORT2(float _x, float _y);
-            explicit XMSHORT2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMSHORT2(uint32_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMSHORT2(int16_t _x, int16_t _y) noexcept : x(_x), y(_y) {}
+            explicit XMSHORT2(_In_reads_(2) const int16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMSHORT2(float _x, float _y) noexcept;
+            explicit XMSHORT2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMSHORT2& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMSHORT2& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 2D Vector; 16 bit unsigned normalized integer components
@@ -180,13 +180,13 @@ namespace DirectX
             XMUSHORTN2(XMUSHORTN2&&) = default;
             XMUSHORTN2& operator=(XMUSHORTN2&&) = default;
 
-            explicit XM_CONSTEXPR XMUSHORTN2(uint32_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMUSHORTN2(uint16_t _x, uint16_t _y) : x(_x), y(_y) {}
-            explicit XMUSHORTN2(_In_reads_(2) const uint16_t* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMUSHORTN2(float _x, float _y);
-            explicit XMUSHORTN2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMUSHORTN2(uint32_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMUSHORTN2(uint16_t _x, uint16_t _y) noexcept : x(_x), y(_y) {}
+            explicit XMUSHORTN2(_In_reads_(2) const uint16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMUSHORTN2(float _x, float _y) noexcept;
+            explicit XMUSHORTN2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMUSHORTN2& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMUSHORTN2& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 2D Vector; 16 bit unsigned integer components
@@ -210,13 +210,13 @@ namespace DirectX
             XMUSHORT2(XMUSHORT2&&) = default;
             XMUSHORT2& operator=(XMUSHORT2&&) = default;
 
-            explicit XM_CONSTEXPR XMUSHORT2(uint32_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMUSHORT2(uint16_t _x, uint16_t _y) : x(_x), y(_y) {}
-            explicit XMUSHORT2(_In_reads_(2) const uint16_t* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMUSHORT2(float _x, float _y);
-            explicit XMUSHORT2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMUSHORT2(uint32_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMUSHORT2(uint16_t _x, uint16_t _y) noexcept : x(_x), y(_y) {}
+            explicit XMUSHORT2(_In_reads_(2) const uint16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMUSHORT2(float _x, float _y) noexcept;
+            explicit XMUSHORT2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMUSHORT2& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMUSHORT2& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -241,13 +241,13 @@ namespace DirectX
             XMBYTEN2(XMBYTEN2&&) = default;
             XMBYTEN2& operator=(XMBYTEN2&&) = default;
 
-            explicit XM_CONSTEXPR XMBYTEN2(uint16_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMBYTEN2(int8_t _x, int8_t _y) : x(_x), y(_y) {}
-            explicit XMBYTEN2(_In_reads_(2) const int8_t* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMBYTEN2(float _x, float _y);
-            explicit XMBYTEN2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMBYTEN2(uint16_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMBYTEN2(int8_t _x, int8_t _y) noexcept : x(_x), y(_y) {}
+            explicit XMBYTEN2(_In_reads_(2) const int8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMBYTEN2(float _x, float _y) noexcept;
+            explicit XMBYTEN2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMBYTEN2& operator= (uint16_t Packed) { v = Packed; return *this; }
+            XMBYTEN2& operator= (uint16_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 2D Vector; 8 bit signed integer components
@@ -271,13 +271,13 @@ namespace DirectX
             XMBYTE2(XMBYTE2&&) = default;
             XMBYTE2& operator=(XMBYTE2&&) = default;
 
-            explicit XM_CONSTEXPR XMBYTE2(uint16_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMBYTE2(int8_t _x, int8_t _y) : x(_x), y(_y) {}
-            explicit XMBYTE2(_In_reads_(2) const int8_t* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMBYTE2(float _x, float _y);
-            explicit XMBYTE2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMBYTE2(uint16_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMBYTE2(int8_t _x, int8_t _y) noexcept : x(_x), y(_y) {}
+            explicit XMBYTE2(_In_reads_(2) const int8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMBYTE2(float _x, float _y) noexcept;
+            explicit XMBYTE2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMBYTE2& operator= (uint16_t Packed) { v = Packed; return *this; }
+            XMBYTE2& operator= (uint16_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 2D Vector; 8 bit unsigned normalized integer components
@@ -301,13 +301,13 @@ namespace DirectX
             XMUBYTEN2(XMUBYTEN2&&) = default;
             XMUBYTEN2& operator=(XMUBYTEN2&&) = default;
 
-            explicit XM_CONSTEXPR XMUBYTEN2(uint16_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMUBYTEN2(uint8_t _x, uint8_t _y) : x(_x), y(_y) {}
-            explicit XMUBYTEN2(_In_reads_(2) const uint8_t* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMUBYTEN2(float _x, float _y);
-            explicit XMUBYTEN2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMUBYTEN2(uint16_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMUBYTEN2(uint8_t _x, uint8_t _y) noexcept : x(_x), y(_y) {}
+            explicit XMUBYTEN2(_In_reads_(2) const uint8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMUBYTEN2(float _x, float _y) noexcept;
+            explicit XMUBYTEN2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMUBYTEN2& operator= (uint16_t Packed) { v = Packed; return *this; }
+            XMUBYTEN2& operator= (uint16_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 2D Vector; 8 bit unsigned integer components
@@ -331,13 +331,13 @@ namespace DirectX
             XMUBYTE2(XMUBYTE2&&) = default;
             XMUBYTE2& operator=(XMUBYTE2&&) = default;
 
-            explicit XM_CONSTEXPR XMUBYTE2(uint16_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMUBYTE2(uint8_t _x, uint8_t _y) : x(_x), y(_y) {}
-            explicit XMUBYTE2(_In_reads_(2) const uint8_t* pArray) : x(pArray[0]), y(pArray[1]) {}
-            XMUBYTE2(float _x, float _y);
-            explicit XMUBYTE2(_In_reads_(2) const float* pArray);
+            explicit XM_CONSTEXPR XMUBYTE2(uint16_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMUBYTE2(uint8_t _x, uint8_t _y) noexcept : x(_x), y(_y) {}
+            explicit XMUBYTE2(_In_reads_(2) const uint8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+            XMUBYTE2(float _x, float _y) noexcept;
+            explicit XMUBYTE2(_In_reads_(2) const float* pArray) noexcept;
 
-            XMUBYTE2& operator= (uint16_t Packed) { v = Packed; return *this; }
+            XMUBYTE2& operator= (uint16_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -363,15 +363,15 @@ namespace DirectX
             XMU565(XMU565&&) = default;
             XMU565& operator=(XMU565&&) = default;
 
-            explicit XM_CONSTEXPR XMU565(uint16_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMU565(uint8_t _x, uint8_t _y, uint8_t _z) : x(_x), y(_y), z(_z) {}
-            explicit XMU565(_In_reads_(3) const uint8_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
-            XMU565(float _x, float _y, float _z);
-            explicit XMU565(_In_reads_(3) const float* pArray);
+            explicit XM_CONSTEXPR XMU565(uint16_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMU565(uint8_t _x, uint8_t _y, uint8_t _z) noexcept : x(_x), y(_y), z(_z) {}
+            explicit XMU565(_In_reads_(3) const uint8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
+            XMU565(float _x, float _y, float _z) noexcept;
+            explicit XMU565(_In_reads_(3) const float* pArray) noexcept;
 
-            operator uint16_t () const { return v; }
+            operator uint16_t () const noexcept { return v; }
 
-            XMU565& operator= (uint16_t Packed) { v = Packed; return *this; }
+            XMU565& operator= (uint16_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -407,13 +407,13 @@ namespace DirectX
             XMFLOAT3PK(XMFLOAT3PK&&) = default;
             XMFLOAT3PK& operator=(XMFLOAT3PK&&) = default;
 
-            explicit XM_CONSTEXPR XMFLOAT3PK(uint32_t Packed) : v(Packed) {}
-            XMFLOAT3PK(float _x, float _y, float _z);
-            explicit XMFLOAT3PK(_In_reads_(3) const float* pArray);
+            explicit XM_CONSTEXPR XMFLOAT3PK(uint32_t Packed) noexcept : v(Packed) {}
+            XMFLOAT3PK(float _x, float _y, float _z) noexcept;
+            explicit XMFLOAT3PK(_In_reads_(3) const float* pArray) noexcept;
 
-            operator uint32_t () const { return v; }
+            operator uint32_t () const noexcept { return v; }
 
-            XMFLOAT3PK& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMFLOAT3PK& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -446,13 +446,13 @@ namespace DirectX
             XMFLOAT3SE(XMFLOAT3SE&&) = default;
             XMFLOAT3SE& operator=(XMFLOAT3SE&&) = default;
 
-            explicit XM_CONSTEXPR XMFLOAT3SE(uint32_t Packed) : v(Packed) {}
-            XMFLOAT3SE(float _x, float _y, float _z);
-            explicit XMFLOAT3SE(_In_reads_(3) const float* pArray);
+            explicit XM_CONSTEXPR XMFLOAT3SE(uint32_t Packed) noexcept : v(Packed) {}
+            XMFLOAT3SE(float _x, float _y, float _z) noexcept;
+            explicit XMFLOAT3SE(_In_reads_(3) const float* pArray) noexcept;
 
-            operator uint32_t () const { return v; }
+            operator uint32_t () const noexcept { return v; }
 
-            XMFLOAT3SE& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMFLOAT3SE& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -479,13 +479,13 @@ namespace DirectX
             XMHALF4(XMHALF4&&) = default;
             XMHALF4& operator=(XMHALF4&&) = default;
 
-            explicit XM_CONSTEXPR XMHALF4(uint64_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMHALF4(HALF _x, HALF _y, HALF _z, HALF _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XMHALF4(_In_reads_(4) const HALF* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMHALF4(float _x, float _y, float _z, float _w);
-            explicit XMHALF4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMHALF4(uint64_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMHALF4(HALF _x, HALF _y, HALF _z, HALF _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XMHALF4(_In_reads_(4) const HALF* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMHALF4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMHALF4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMHALF4& operator= (uint64_t Packed) { v = Packed; return *this; }
+            XMHALF4& operator= (uint64_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -512,13 +512,13 @@ namespace DirectX
             XMSHORTN4(XMSHORTN4&&) = default;
             XMSHORTN4& operator=(XMSHORTN4&&) = default;
 
-            explicit XM_CONSTEXPR XMSHORTN4(uint64_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMSHORTN4(int16_t _x, int16_t _y, int16_t _z, int16_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XMSHORTN4(_In_reads_(4) const int16_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMSHORTN4(float _x, float _y, float _z, float _w);
-            explicit XMSHORTN4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMSHORTN4(uint64_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMSHORTN4(int16_t _x, int16_t _y, int16_t _z, int16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XMSHORTN4(_In_reads_(4) const int16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMSHORTN4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMSHORTN4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMSHORTN4& operator= (uint64_t Packed) { v = Packed; return *this; }
+            XMSHORTN4& operator= (uint64_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 16 bit signed integer components
@@ -544,13 +544,13 @@ namespace DirectX
             XMSHORT4(XMSHORT4&&) = default;
             XMSHORT4& operator=(XMSHORT4&&) = default;
 
-            explicit XM_CONSTEXPR XMSHORT4(uint64_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMSHORT4(int16_t _x, int16_t _y, int16_t _z, int16_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XMSHORT4(_In_reads_(4) const int16_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMSHORT4(float _x, float _y, float _z, float _w);
-            explicit XMSHORT4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMSHORT4(uint64_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMSHORT4(int16_t _x, int16_t _y, int16_t _z, int16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XMSHORT4(_In_reads_(4) const int16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMSHORT4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMSHORT4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMSHORT4& operator= (uint64_t Packed) { v = Packed; return *this; }
+            XMSHORT4& operator= (uint64_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 16 bit unsigned normalized integer components
@@ -576,13 +576,13 @@ namespace DirectX
             XMUSHORTN4(XMUSHORTN4&&) = default;
             XMUSHORTN4& operator=(XMUSHORTN4&&) = default;
 
-            explicit XM_CONSTEXPR XMUSHORTN4(uint64_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMUSHORTN4(uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XMUSHORTN4(_In_reads_(4) const uint16_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMUSHORTN4(float _x, float _y, float _z, float _w);
-            explicit XMUSHORTN4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMUSHORTN4(uint64_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMUSHORTN4(uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XMUSHORTN4(_In_reads_(4) const uint16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMUSHORTN4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMUSHORTN4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMUSHORTN4& operator= (uint64_t Packed) { v = Packed; return *this; }
+            XMUSHORTN4& operator= (uint64_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 16 bit unsigned integer components
@@ -608,13 +608,13 @@ namespace DirectX
             XMUSHORT4(XMUSHORT4&&) = default;
             XMUSHORT4& operator=(XMUSHORT4&&) = default;
 
-            explicit XM_CONSTEXPR XMUSHORT4(uint64_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMUSHORT4(uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XMUSHORT4(_In_reads_(4) const uint16_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMUSHORT4(float _x, float _y, float _z, float _w);
-            explicit XMUSHORT4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMUSHORT4(uint64_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMUSHORT4(uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XMUSHORT4(_In_reads_(4) const uint16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMUSHORT4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMUSHORT4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMUSHORT4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMUSHORT4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -647,12 +647,12 @@ namespace DirectX
             XMXDECN4& operator=(XMXDECN4&&) = default;
 
             explicit XM_CONSTEXPR XMXDECN4(uint32_t Packed) : v(Packed) {}
-            XMXDECN4(float _x, float _y, float _z, float _w);
-            explicit XMXDECN4(_In_reads_(4) const float* pArray);
+            XMXDECN4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMXDECN4(_In_reads_(4) const float* pArray) noexcept;
 
-            operator uint32_t () const { return v; }
+            operator uint32_t () const noexcept { return v; }
 
-            XMXDECN4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMXDECN4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 10-10-10-2 bit components packed into a 32 bit integer
@@ -683,13 +683,13 @@ namespace DirectX
             XMXDEC4(XMXDEC4&&) = default;
             XMXDEC4& operator=(XMXDEC4&&) = default;
 
-            explicit XM_CONSTEXPR XMXDEC4(uint32_t Packed) : v(Packed) {}
-            XMXDEC4(float _x, float _y, float _z, float _w);
-            explicit XMXDEC4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMXDEC4(uint32_t Packed) noexcept : v(Packed) {}
+            XMXDEC4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMXDEC4(_In_reads_(4) const float* pArray) noexcept;
 
-            operator uint32_t () const { return v; }
+            operator uint32_t () const noexcept { return v; }
 
-            XMXDEC4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMXDEC4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 10-10-10-2 bit normalized components packed into a 32 bit integer
@@ -720,13 +720,13 @@ namespace DirectX
             XMDECN4(XMDECN4&&) = default;
             XMDECN4& operator=(XMDECN4&&) = default;
 
-            explicit XM_CONSTEXPR XMDECN4(uint32_t Packed) : v(Packed) {}
-            XMDECN4(float _x, float _y, float _z, float _w);
-            explicit XMDECN4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMDECN4(uint32_t Packed) noexcept : v(Packed) {}
+            XMDECN4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMDECN4(_In_reads_(4) const float* pArray) noexcept;
 
-            operator uint32_t () const { return v; }
+            operator uint32_t () const noexcept { return v; }
 
-            XMDECN4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMDECN4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 10-10-10-2 bit components packed into a 32 bit integer
@@ -757,13 +757,13 @@ namespace DirectX
             XMDEC4(XMDEC4&&) = default;
             XMDEC4& operator=(XMDEC4&&) = default;
 
-            explicit XM_CONSTEXPR XMDEC4(uint32_t Packed) : v(Packed) {}
-            XMDEC4(float _x, float _y, float _z, float _w);
-            explicit XMDEC4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMDEC4(uint32_t Packed) noexcept : v(Packed) {}
+            XMDEC4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMDEC4(_In_reads_(4) const float* pArray) noexcept;
 
-            operator uint32_t () const { return v; }
+            operator uint32_t () const noexcept { return v; }
 
-            XMDEC4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMDEC4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 10-10-10-2 bit normalized components packed into a 32 bit integer
@@ -794,13 +794,13 @@ namespace DirectX
             XMUDECN4(XMUDECN4&&) = default;
             XMUDECN4& operator=(XMUDECN4&&) = default;
 
-            explicit XM_CONSTEXPR XMUDECN4(uint32_t Packed) : v(Packed) {}
-            XMUDECN4(float _x, float _y, float _z, float _w);
-            explicit XMUDECN4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMUDECN4(uint32_t Packed) noexcept : v(Packed) {}
+            XMUDECN4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMUDECN4(_In_reads_(4) const float* pArray) noexcept;
 
-            operator uint32_t () const { return v; }
+            operator uint32_t () const noexcept { return v; }
 
-            XMUDECN4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMUDECN4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 10-10-10-2 bit components packed into a 32 bit integer
@@ -831,13 +831,13 @@ namespace DirectX
             XMUDEC4(XMUDEC4&&) = default;
             XMUDEC4& operator=(XMUDEC4&&) = default;
 
-            explicit XM_CONSTEXPR XMUDEC4(uint32_t Packed) : v(Packed) {}
-            XMUDEC4(float _x, float _y, float _z, float _w);
-            explicit XMUDEC4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMUDEC4(uint32_t Packed) noexcept : v(Packed) {}
+            XMUDEC4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMUDEC4(_In_reads_(4) const float* pArray) noexcept;
 
-            operator uint32_t () const { return v; }
+            operator uint32_t () const noexcept { return v; }
 
-            XMUDEC4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMUDEC4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -864,13 +864,13 @@ namespace DirectX
             XMBYTEN4(XMBYTEN4&&) = default;
             XMBYTEN4& operator=(XMBYTEN4&&) = default;
 
-            XM_CONSTEXPR XMBYTEN4(int8_t _x, int8_t _y, int8_t _z, int8_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XM_CONSTEXPR XMBYTEN4(uint32_t Packed) : v(Packed) {}
-            explicit XMBYTEN4(_In_reads_(4) const int8_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMBYTEN4(float _x, float _y, float _z, float _w);
-            explicit XMBYTEN4(_In_reads_(4) const float* pArray);
+            XM_CONSTEXPR XMBYTEN4(int8_t _x, int8_t _y, int8_t _z, int8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XM_CONSTEXPR XMBYTEN4(uint32_t Packed) noexcept : v(Packed) {}
+            explicit XMBYTEN4(_In_reads_(4) const int8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMBYTEN4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMBYTEN4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMBYTEN4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMBYTEN4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 8 bit signed integer components
@@ -896,13 +896,13 @@ namespace DirectX
             XMBYTE4(XMBYTE4&&) = default;
             XMBYTE4& operator=(XMBYTE4&&) = default;
 
-            XM_CONSTEXPR XMBYTE4(int8_t _x, int8_t _y, int8_t _z, int8_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XM_CONSTEXPR XMBYTE4(uint32_t Packed) : v(Packed) {}
-            explicit XMBYTE4(_In_reads_(4) const int8_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMBYTE4(float _x, float _y, float _z, float _w);
-            explicit XMBYTE4(_In_reads_(4) const float* pArray);
+            XM_CONSTEXPR XMBYTE4(int8_t _x, int8_t _y, int8_t _z, int8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XM_CONSTEXPR XMBYTE4(uint32_t Packed) noexcept : v(Packed) {}
+            explicit XMBYTE4(_In_reads_(4) const int8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMBYTE4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMBYTE4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMBYTE4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMBYTE4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 8 bit unsigned normalized integer components
@@ -928,13 +928,13 @@ namespace DirectX
             XMUBYTEN4(XMUBYTEN4&&) = default;
             XMUBYTEN4& operator=(XMUBYTEN4&&) = default;
 
-            XM_CONSTEXPR XMUBYTEN4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XM_CONSTEXPR XMUBYTEN4(uint32_t Packed) : v(Packed) {}
-            explicit XMUBYTEN4(_In_reads_(4) const uint8_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMUBYTEN4(float _x, float _y, float _z, float _w);
-            explicit XMUBYTEN4(_In_reads_(4) const float* pArray);
+            XM_CONSTEXPR XMUBYTEN4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XM_CONSTEXPR XMUBYTEN4(uint32_t Packed) noexcept : v(Packed) {}
+            explicit XMUBYTEN4(_In_reads_(4) const uint8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMUBYTEN4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMUBYTEN4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMUBYTEN4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMUBYTEN4& operator= (uint32_t Packed) noexcept { v = Packed; return *this; }
         };
 
         // 4D Vector; 8 bit unsigned integer components
@@ -960,13 +960,13 @@ namespace DirectX
             XMUBYTE4(XMUBYTE4&&) = default;
             XMUBYTE4& operator=(XMUBYTE4&&) = default;
 
-            XM_CONSTEXPR XMUBYTE4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XM_CONSTEXPR XMUBYTE4(uint32_t Packed) : v(Packed) {}
-            explicit XMUBYTE4(_In_reads_(4) const uint8_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMUBYTE4(float _x, float _y, float _z, float _w);
-            explicit XMUBYTE4(_In_reads_(4) const float* pArray);
+            XM_CONSTEXPR XMUBYTE4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XM_CONSTEXPR XMUBYTE4(uint32_t Packed)  noexcept : v(Packed) {}
+            explicit XMUBYTE4(_In_reads_(4) const uint8_t* pArray)  noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMUBYTE4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMUBYTE4(_In_reads_(4) const float* pArray) noexcept;
 
-            XMUBYTE4& operator= (uint32_t Packed) { v = Packed; return *this; }
+            XMUBYTE4& operator= (uint32_t Packed)  noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -993,15 +993,15 @@ namespace DirectX
             XMUNIBBLE4(XMUNIBBLE4&&) = default;
             XMUNIBBLE4& operator=(XMUNIBBLE4&&) = default;
 
-            explicit XM_CONSTEXPR XMUNIBBLE4(uint16_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMUNIBBLE4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XMUNIBBLE4(_In_reads_(4) const uint8_t* pArray) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
-            XMUNIBBLE4(float _x, float _y, float _z, float _w);
-            explicit XMUNIBBLE4(_In_reads_(4) const float* pArray);
+            explicit XM_CONSTEXPR XMUNIBBLE4(uint16_t Packed)  noexcept : v(Packed) {}
+            XM_CONSTEXPR XMUNIBBLE4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w)  noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit XMUNIBBLE4(_In_reads_(4) const uint8_t* pArray)  noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+            XMUNIBBLE4(float _x, float _y, float _z, float _w) noexcept;
+            explicit XMUNIBBLE4(_In_reads_(4) const float* pArray) noexcept;
 
-            operator uint16_t () const { return v; }
+            operator uint16_t () const  noexcept { return v; }
 
-            XMUNIBBLE4& operator= (uint16_t Packed) { v = Packed; return *this; }
+            XMUNIBBLE4& operator= (uint16_t Packed) noexcept { v = Packed; return *this; }
         };
 
         //------------------------------------------------------------------------------
@@ -1028,15 +1028,15 @@ namespace DirectX
             XMU555(XMU555&&) = default;
             XMU555& operator=(XMU555&&) = default;
 
-            explicit XM_CONSTEXPR XMU555(uint16_t Packed) : v(Packed) {}
-            XM_CONSTEXPR XMU555(uint8_t _x, uint8_t _y, uint8_t _z, bool _w) : x(_x), y(_y), z(_z), w(_w ? 0x1 : 0) {}
-            XMU555(_In_reads_(3) const uint8_t* pArray, _In_ bool _w) : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(_w ? 0x1 : 0) {}
-            XMU555(float _x, float _y, float _z, bool _w);
-            XMU555(_In_reads_(3) const float* pArray, _In_ bool _w);
+            explicit XM_CONSTEXPR XMU555(uint16_t Packed) noexcept : v(Packed) {}
+            XM_CONSTEXPR XMU555(uint8_t _x, uint8_t _y, uint8_t _z, bool _w) noexcept : x(_x), y(_y), z(_z), w(_w ? 0x1 : 0) {}
+            XMU555(_In_reads_(3) const uint8_t* pArray, _In_ bool _w) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(_w ? 0x1 : 0) {}
+            XMU555(float _x, float _y, float _z, bool _w) noexcept;
+            XMU555(_In_reads_(3) const float* pArray, _In_ bool _w) noexcept;
 
-            operator uint16_t () const { return v; }
+            operator uint16_t () const noexcept { return v; }
 
-            XMU555& operator= (uint16_t Packed) { v = Packed; return *this; }
+            XMU555& operator= (uint16_t Packed) noexcept { v = Packed; return *this; }
         };
 
 #pragma warning(pop)
@@ -1048,16 +1048,16 @@ namespace DirectX
          *
          ****************************************************************************/
 
-        float           XMConvertHalfToFloat(HALF Value);
+        float           XMConvertHalfToFloat(HALF Value) noexcept;
         float* XMConvertHalfToFloatStream(_Out_writes_bytes_(sizeof(float) + OutputStride * (HalfCount - 1)) float* pOutputStream,
             _In_ size_t OutputStride,
             _In_reads_bytes_(sizeof(HALF) + InputStride * (HalfCount - 1)) const HALF* pInputStream,
-            _In_ size_t InputStride, _In_ size_t HalfCount);
-        HALF            XMConvertFloatToHalf(float Value);
+            _In_ size_t InputStride, _In_ size_t HalfCount) noexcept;
+        HALF            XMConvertFloatToHalf(float Value) noexcept;
         HALF* XMConvertFloatToHalfStream(_Out_writes_bytes_(sizeof(HALF) + OutputStride * (FloatCount - 1)) HALF* pOutputStream,
             _In_ size_t OutputStride,
             _In_reads_bytes_(sizeof(float) + InputStride * (FloatCount - 1)) const float* pInputStream,
-            _In_ size_t InputStride, _In_ size_t FloatCount);
+            _In_ size_t InputStride, _In_ size_t FloatCount) noexcept;
 
         /****************************************************************************
          *
@@ -1065,45 +1065,45 @@ namespace DirectX
          *
          ****************************************************************************/
 
-        XMVECTOR    XM_CALLCONV     XMLoadColor(_In_ const XMCOLOR* pSource);
+        XMVECTOR    XM_CALLCONV     XMLoadColor(_In_ const XMCOLOR* pSource) noexcept;
 
-        XMVECTOR    XM_CALLCONV     XMLoadHalf2(_In_ const XMHALF2* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadShortN2(_In_ const XMSHORTN2* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadShort2(_In_ const XMSHORT2* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUShortN2(_In_ const XMUSHORTN2* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUShort2(_In_ const XMUSHORT2* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadByteN2(_In_ const XMBYTEN2* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadByte2(_In_ const XMBYTE2* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUByteN2(_In_ const XMUBYTEN2* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUByte2(_In_ const XMUBYTE2* pSource);
+        XMVECTOR    XM_CALLCONV     XMLoadHalf2(_In_ const XMHALF2* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadShortN2(_In_ const XMSHORTN2* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadShort2(_In_ const XMSHORT2* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUShortN2(_In_ const XMUSHORTN2* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUShort2(_In_ const XMUSHORT2* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadByteN2(_In_ const XMBYTEN2* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadByte2(_In_ const XMBYTE2* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUByteN2(_In_ const XMUBYTEN2* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUByte2(_In_ const XMUBYTE2* pSource) noexcept;
 
-        XMVECTOR    XM_CALLCONV     XMLoadU565(_In_ const XMU565* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadFloat3PK(_In_ const XMFLOAT3PK* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadFloat3SE(_In_ const XMFLOAT3SE* pSource);
+        XMVECTOR    XM_CALLCONV     XMLoadU565(_In_ const XMU565* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadFloat3PK(_In_ const XMFLOAT3PK* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadFloat3SE(_In_ const XMFLOAT3SE* pSource) noexcept;
 
-        XMVECTOR    XM_CALLCONV     XMLoadHalf4(_In_ const XMHALF4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadShortN4(_In_ const XMSHORTN4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadShort4(_In_ const XMSHORT4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUShortN4(_In_ const XMUSHORTN4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUShort4(_In_ const XMUSHORT4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadXDecN4(_In_ const XMXDECN4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUDecN4(_In_ const XMUDECN4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUDecN4_XR(_In_ const XMUDECN4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUDec4(_In_ const XMUDEC4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadByteN4(_In_ const XMBYTEN4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadByte4(_In_ const XMBYTE4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUByteN4(_In_ const XMUBYTEN4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUByte4(_In_ const XMUBYTE4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadUNibble4(_In_ const XMUNIBBLE4* pSource);
-        XMVECTOR    XM_CALLCONV     XMLoadU555(_In_ const XMU555* pSource);
+        XMVECTOR    XM_CALLCONV     XMLoadHalf4(_In_ const XMHALF4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadShortN4(_In_ const XMSHORTN4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadShort4(_In_ const XMSHORT4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUShortN4(_In_ const XMUSHORTN4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUShort4(_In_ const XMUSHORT4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadXDecN4(_In_ const XMXDECN4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUDecN4(_In_ const XMUDECN4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUDecN4_XR(_In_ const XMUDECN4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUDec4(_In_ const XMUDEC4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadByteN4(_In_ const XMBYTEN4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadByte4(_In_ const XMBYTE4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUByteN4(_In_ const XMUBYTEN4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUByte4(_In_ const XMUBYTE4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadUNibble4(_In_ const XMUNIBBLE4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV     XMLoadU555(_In_ const XMU555* pSource) noexcept;
 
 #pragma warning(push)
 #pragma warning(disable : 4996)
         // C4996: ignore deprecation warning
 
-        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadDecN4(_In_ const XMDECN4* pSource);
-        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadDec4(_In_ const XMDEC4* pSource);
-        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadXDec4(_In_ const XMXDEC4* pSource);
+        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadDecN4(_In_ const XMDECN4* pSource) noexcept;
+        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadDec4(_In_ const XMDEC4* pSource) noexcept;
+        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadXDec4(_In_ const XMXDEC4* pSource) noexcept;
 #pragma warning(pop)
 
         /****************************************************************************
@@ -1112,45 +1112,45 @@ namespace DirectX
          *
          ****************************************************************************/
 
-        void    XM_CALLCONV     XMStoreColor(_Out_ XMCOLOR* pDestination, _In_ FXMVECTOR V);
+        void    XM_CALLCONV     XMStoreColor(_Out_ XMCOLOR* pDestination, _In_ FXMVECTOR V) noexcept;
 
-        void    XM_CALLCONV     XMStoreHalf2(_Out_ XMHALF2* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreShortN2(_Out_ XMSHORTN2* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreShort2(_Out_ XMSHORT2* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUShortN2(_Out_ XMUSHORTN2* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUShort2(_Out_ XMUSHORT2* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreByteN2(_Out_ XMBYTEN2* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreByte2(_Out_ XMBYTE2* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUByteN2(_Out_ XMUBYTEN2* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUByte2(_Out_ XMUBYTE2* pDestination, _In_ FXMVECTOR V);
+        void    XM_CALLCONV     XMStoreHalf2(_Out_ XMHALF2* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreShortN2(_Out_ XMSHORTN2* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreShort2(_Out_ XMSHORT2* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUShortN2(_Out_ XMUSHORTN2* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUShort2(_Out_ XMUSHORT2* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreByteN2(_Out_ XMBYTEN2* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreByte2(_Out_ XMBYTE2* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUByteN2(_Out_ XMUBYTEN2* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUByte2(_Out_ XMUBYTE2* pDestination, _In_ FXMVECTOR V) noexcept;
 
-        void    XM_CALLCONV     XMStoreU565(_Out_ XMU565* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreFloat3PK(_Out_ XMFLOAT3PK* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreFloat3SE(_Out_ XMFLOAT3SE* pDestination, _In_ FXMVECTOR V);
+        void    XM_CALLCONV     XMStoreU565(_Out_ XMU565* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreFloat3PK(_Out_ XMFLOAT3PK* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreFloat3SE(_Out_ XMFLOAT3SE* pDestination, _In_ FXMVECTOR V) noexcept;
 
-        void    XM_CALLCONV     XMStoreHalf4(_Out_ XMHALF4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreShortN4(_Out_ XMSHORTN4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreShort4(_Out_ XMSHORT4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUShortN4(_Out_ XMUSHORTN4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUShort4(_Out_ XMUSHORT4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreXDecN4(_Out_ XMXDECN4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUDecN4(_Out_ XMUDECN4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUDecN4_XR(_Out_ XMUDECN4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUDec4(_Out_ XMUDEC4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreByteN4(_Out_ XMBYTEN4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreByte4(_Out_ XMBYTE4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUByteN4(_Out_ XMUBYTEN4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUByte4(_Out_ XMUBYTE4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreUNibble4(_Out_ XMUNIBBLE4* pDestination, _In_ FXMVECTOR V);
-        void    XM_CALLCONV     XMStoreU555(_Out_ XMU555* pDestination, _In_ FXMVECTOR V);
+        void    XM_CALLCONV     XMStoreHalf4(_Out_ XMHALF4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreShortN4(_Out_ XMSHORTN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreShort4(_Out_ XMSHORT4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUShortN4(_Out_ XMUSHORTN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUShort4(_Out_ XMUSHORT4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreXDecN4(_Out_ XMXDECN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUDecN4(_Out_ XMUDECN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUDecN4_XR(_Out_ XMUDECN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUDec4(_Out_ XMUDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreByteN4(_Out_ XMBYTEN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreByte4(_Out_ XMBYTE4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUByteN4(_Out_ XMUBYTEN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUByte4(_Out_ XMUBYTE4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreUNibble4(_Out_ XMUNIBBLE4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV     XMStoreU555(_Out_ XMU555* pDestination, _In_ FXMVECTOR V) noexcept;
 
 #pragma warning(push)
 #pragma warning(disable : 4996)
         // C4996: ignore deprecation warning
 
-        void    XM_DEPRECATED XM_CALLCONV XMStoreDecN4(_Out_ XMDECN4* pDestination, _In_ FXMVECTOR V);
-        void    XM_DEPRECATED XM_CALLCONV XMStoreDec4(_Out_ XMDEC4* pDestination, _In_ FXMVECTOR V);
-        void    XM_DEPRECATED XM_CALLCONV XMStoreXDec4(_Out_ XMXDEC4* pDestination, _In_ FXMVECTOR V);
+        void    XM_DEPRECATED XM_CALLCONV XMStoreDecN4(_Out_ XMDECN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_DEPRECATED XM_CALLCONV XMStoreDec4(_Out_ XMDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_DEPRECATED XM_CALLCONV XMStoreXDec4(_Out_ XMXDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
 #pragma warning(pop)
 
         /****************************************************************************

--- a/Inc/DirectXPackedVector.inl
+++ b/Inc/DirectXPackedVector.inl
@@ -17,10 +17,7 @@
 
  //------------------------------------------------------------------------------
 
-inline float XMConvertHalfToFloat
-(
-    HALF Value
-)
+inline float XMConvertHalfToFloat(HALF Value) noexcept
 {
 #if defined(_XM_F16C_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     __m128i V1 = _mm_cvtsi32_si128(static_cast<int>(Value));
@@ -83,7 +80,7 @@ inline float* XMConvertHalfToFloatStream
     const HALF* pInputStream,
     size_t      InputStride,
     size_t      HalfCount
-)
+) noexcept
 {
     assert(pOutputStream);
     assert(pInputStream);
@@ -386,10 +383,7 @@ inline float* XMConvertHalfToFloatStream
 
 //------------------------------------------------------------------------------
 
-inline HALF XMConvertFloatToHalf
-(
-    float Value
-)
+inline HALF XMConvertFloatToHalf(float Value) noexcept
 {
 #if defined(_XM_F16C_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     __m128 V1 = _mm_set_ss(Value);
@@ -452,7 +446,7 @@ inline HALF* XMConvertFloatToHalfStream
     const float* pInputStream,
     size_t       InputStride,
     size_t       FloatCount
-)
+) noexcept
 {
     assert(pOutputStream);
     assert(pInputStream);
@@ -767,10 +761,7 @@ inline HALF* XMConvertFloatToHalfStream
 #endif
 
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadColor
-(
-    const XMCOLOR* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadColor(const XMCOLOR* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -810,10 +801,7 @@ inline XMVECTOR XM_CALLCONV XMLoadColor
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadHalf2
-(
-    const XMHALF2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadHalf2(const XMHALF2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_F16C_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
@@ -832,10 +820,7 @@ inline XMVECTOR XM_CALLCONV XMLoadHalf2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadShortN2
-(
-    const XMSHORTN2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadShortN2(const XMSHORTN2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -874,10 +859,7 @@ inline XMVECTOR XM_CALLCONV XMLoadShortN2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadShort2
-(
-    const XMSHORT2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadShort2(const XMSHORT2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -912,10 +894,7 @@ inline XMVECTOR XM_CALLCONV XMLoadShort2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUShortN2
-(
-    const XMUSHORTN2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUShortN2(const XMUSHORTN2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -955,10 +934,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUShortN2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUShort2
-(
-    const XMUSHORT2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUShort2(const XMUSHORT2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -995,10 +971,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUShort2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadByteN2
-(
-    const XMBYTEN2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadByteN2(const XMBYTEN2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1039,10 +1012,7 @@ inline XMVECTOR XM_CALLCONV XMLoadByteN2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadByte2
-(
-    const XMBYTE2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadByte2(const XMBYTE2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1079,10 +1049,7 @@ inline XMVECTOR XM_CALLCONV XMLoadByte2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUByteN2
-(
-    const XMUBYTEN2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUByteN2(const XMUBYTEN2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1120,10 +1087,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUByteN2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUByte2
-(
-    const XMUBYTE2* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUByte2(const XMUBYTE2* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1160,10 +1124,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUByte2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadU565
-(
-    const XMU565* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadU565(const XMU565* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1199,10 +1160,7 @@ inline XMVECTOR XM_CALLCONV XMLoadU565
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat3PK
-(
-    const XMFLOAT3PK* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadFloat3PK(const XMFLOAT3PK* pSource) noexcept
 {
     assert(pSource);
 
@@ -1317,10 +1275,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat3PK
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadFloat3SE
-(
-    const XMFLOAT3SE* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadFloat3SE(const XMFLOAT3SE* pSource) noexcept
 {
     assert(pSource);
 
@@ -1338,10 +1293,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat3SE
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadHalf4
-(
-    const XMHALF4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadHalf4(const XMHALF4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_F16C_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
@@ -1360,10 +1312,7 @@ inline XMVECTOR XM_CALLCONV XMLoadHalf4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadShortN4
-(
-    const XMSHORTN4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadShortN4(const XMSHORTN4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1402,10 +1351,7 @@ inline XMVECTOR XM_CALLCONV XMLoadShortN4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadShort4
-(
-    const XMSHORT4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadShort4(const XMSHORT4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1440,10 +1386,7 @@ inline XMVECTOR XM_CALLCONV XMLoadShort4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUShortN4
-(
-    const XMUSHORTN4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUShortN4(const XMUSHORTN4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1481,10 +1424,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUShortN4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUShort4
-(
-    const XMUSHORT4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUShort4(const XMUSHORT4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1520,10 +1460,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUShort4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadXDecN4
-(
-    const XMXDECN4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadXDecN4(const XMXDECN4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1572,10 +1509,7 @@ inline XMVECTOR XM_CALLCONV XMLoadXDecN4
 // C4996: ignore deprecation warning
 
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadXDec4
-(
-    const XMXDEC4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadXDec4(const XMXDEC4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1624,10 +1558,7 @@ inline XMVECTOR XM_CALLCONV XMLoadXDec4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUDecN4
-(
-    const XMUDECN4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUDecN4(const XMUDECN4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1671,10 +1602,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUDecN4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUDecN4_XR
-(
-    const XMUDECN4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUDecN4_XR(const XMUDECN4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1725,10 +1653,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUDecN4_XR
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUDec4
-(
-    const XMUDEC4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUDec4(const XMUDEC4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1771,10 +1696,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUDec4
 // C4996: ignore deprecation warning
 
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadDecN4
-(
-    const XMDECN4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadDecN4(const XMDECN4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1823,10 +1745,7 @@ inline XMVECTOR XM_CALLCONV XMLoadDecN4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadDec4
-(
-    const XMDEC4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadDec4(const XMDEC4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1873,10 +1792,7 @@ inline XMVECTOR XM_CALLCONV XMLoadDec4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUByteN4
-(
-    const XMUBYTEN4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUByteN4(const XMUBYTEN4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1913,10 +1829,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUByteN4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUByte4
-(
-    const XMUBYTE4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUByte4(const XMUBYTE4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1952,10 +1865,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUByte4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadByteN4
-(
-    const XMBYTEN4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadByteN4(const XMBYTEN4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -1994,10 +1904,7 @@ inline XMVECTOR XM_CALLCONV XMLoadByteN4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadByte4
-(
-    const XMBYTE4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadByte4(const XMBYTE4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2033,10 +1940,7 @@ inline XMVECTOR XM_CALLCONV XMLoadByte4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadUNibble4
-(
-    const XMUNIBBLE4* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadUNibble4(const XMUNIBBLE4* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2072,10 +1976,7 @@ inline XMVECTOR XM_CALLCONV XMLoadUNibble4
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMVECTOR XM_CALLCONV XMLoadU555
-(
-    const XMU555* pSource
-)
+inline XMVECTOR XM_CALLCONV XMLoadU555(const XMU555* pSource) noexcept
 {
     assert(pSource);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2123,7 +2024,7 @@ inline void XM_CALLCONV XMStoreColor
 (
     XMCOLOR* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2176,7 +2077,7 @@ inline void XM_CALLCONV XMStoreHalf2
 (
     XMHALF2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_F16C_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
@@ -2194,7 +2095,7 @@ inline void XM_CALLCONV XMStoreShortN2
 (
     XMSHORTN2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2232,7 +2133,7 @@ inline void XM_CALLCONV XMStoreShort2
 (
     XMSHORT2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2270,7 +2171,7 @@ inline void XM_CALLCONV XMStoreUShortN2
 (
     XMUSHORTN2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2314,7 +2215,7 @@ inline void XM_CALLCONV XMStoreUShort2
 (
     XMUSHORT2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2353,7 +2254,7 @@ inline void XM_CALLCONV XMStoreByteN2
 (
     XMBYTEN2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2397,7 +2298,7 @@ inline void XM_CALLCONV XMStoreByte2
 (
     XMBYTE2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2437,7 +2338,7 @@ inline void XM_CALLCONV XMStoreUByteN2
 (
     XMUBYTEN2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2483,7 +2384,7 @@ inline void XM_CALLCONV XMStoreUByte2
 (
     XMUBYTE2* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2523,7 +2424,7 @@ inline void XM_CALLCONV XMStoreU565
 (
     XMU565* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     static const XMVECTORF32 Max = { { { 31.0f, 63.0f, 31.0f, 0.0f } } };
@@ -2576,7 +2477,7 @@ inline void XM_CALLCONV XMStoreFloat3PK
 (
     XMFLOAT3PK* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 
@@ -2692,7 +2593,7 @@ inline void XM_CALLCONV XMStoreFloat3SE
 (
     XMFLOAT3SE* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 
@@ -2732,7 +2633,7 @@ inline void XM_CALLCONV XMStoreHalf4
 (
     XMHALF4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_F16C_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
@@ -2755,7 +2656,7 @@ inline void XM_CALLCONV XMStoreShortN4
 (
     XMSHORTN4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2795,7 +2696,7 @@ inline void XM_CALLCONV XMStoreShort4
 (
     XMSHORT4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2835,7 +2736,7 @@ inline void XM_CALLCONV XMStoreUShortN4
 (
     XMUSHORTN4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2883,7 +2784,7 @@ inline void XM_CALLCONV XMStoreUShort4
 (
     XMUSHORT4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -2926,7 +2827,7 @@ inline void XM_CALLCONV XMStoreXDecN4
 (
     XMXDECN4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     static const XMVECTORF32 Min = { { { -1.0f, -1.0f, -1.0f, 0.0f } } };
@@ -2999,7 +2900,7 @@ inline void XM_CALLCONV XMStoreXDec4
 (
     XMXDEC4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     static const XMVECTORF32 MinXDec4 = { { { -511.0f, -511.0f, -511.0f, 0.0f } } };
@@ -3069,7 +2970,7 @@ inline void XM_CALLCONV XMStoreUDecN4
 (
     XMUDECN4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -3137,7 +3038,7 @@ inline void XM_CALLCONV XMStoreUDecN4_XR
 (
     XMUDECN4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     static const XMVECTORF32 Scale = { { { 510.0f, 510.0f, 510.0f, 3.0f } } };
@@ -3211,7 +3112,7 @@ inline void XM_CALLCONV XMStoreUDec4
 (
     XMUDEC4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     static const XMVECTORF32 MaxUDec4 = { { { 1023.0f, 1023.0f, 1023.0f, 3.0f } } };
@@ -3282,7 +3183,7 @@ inline void XM_CALLCONV XMStoreDecN4
 (
     XMDECN4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -3343,7 +3244,7 @@ inline void XM_CALLCONV XMStoreDec4
 (
     XMDEC4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     static const XMVECTORF32 MinDec4 = { { { -511.0f, -511.0f, -511.0f, -1.0f } } };
@@ -3406,7 +3307,7 @@ inline void XM_CALLCONV XMStoreUByteN4
 (
     XMUBYTEN4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -3463,7 +3364,7 @@ inline void XM_CALLCONV XMStoreUByte4
 (
     XMUBYTE4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -3518,7 +3419,7 @@ inline void XM_CALLCONV XMStoreByteN4
 (
     XMBYTEN4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -3573,7 +3474,7 @@ inline void XM_CALLCONV XMStoreByte4
 (
     XMBYTE4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
 #if defined(_XM_NO_INTRINSICS_)
@@ -3626,7 +3527,7 @@ inline void XM_CALLCONV XMStoreUNibble4
 (
     XMUNIBBLE4* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     static const XMVECTORF32 Max = { { { 15.0f, 15.0f, 15.0f, 15.0f } } };
@@ -3682,7 +3583,7 @@ inline void XM_CALLCONV XMStoreU555
 (
     XMU555* pDestination,
     FXMVECTOR V
-)
+) noexcept
 {
     assert(pDestination);
     static const XMVECTORF32 Max = { { { 31.0f, 31.0f, 31.0f, 1.0f } } };
@@ -3750,17 +3651,14 @@ inline XMCOLOR::XMCOLOR
     float _g,
     float _b,
     float _a
-)
+) noexcept
 {
     XMStoreColor(this, XMVectorSet(_r, _g, _b, _a));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMCOLOR::XMCOLOR
-(
-    const float* pArray
-)
+inline XMCOLOR::XMCOLOR(const float* pArray) noexcept
 {
     XMStoreColor(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -3777,7 +3675,7 @@ inline XMHALF2::XMHALF2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     x = XMConvertFloatToHalf(_x);
     y = XMConvertFloatToHalf(_y);
@@ -3785,10 +3683,7 @@ inline XMHALF2::XMHALF2
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMHALF2::XMHALF2
-(
-    const float* pArray
-)
+inline XMHALF2::XMHALF2(const float* pArray) noexcept
 {
     assert(pArray != nullptr);
     x = XMConvertFloatToHalf(pArray[0]);
@@ -3807,17 +3702,14 @@ inline XMSHORTN2::XMSHORTN2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     XMStoreShortN2(this, XMVectorSet(_x, _y, 0.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMSHORTN2::XMSHORTN2
-(
-    const float* pArray
-)
+inline XMSHORTN2::XMSHORTN2(const float* pArray) noexcept
 {
     XMStoreShortN2(this, XMLoadFloat2(reinterpret_cast<const XMFLOAT2*>(pArray)));
 }
@@ -3834,17 +3726,14 @@ inline XMSHORT2::XMSHORT2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     XMStoreShort2(this, XMVectorSet(_x, _y, 0.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMSHORT2::XMSHORT2
-(
-    const float* pArray
-)
+inline XMSHORT2::XMSHORT2(const float* pArray) noexcept
 {
     XMStoreShort2(this, XMLoadFloat2(reinterpret_cast<const XMFLOAT2*>(pArray)));
 }
@@ -3861,17 +3750,14 @@ inline XMUSHORTN2::XMUSHORTN2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     XMStoreUShortN2(this, XMVectorSet(_x, _y, 0.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUSHORTN2::XMUSHORTN2
-(
-    const float* pArray
-)
+inline XMUSHORTN2::XMUSHORTN2(const float* pArray) noexcept
 {
     XMStoreUShortN2(this, XMLoadFloat2(reinterpret_cast<const XMFLOAT2*>(pArray)));
 }
@@ -3888,17 +3774,14 @@ inline XMUSHORT2::XMUSHORT2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     XMStoreUShort2(this, XMVectorSet(_x, _y, 0.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUSHORT2::XMUSHORT2
-(
-    const float* pArray
-)
+inline XMUSHORT2::XMUSHORT2(const float* pArray) noexcept
 {
     XMStoreUShort2(this, XMLoadFloat2(reinterpret_cast<const XMFLOAT2*>(pArray)));
 }
@@ -3915,17 +3798,14 @@ inline XMBYTEN2::XMBYTEN2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     XMStoreByteN2(this, XMVectorSet(_x, _y, 0.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMBYTEN2::XMBYTEN2
-(
-    const float* pArray
-)
+inline XMBYTEN2::XMBYTEN2(const float* pArray) noexcept
 {
     XMStoreByteN2(this, XMLoadFloat2(reinterpret_cast<const XMFLOAT2*>(pArray)));
 }
@@ -3942,17 +3822,14 @@ inline XMBYTE2::XMBYTE2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     XMStoreByte2(this, XMVectorSet(_x, _y, 0.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMBYTE2::XMBYTE2
-(
-    const float* pArray
-)
+inline XMBYTE2::XMBYTE2(const float* pArray) noexcept
 {
     XMStoreByte2(this, XMLoadFloat2(reinterpret_cast<const XMFLOAT2*>(pArray)));
 }
@@ -3969,17 +3846,14 @@ inline XMUBYTEN2::XMUBYTEN2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     XMStoreUByteN2(this, XMVectorSet(_x, _y, 0.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUBYTEN2::XMUBYTEN2
-(
-    const float* pArray
-)
+inline XMUBYTEN2::XMUBYTEN2(const float* pArray) noexcept
 {
     XMStoreUByteN2(this, XMLoadFloat2(reinterpret_cast<const XMFLOAT2*>(pArray)));
 }
@@ -3996,17 +3870,14 @@ inline XMUBYTE2::XMUBYTE2
 (
     float _x,
     float _y
-)
+) noexcept
 {
     XMStoreUByte2(this, XMVectorSet(_x, _y, 0.0f, 0.0f));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUBYTE2::XMUBYTE2
-(
-    const float* pArray
-)
+inline XMUBYTE2::XMUBYTE2(const float* pArray) noexcept
 {
     XMStoreUByte2(this, XMLoadFloat2(reinterpret_cast<const XMFLOAT2*>(pArray)));
 }
@@ -4022,16 +3893,13 @@ inline XMU565::XMU565
     float _x,
     float _y,
     float _z
-)
+) noexcept
 {
     XMStoreU565(this, XMVectorSet(_x, _y, _z, 0.0f));
 }
 
 _Use_decl_annotations_
-inline XMU565::XMU565
-(
-    const float* pArray
-)
+inline XMU565::XMU565(const float* pArray) noexcept
 {
     XMStoreU565(this, XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(pArray)));
 }
@@ -4047,16 +3915,13 @@ inline XMFLOAT3PK::XMFLOAT3PK
     float _x,
     float _y,
     float _z
-)
+) noexcept
 {
     XMStoreFloat3PK(this, XMVectorSet(_x, _y, _z, 0.0f));
 }
 
 _Use_decl_annotations_
-inline XMFLOAT3PK::XMFLOAT3PK
-(
-    const float* pArray
-)
+inline XMFLOAT3PK::XMFLOAT3PK(const float* pArray) noexcept
 {
     XMStoreFloat3PK(this, XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(pArray)));
 }
@@ -4072,16 +3937,13 @@ inline XMFLOAT3SE::XMFLOAT3SE
     float _x,
     float _y,
     float _z
-)
+) noexcept
 {
     XMStoreFloat3SE(this, XMVectorSet(_x, _y, _z, 0.0f));
 }
 
 _Use_decl_annotations_
-inline XMFLOAT3SE::XMFLOAT3SE
-(
-    const float* pArray
-)
+inline XMFLOAT3SE::XMFLOAT3SE(const float* pArray) noexcept
 {
     XMStoreFloat3SE(this, XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(pArray)));
 }
@@ -4100,7 +3962,7 @@ inline XMHALF4::XMHALF4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     x = XMConvertFloatToHalf(_x);
     y = XMConvertFloatToHalf(_y);
@@ -4111,10 +3973,7 @@ inline XMHALF4::XMHALF4
 //------------------------------------------------------------------------------
 
 _Use_decl_annotations_
-inline XMHALF4::XMHALF4
-(
-    const float* pArray
-)
+inline XMHALF4::XMHALF4(const float* pArray) noexcept
 {
     XMConvertFloatToHalfStream(&x, sizeof(HALF), pArray, sizeof(float), 4);
 }
@@ -4133,17 +3992,14 @@ inline XMSHORTN4::XMSHORTN4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreShortN4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMSHORTN4::XMSHORTN4
-(
-    const float* pArray
-)
+inline XMSHORTN4::XMSHORTN4(const float* pArray) noexcept
 {
     XMStoreShortN4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4162,17 +4018,14 @@ inline XMSHORT4::XMSHORT4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreShort4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMSHORT4::XMSHORT4
-(
-    const float* pArray
-)
+inline XMSHORT4::XMSHORT4(const float* pArray) noexcept
 {
     XMStoreShort4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4191,17 +4044,14 @@ inline XMUSHORTN4::XMUSHORTN4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreUShortN4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUSHORTN4::XMUSHORTN4
-(
-    const float* pArray
-)
+inline XMUSHORTN4::XMUSHORTN4(const float* pArray) noexcept
 {
     XMStoreUShortN4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4220,17 +4070,14 @@ inline XMUSHORT4::XMUSHORT4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreUShort4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUSHORT4::XMUSHORT4
-(
-    const float* pArray
-)
+inline XMUSHORT4::XMUSHORT4(const float* pArray) noexcept
 {
     XMStoreUShort4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4249,17 +4096,14 @@ inline XMXDECN4::XMXDECN4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreXDecN4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMXDECN4::XMXDECN4
-(
-    const float* pArray
-)
+inline XMXDECN4::XMXDECN4(const float* pArray) noexcept
 {
     XMStoreXDecN4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4282,17 +4126,14 @@ inline XMXDEC4::XMXDEC4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreXDec4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMXDEC4::XMXDEC4
-(
-    const float* pArray
-)
+inline XMXDEC4::XMXDEC4(const float* pArray) noexcept
 {
     XMStoreXDec4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4311,17 +4152,14 @@ inline XMDECN4::XMDECN4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreDecN4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMDECN4::XMDECN4
-(
-    const float* pArray
-)
+inline XMDECN4::XMDECN4(const float* pArray) noexcept
 {
     XMStoreDecN4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4340,17 +4178,14 @@ inline XMDEC4::XMDEC4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreDec4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMDEC4::XMDEC4
-(
-    const float* pArray
-)
+inline XMDEC4::XMDEC4(const float* pArray) noexcept
 {
     XMStoreDec4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4371,17 +4206,14 @@ inline XMUDECN4::XMUDECN4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreUDecN4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUDECN4::XMUDECN4
-(
-    const float* pArray
-)
+inline XMUDECN4::XMUDECN4(const float* pArray) noexcept
 {
     XMStoreUDecN4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4400,17 +4232,14 @@ inline XMUDEC4::XMUDEC4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreUDec4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUDEC4::XMUDEC4
-(
-    const float* pArray
-)
+inline XMUDEC4::XMUDEC4(const float* pArray) noexcept
 {
     XMStoreUDec4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4429,17 +4258,14 @@ inline XMBYTEN4::XMBYTEN4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreByteN4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMBYTEN4::XMBYTEN4
-(
-    const float* pArray
-)
+inline XMBYTEN4::XMBYTEN4(const float* pArray) noexcept
 {
     XMStoreByteN4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4458,17 +4284,14 @@ inline XMBYTE4::XMBYTE4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreByte4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMBYTE4::XMBYTE4
-(
-    const float* pArray
-)
+inline XMBYTE4::XMBYTE4(const float* pArray) noexcept
 {
     XMStoreByte4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4487,17 +4310,14 @@ inline XMUBYTEN4::XMUBYTEN4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreUByteN4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUBYTEN4::XMUBYTEN4
-(
-    const float* pArray
-)
+inline XMUBYTEN4::XMUBYTEN4(const float* pArray) noexcept
 {
     XMStoreUByteN4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4516,17 +4336,14 @@ inline XMUBYTE4::XMUBYTE4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreUByte4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUBYTE4::XMUBYTE4
-(
-    const float* pArray
-)
+inline XMUBYTE4::XMUBYTE4(const float* pArray) noexcept
 {
     XMStoreUByte4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4545,17 +4362,14 @@ inline XMUNIBBLE4::XMUNIBBLE4
     float _y,
     float _z,
     float _w
-)
+) noexcept
 {
     XMStoreUNibble4(this, XMVectorSet(_x, _y, _z, _w));
 }
 
 //------------------------------------------------------------------------------
 _Use_decl_annotations_
-inline XMUNIBBLE4::XMUNIBBLE4
-(
-    const float* pArray
-)
+inline XMUNIBBLE4::XMUNIBBLE4(const float* pArray) noexcept
 {
     XMStoreUNibble4(this, XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(pArray)));
 }
@@ -4574,7 +4388,7 @@ inline XMU555::XMU555
     float _y,
     float _z,
     bool _w
-)
+) noexcept
 {
     XMStoreU555(this, XMVectorSet(_x, _y, _z, ((_w) ? 1.0f : 0.0f)));
 }
@@ -4585,7 +4399,7 @@ inline XMU555::XMU555
 (
     const float* pArray,
     bool _w
-)
+) noexcept
 {
     XMVECTOR V = XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(pArray));
     XMStoreU555(this, XMVectorSetW(V, ((_w) ? 1.0f : 0.0f)));


### PR DESCRIPTION
When trying to make a library ``noexcept``, it can be difficult to do without a lot of warning suppression if you don't have all the functions you call annotated. I hit this trying to make SimpleMath noexcept.

These changes adds ``noexcept`` to all the DirectXMath functions.