### PR TITLE
Retired VS 2015 support

### DIFF
--- a/Inc/DirectXCollision.h
+++ b/Inc/DirectXCollision.h
@@ -54,7 +54,7 @@ namespace DirectX
         BoundingSphere(BoundingSphere&&) = default;
         BoundingSphere& operator=(BoundingSphere&&) = default;
 
-        XM_CONSTEXPR BoundingSphere(_In_ const XMFLOAT3& center, _In_ float radius) noexcept
+        constexpr BoundingSphere(_In_ const XMFLOAT3& center, _In_ float radius) noexcept
             : Center(center), Radius(radius) {}
 
         // Methods
@@ -118,7 +118,7 @@ namespace DirectX
         BoundingBox(BoundingBox&&) = default;
         BoundingBox& operator=(BoundingBox&&) = default;
 
-        XM_CONSTEXPR BoundingBox(_In_ const XMFLOAT3& center, _In_ const XMFLOAT3& extents) noexcept
+        constexpr BoundingBox(_In_ const XMFLOAT3& center, _In_ const XMFLOAT3& extents) noexcept
             : Center(center), Extents(extents) {}
 
         // Methods
@@ -183,7 +183,7 @@ namespace DirectX
         BoundingOrientedBox(BoundingOrientedBox&&) = default;
         BoundingOrientedBox& operator=(BoundingOrientedBox&&) = default;
 
-        XM_CONSTEXPR BoundingOrientedBox(_In_ const XMFLOAT3& _Center, _In_ const XMFLOAT3& _Extents, _In_ const XMFLOAT4& _Orientation) noexcept
+        constexpr BoundingOrientedBox(_In_ const XMFLOAT3& _Center, _In_ const XMFLOAT3& _Extents, _In_ const XMFLOAT4& _Orientation) noexcept
             : Center(_Center), Extents(_Extents), Orientation(_Orientation) {}
 
         // Methods
@@ -252,7 +252,7 @@ namespace DirectX
         BoundingFrustum(BoundingFrustum&&) = default;
         BoundingFrustum& operator=(BoundingFrustum&&) = default;
 
-        XM_CONSTEXPR BoundingFrustum(_In_ const XMFLOAT3& _Origin, _In_ const XMFLOAT4& _Orientation,
+        constexpr BoundingFrustum(_In_ const XMFLOAT3& _Origin, _In_ const XMFLOAT4& _Orientation,
             _In_ float _RightSlope, _In_ float _LeftSlope, _In_ float _TopSlope, _In_ float _BottomSlope,
             _In_ float _Near, _In_ float _Far) noexcept
             : Origin(_Origin), Orientation(_Orientation),

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -266,13 +266,13 @@ namespace DirectX
 
     // Condition register evaluation proceeding a recording (R) comparison
 
-    inline bool XMComparisonAllTrue(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6TRUE) == XM_CRMASK_CR6TRUE); }
-    inline bool XMComparisonAnyTrue(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6FALSE) != XM_CRMASK_CR6FALSE); }
-    inline bool XMComparisonAllFalse(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6FALSE) == XM_CRMASK_CR6FALSE); }
-    inline bool XMComparisonAnyFalse(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6TRUE) != XM_CRMASK_CR6TRUE); }
-    inline bool XMComparisonMixed(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6) == 0); }
-    inline bool XMComparisonAllInBounds(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6BOUNDS) == XM_CRMASK_CR6BOUNDS); }
-    inline bool XMComparisonAnyOutOfBounds(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6BOUNDS) != XM_CRMASK_CR6BOUNDS); }
+    inline constexpr bool XMComparisonAllTrue(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6TRUE) == XM_CRMASK_CR6TRUE); }
+    inline constexpr bool XMComparisonAnyTrue(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6FALSE) != XM_CRMASK_CR6FALSE); }
+    inline constexpr bool XMComparisonAllFalse(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6FALSE) == XM_CRMASK_CR6FALSE); }
+    inline constexpr bool XMComparisonAnyFalse(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6TRUE) != XM_CRMASK_CR6TRUE); }
+    inline constexpr bool XMComparisonMixed(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6) == 0); }
+    inline constexpr bool XMComparisonAllInBounds(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6BOUNDS) == XM_CRMASK_CR6BOUNDS); }
+    inline constexpr bool XMComparisonAnyOutOfBounds(uint32_t CR) noexcept { return (((CR)&XM_CRMASK_CR6BOUNDS) != XM_CRMASK_CR6BOUNDS); }
 
 
     /****************************************************************************

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -15,8 +15,8 @@
 
 #define DIRECTX_MATH_VERSION 314
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-#error DirectX Math requires Visual C++ 2015 or later.
+#if defined(_MSC_VER) && (_MSC_VER < 1910)
+#error DirectX Math requires Visual C++ 2017 or later.
 #endif
 
 #if defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64) && !defined(_M_HYBRID_X86_ARM64) && (!_MANAGED) && (!_M_CEE) && (!defined(_M_IX86_FP) || (_M_IX86_FP > 1)) && !defined(_XM_NO_INTRINSICS_) && !defined(_XM_VECTORCALL_)
@@ -27,14 +27,6 @@
 #define XM_CALLCONV __vectorcall
 #else
 #define XM_CALLCONV __fastcall
-#endif
-
-#if defined(_MSC_VER) && (_MSC_FULL_VER < 190023506)
-#define XM_CONST const
-#define XM_CONSTEXPR
-#else
-#define XM_CONST constexpr
-#define XM_CONSTEXPR constexpr
 #endif
 
 #ifndef XM_DEPRECATED
@@ -219,36 +211,36 @@ namespace DirectX
 #undef XM_CACHE_LINE_SIZE
 #endif
 
-    XM_CONST float XM_PI = 3.141592654f;
-    XM_CONST float XM_2PI = 6.283185307f;
-    XM_CONST float XM_1DIVPI = 0.318309886f;
-    XM_CONST float XM_1DIV2PI = 0.159154943f;
-    XM_CONST float XM_PIDIV2 = 1.570796327f;
-    XM_CONST float XM_PIDIV4 = 0.785398163f;
+    constexpr float XM_PI = 3.141592654f;
+    constexpr float XM_2PI = 6.283185307f;
+    constexpr float XM_1DIVPI = 0.318309886f;
+    constexpr float XM_1DIV2PI = 0.159154943f;
+    constexpr float XM_PIDIV2 = 1.570796327f;
+    constexpr float XM_PIDIV4 = 0.785398163f;
 
-    XM_CONST uint32_t XM_SELECT_0 = 0x00000000;
-    XM_CONST uint32_t XM_SELECT_1 = 0xFFFFFFFF;
+    constexpr uint32_t XM_SELECT_0 = 0x00000000;
+    constexpr uint32_t XM_SELECT_1 = 0xFFFFFFFF;
 
-    XM_CONST uint32_t XM_PERMUTE_0X = 0;
-    XM_CONST uint32_t XM_PERMUTE_0Y = 1;
-    XM_CONST uint32_t XM_PERMUTE_0Z = 2;
-    XM_CONST uint32_t XM_PERMUTE_0W = 3;
-    XM_CONST uint32_t XM_PERMUTE_1X = 4;
-    XM_CONST uint32_t XM_PERMUTE_1Y = 5;
-    XM_CONST uint32_t XM_PERMUTE_1Z = 6;
-    XM_CONST uint32_t XM_PERMUTE_1W = 7;
+    constexpr uint32_t XM_PERMUTE_0X = 0;
+    constexpr uint32_t XM_PERMUTE_0Y = 1;
+    constexpr uint32_t XM_PERMUTE_0Z = 2;
+    constexpr uint32_t XM_PERMUTE_0W = 3;
+    constexpr uint32_t XM_PERMUTE_1X = 4;
+    constexpr uint32_t XM_PERMUTE_1Y = 5;
+    constexpr uint32_t XM_PERMUTE_1Z = 6;
+    constexpr uint32_t XM_PERMUTE_1W = 7;
 
-    XM_CONST uint32_t XM_SWIZZLE_X = 0;
-    XM_CONST uint32_t XM_SWIZZLE_Y = 1;
-    XM_CONST uint32_t XM_SWIZZLE_Z = 2;
-    XM_CONST uint32_t XM_SWIZZLE_W = 3;
+    constexpr uint32_t XM_SWIZZLE_X = 0;
+    constexpr uint32_t XM_SWIZZLE_Y = 1;
+    constexpr uint32_t XM_SWIZZLE_Z = 2;
+    constexpr uint32_t XM_SWIZZLE_W = 3;
 
-    XM_CONST uint32_t XM_CRMASK_CR6 = 0x000000F0;
-    XM_CONST uint32_t XM_CRMASK_CR6TRUE = 0x00000080;
-    XM_CONST uint32_t XM_CRMASK_CR6FALSE = 0x00000020;
-    XM_CONST uint32_t XM_CRMASK_CR6BOUNDS = XM_CRMASK_CR6FALSE;
+    constexpr uint32_t XM_CRMASK_CR6 = 0x000000F0;
+    constexpr uint32_t XM_CRMASK_CR6TRUE = 0x00000080;
+    constexpr uint32_t XM_CRMASK_CR6FALSE = 0x00000020;
+    constexpr uint32_t XM_CRMASK_CR6BOUNDS = XM_CRMASK_CR6FALSE;
 
-    XM_CONST size_t XM_CACHE_LINE_SIZE = 64;
+    constexpr size_t XM_CACHE_LINE_SIZE = 64;
 
 
     /****************************************************************************
@@ -269,8 +261,8 @@ namespace DirectX
 
      // Unit conversion
 
-    inline XM_CONSTEXPR float XMConvertToRadians(float fDegrees) noexcept { return fDegrees * (XM_PI / 180.0f); }
-    inline XM_CONSTEXPR float XMConvertToDegrees(float fRadians) noexcept { return fRadians * (180.0f / XM_PI); }
+    inline constexpr float XMConvertToRadians(float fDegrees) noexcept { return fDegrees * (XM_PI / 180.0f); }
+    inline constexpr float XMConvertToDegrees(float fRadians) noexcept { return fRadians * (180.0f / XM_PI); }
 
     // Condition register evaluation proceeding a recording (R) comparison
 
@@ -532,7 +524,7 @@ namespace DirectX
         XMFLOAT2(XMFLOAT2&&) = default;
         XMFLOAT2& operator=(XMFLOAT2&&) = default;
 
-        XM_CONSTEXPR XMFLOAT2(float _x, float _y) noexcept : x(_x), y(_y) {}
+        constexpr XMFLOAT2(float _x, float _y) noexcept : x(_x), y(_y) {}
         explicit XMFLOAT2(_In_reads_(2) const float* pArray)  noexcept : x(pArray[0]), y(pArray[1]) {}
     };
 
@@ -547,7 +539,7 @@ namespace DirectX
         XMFLOAT2A(XMFLOAT2A&&) = default;
         XMFLOAT2A& operator=(XMFLOAT2A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT2A(float _x, float _y) noexcept : XMFLOAT2(_x, _y) {}
+        constexpr XMFLOAT2A(float _x, float _y) noexcept : XMFLOAT2(_x, _y) {}
         explicit XMFLOAT2A(_In_reads_(2) const float* pArray) noexcept : XMFLOAT2(pArray) {}
     };
 
@@ -566,7 +558,7 @@ namespace DirectX
         XMINT2(XMINT2&&) = default;
         XMINT2& operator=(XMINT2&&) = default;
 
-        XM_CONSTEXPR XMINT2(int32_t _x, int32_t _y) noexcept : x(_x), y(_y) {}
+        constexpr XMINT2(int32_t _x, int32_t _y) noexcept : x(_x), y(_y) {}
         explicit XMINT2(_In_reads_(2) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
     };
 
@@ -584,7 +576,7 @@ namespace DirectX
         XMUINT2(XMUINT2&&) = default;
         XMUINT2& operator=(XMUINT2&&) = default;
 
-        XM_CONSTEXPR XMUINT2(uint32_t _x, uint32_t _y) noexcept : x(_x), y(_y) {}
+        constexpr XMUINT2(uint32_t _x, uint32_t _y) noexcept : x(_x), y(_y) {}
         explicit XMUINT2(_In_reads_(2) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
     };
 
@@ -604,7 +596,7 @@ namespace DirectX
         XMFLOAT3(XMFLOAT3&&) = default;
         XMFLOAT3& operator=(XMFLOAT3&&) = default;
 
-        XM_CONSTEXPR XMFLOAT3(float _x, float _y, float _z) noexcept : x(_x), y(_y), z(_z) {}
+        constexpr XMFLOAT3(float _x, float _y, float _z) noexcept : x(_x), y(_y), z(_z) {}
         explicit XMFLOAT3(_In_reads_(3) const float* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
     };
 
@@ -619,7 +611,7 @@ namespace DirectX
         XMFLOAT3A(XMFLOAT3A&&) = default;
         XMFLOAT3A& operator=(XMFLOAT3A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT3A(float _x, float _y, float _z) noexcept : XMFLOAT3(_x, _y, _z) {}
+        constexpr XMFLOAT3A(float _x, float _y, float _z) noexcept : XMFLOAT3(_x, _y, _z) {}
         explicit XMFLOAT3A(_In_reads_(3) const float* pArray) noexcept : XMFLOAT3(pArray) {}
     };
 
@@ -639,7 +631,7 @@ namespace DirectX
         XMINT3(XMINT3&&) = default;
         XMINT3& operator=(XMINT3&&) = default;
 
-        XM_CONSTEXPR XMINT3(int32_t _x, int32_t _y, int32_t _z) noexcept : x(_x), y(_y), z(_z) {}
+        constexpr XMINT3(int32_t _x, int32_t _y, int32_t _z) noexcept : x(_x), y(_y), z(_z) {}
         explicit XMINT3(_In_reads_(3) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
     };
 
@@ -658,7 +650,7 @@ namespace DirectX
         XMUINT3(XMUINT3&&) = default;
         XMUINT3& operator=(XMUINT3&&) = default;
 
-        XM_CONSTEXPR XMUINT3(uint32_t _x, uint32_t _y, uint32_t _z) noexcept : x(_x), y(_y), z(_z) {}
+        constexpr XMUINT3(uint32_t _x, uint32_t _y, uint32_t _z) noexcept : x(_x), y(_y), z(_z) {}
         explicit XMUINT3(_In_reads_(3) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
     };
 
@@ -679,7 +671,7 @@ namespace DirectX
         XMFLOAT4(XMFLOAT4&&) = default;
         XMFLOAT4& operator=(XMFLOAT4&&) = default;
 
-        XM_CONSTEXPR XMFLOAT4(float _x, float _y, float _z, float _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+        constexpr XMFLOAT4(float _x, float _y, float _z, float _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
         explicit XMFLOAT4(_In_reads_(4) const float* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
     };
 
@@ -694,7 +686,7 @@ namespace DirectX
         XMFLOAT4A(XMFLOAT4A&&) = default;
         XMFLOAT4A& operator=(XMFLOAT4A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT4A(float _x, float _y, float _z, float _w) noexcept : XMFLOAT4(_x, _y, _z, _w) {}
+        constexpr XMFLOAT4A(float _x, float _y, float _z, float _w) noexcept : XMFLOAT4(_x, _y, _z, _w) {}
         explicit XMFLOAT4A(_In_reads_(4) const float* pArray) noexcept : XMFLOAT4(pArray) {}
     };
 
@@ -715,7 +707,7 @@ namespace DirectX
         XMINT4(XMINT4&&) = default;
         XMINT4& operator=(XMINT4&&) = default;
 
-        XM_CONSTEXPR XMINT4(int32_t _x, int32_t _y, int32_t _z, int32_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+        constexpr XMINT4(int32_t _x, int32_t _y, int32_t _z, int32_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
         explicit XMINT4(_In_reads_(4) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
     };
 
@@ -735,7 +727,7 @@ namespace DirectX
         XMUINT4(XMUINT4&&) = default;
         XMUINT4& operator=(XMUINT4&&) = default;
 
-        XM_CONSTEXPR XMUINT4(uint32_t _x, uint32_t _y, uint32_t _z, uint32_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+        constexpr XMUINT4(uint32_t _x, uint32_t _y, uint32_t _z, uint32_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
         explicit XMUINT4(_In_reads_(4) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
     };
 
@@ -762,7 +754,7 @@ namespace DirectX
         XMFLOAT3X3(XMFLOAT3X3&&) = default;
         XMFLOAT3X3& operator=(XMFLOAT3X3&&) = default;
 
-        XM_CONSTEXPR XMFLOAT3X3(float m00, float m01, float m02,
+        constexpr XMFLOAT3X3(float m00, float m01, float m02,
             float m10, float m11, float m12,
             float m20, float m21, float m22) noexcept
             : _11(m00), _12(m01), _13(m02),
@@ -799,7 +791,7 @@ namespace DirectX
         XMFLOAT4X3(XMFLOAT4X3&&) = default;
         XMFLOAT4X3& operator=(XMFLOAT4X3&&) = default;
 
-        XM_CONSTEXPR XMFLOAT4X3(float m00, float m01, float m02,
+        constexpr XMFLOAT4X3(float m00, float m01, float m02,
             float m10, float m11, float m12,
             float m20, float m21, float m22,
             float m30, float m31, float m32) noexcept
@@ -824,7 +816,7 @@ namespace DirectX
         XMFLOAT4X3A(XMFLOAT4X3A&&) = default;
         XMFLOAT4X3A& operator=(XMFLOAT4X3A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT4X3A(float m00, float m01, float m02,
+        constexpr XMFLOAT4X3A(float m00, float m01, float m02,
             float m10, float m11, float m12,
             float m20, float m21, float m22,
             float m30, float m31, float m32)  noexcept :
@@ -856,7 +848,7 @@ namespace DirectX
         XMFLOAT3X4(XMFLOAT3X4&&) = default;
         XMFLOAT3X4& operator=(XMFLOAT3X4&&) = default;
 
-        XM_CONSTEXPR XMFLOAT3X4(float m00, float m01, float m02, float m03,
+        constexpr XMFLOAT3X4(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
             float m20, float m21, float m22, float m23) noexcept
             : _11(m00), _12(m01), _13(m02), _14(m03),
@@ -879,7 +871,7 @@ namespace DirectX
         XMFLOAT3X4A(XMFLOAT3X4A&&) = default;
         XMFLOAT3X4A& operator=(XMFLOAT3X4A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT3X4A(float m00, float m01, float m02, float m03,
+        constexpr XMFLOAT3X4A(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
             float m20, float m21, float m22, float m23)  noexcept :
             XMFLOAT3X4(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23) {}
@@ -910,7 +902,7 @@ namespace DirectX
         XMFLOAT4X4(XMFLOAT4X4&&) = default;
         XMFLOAT4X4& operator=(XMFLOAT4X4&&) = default;
 
-        XM_CONSTEXPR XMFLOAT4X4(float m00, float m01, float m02, float m03,
+        constexpr XMFLOAT4X4(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
             float m20, float m21, float m22, float m23,
             float m30, float m31, float m32, float m33) noexcept
@@ -935,7 +927,7 @@ namespace DirectX
         XMFLOAT4X4A(XMFLOAT4X4A&&) = default;
         XMFLOAT4X4A& operator=(XMFLOAT4X4A&&) = default;
 
-        XM_CONSTEXPR XMFLOAT4X4A(float m00, float m01, float m02, float m03,
+        constexpr XMFLOAT4X4A(float m00, float m01, float m02, float m03,
             float m10, float m11, float m12, float m13,
             float m20, float m21, float m22, float m23,
             float m30, float m31, float m32, float m33) noexcept

--- a/Inc/DirectXPackedVector.h
+++ b/Inc/DirectXPackedVector.h
@@ -53,7 +53,7 @@ namespace DirectX
             XMCOLOR(XMCOLOR&&) = default;
             XMCOLOR& operator=(XMCOLOR&&) = default;
 
-            XM_CONSTEXPR XMCOLOR(uint32_t Color) noexcept : c(Color) {}
+            constexpr XMCOLOR(uint32_t Color) noexcept : c(Color) {}
             XMCOLOR(float _r, float _g, float _b, float _a) noexcept;
             explicit XMCOLOR(_In_reads_(4) const float* pArray) noexcept;
 
@@ -89,8 +89,8 @@ namespace DirectX
             XMHALF2(XMHALF2&&) = default;
             XMHALF2& operator=(XMHALF2&&) = default;
 
-            explicit XM_CONSTEXPR XMHALF2(uint32_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMHALF2(HALF _x, HALF _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMHALF2(uint32_t Packed) noexcept : v(Packed) {}
+            constexpr XMHALF2(HALF _x, HALF _y) noexcept : x(_x), y(_y) {}
             explicit XMHALF2(_In_reads_(2) const HALF* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMHALF2(float _x, float _y) noexcept;
             explicit XMHALF2(_In_reads_(2) const float* pArray) noexcept;
@@ -120,8 +120,8 @@ namespace DirectX
             XMSHORTN2(XMSHORTN2&&) = default;
             XMSHORTN2& operator=(XMSHORTN2&&) = default;
 
-            explicit XM_CONSTEXPR XMSHORTN2(uint32_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMSHORTN2(int16_t _x, int16_t _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMSHORTN2(uint32_t Packed) noexcept : v(Packed) {}
+            constexpr XMSHORTN2(int16_t _x, int16_t _y) noexcept : x(_x), y(_y) {}
             explicit XMSHORTN2(_In_reads_(2) const int16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMSHORTN2(float _x, float _y) noexcept;
             explicit XMSHORTN2(_In_reads_(2) const float* pArray) noexcept;
@@ -150,8 +150,8 @@ namespace DirectX
             XMSHORT2(XMSHORT2&&) = default;
             XMSHORT2& operator=(XMSHORT2&&) = default;
 
-            explicit XM_CONSTEXPR XMSHORT2(uint32_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMSHORT2(int16_t _x, int16_t _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMSHORT2(uint32_t Packed) noexcept : v(Packed) {}
+            constexpr XMSHORT2(int16_t _x, int16_t _y) noexcept : x(_x), y(_y) {}
             explicit XMSHORT2(_In_reads_(2) const int16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMSHORT2(float _x, float _y) noexcept;
             explicit XMSHORT2(_In_reads_(2) const float* pArray) noexcept;
@@ -180,8 +180,8 @@ namespace DirectX
             XMUSHORTN2(XMUSHORTN2&&) = default;
             XMUSHORTN2& operator=(XMUSHORTN2&&) = default;
 
-            explicit XM_CONSTEXPR XMUSHORTN2(uint32_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMUSHORTN2(uint16_t _x, uint16_t _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMUSHORTN2(uint32_t Packed) noexcept : v(Packed) {}
+            constexpr XMUSHORTN2(uint16_t _x, uint16_t _y) noexcept : x(_x), y(_y) {}
             explicit XMUSHORTN2(_In_reads_(2) const uint16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMUSHORTN2(float _x, float _y) noexcept;
             explicit XMUSHORTN2(_In_reads_(2) const float* pArray) noexcept;
@@ -210,8 +210,8 @@ namespace DirectX
             XMUSHORT2(XMUSHORT2&&) = default;
             XMUSHORT2& operator=(XMUSHORT2&&) = default;
 
-            explicit XM_CONSTEXPR XMUSHORT2(uint32_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMUSHORT2(uint16_t _x, uint16_t _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMUSHORT2(uint32_t Packed) noexcept : v(Packed) {}
+            constexpr XMUSHORT2(uint16_t _x, uint16_t _y) noexcept : x(_x), y(_y) {}
             explicit XMUSHORT2(_In_reads_(2) const uint16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMUSHORT2(float _x, float _y) noexcept;
             explicit XMUSHORT2(_In_reads_(2) const float* pArray) noexcept;
@@ -241,8 +241,8 @@ namespace DirectX
             XMBYTEN2(XMBYTEN2&&) = default;
             XMBYTEN2& operator=(XMBYTEN2&&) = default;
 
-            explicit XM_CONSTEXPR XMBYTEN2(uint16_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMBYTEN2(int8_t _x, int8_t _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMBYTEN2(uint16_t Packed) noexcept : v(Packed) {}
+            constexpr XMBYTEN2(int8_t _x, int8_t _y) noexcept : x(_x), y(_y) {}
             explicit XMBYTEN2(_In_reads_(2) const int8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMBYTEN2(float _x, float _y) noexcept;
             explicit XMBYTEN2(_In_reads_(2) const float* pArray) noexcept;
@@ -271,8 +271,8 @@ namespace DirectX
             XMBYTE2(XMBYTE2&&) = default;
             XMBYTE2& operator=(XMBYTE2&&) = default;
 
-            explicit XM_CONSTEXPR XMBYTE2(uint16_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMBYTE2(int8_t _x, int8_t _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMBYTE2(uint16_t Packed) noexcept : v(Packed) {}
+            constexpr XMBYTE2(int8_t _x, int8_t _y) noexcept : x(_x), y(_y) {}
             explicit XMBYTE2(_In_reads_(2) const int8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMBYTE2(float _x, float _y) noexcept;
             explicit XMBYTE2(_In_reads_(2) const float* pArray) noexcept;
@@ -301,8 +301,8 @@ namespace DirectX
             XMUBYTEN2(XMUBYTEN2&&) = default;
             XMUBYTEN2& operator=(XMUBYTEN2&&) = default;
 
-            explicit XM_CONSTEXPR XMUBYTEN2(uint16_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMUBYTEN2(uint8_t _x, uint8_t _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMUBYTEN2(uint16_t Packed) noexcept : v(Packed) {}
+            constexpr XMUBYTEN2(uint8_t _x, uint8_t _y) noexcept : x(_x), y(_y) {}
             explicit XMUBYTEN2(_In_reads_(2) const uint8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMUBYTEN2(float _x, float _y) noexcept;
             explicit XMUBYTEN2(_In_reads_(2) const float* pArray) noexcept;
@@ -331,8 +331,8 @@ namespace DirectX
             XMUBYTE2(XMUBYTE2&&) = default;
             XMUBYTE2& operator=(XMUBYTE2&&) = default;
 
-            explicit XM_CONSTEXPR XMUBYTE2(uint16_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMUBYTE2(uint8_t _x, uint8_t _y) noexcept : x(_x), y(_y) {}
+            explicit constexpr XMUBYTE2(uint16_t Packed) noexcept : v(Packed) {}
+            constexpr XMUBYTE2(uint8_t _x, uint8_t _y) noexcept : x(_x), y(_y) {}
             explicit XMUBYTE2(_In_reads_(2) const uint8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
             XMUBYTE2(float _x, float _y) noexcept;
             explicit XMUBYTE2(_In_reads_(2) const float* pArray) noexcept;
@@ -363,8 +363,8 @@ namespace DirectX
             XMU565(XMU565&&) = default;
             XMU565& operator=(XMU565&&) = default;
 
-            explicit XM_CONSTEXPR XMU565(uint16_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMU565(uint8_t _x, uint8_t _y, uint8_t _z) noexcept : x(_x), y(_y), z(_z) {}
+            explicit constexpr XMU565(uint16_t Packed) noexcept : v(Packed) {}
+            constexpr XMU565(uint8_t _x, uint8_t _y, uint8_t _z) noexcept : x(_x), y(_y), z(_z) {}
             explicit XMU565(_In_reads_(3) const uint8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
             XMU565(float _x, float _y, float _z) noexcept;
             explicit XMU565(_In_reads_(3) const float* pArray) noexcept;
@@ -407,7 +407,7 @@ namespace DirectX
             XMFLOAT3PK(XMFLOAT3PK&&) = default;
             XMFLOAT3PK& operator=(XMFLOAT3PK&&) = default;
 
-            explicit XM_CONSTEXPR XMFLOAT3PK(uint32_t Packed) noexcept : v(Packed) {}
+            explicit constexpr XMFLOAT3PK(uint32_t Packed) noexcept : v(Packed) {}
             XMFLOAT3PK(float _x, float _y, float _z) noexcept;
             explicit XMFLOAT3PK(_In_reads_(3) const float* pArray) noexcept;
 
@@ -446,7 +446,7 @@ namespace DirectX
             XMFLOAT3SE(XMFLOAT3SE&&) = default;
             XMFLOAT3SE& operator=(XMFLOAT3SE&&) = default;
 
-            explicit XM_CONSTEXPR XMFLOAT3SE(uint32_t Packed) noexcept : v(Packed) {}
+            explicit constexpr XMFLOAT3SE(uint32_t Packed) noexcept : v(Packed) {}
             XMFLOAT3SE(float _x, float _y, float _z) noexcept;
             explicit XMFLOAT3SE(_In_reads_(3) const float* pArray) noexcept;
 
@@ -479,8 +479,8 @@ namespace DirectX
             XMHALF4(XMHALF4&&) = default;
             XMHALF4& operator=(XMHALF4&&) = default;
 
-            explicit XM_CONSTEXPR XMHALF4(uint64_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMHALF4(HALF _x, HALF _y, HALF _z, HALF _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMHALF4(uint64_t Packed) noexcept : v(Packed) {}
+            constexpr XMHALF4(HALF _x, HALF _y, HALF _z, HALF _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
             explicit XMHALF4(_In_reads_(4) const HALF* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMHALF4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMHALF4(_In_reads_(4) const float* pArray) noexcept;
@@ -512,8 +512,8 @@ namespace DirectX
             XMSHORTN4(XMSHORTN4&&) = default;
             XMSHORTN4& operator=(XMSHORTN4&&) = default;
 
-            explicit XM_CONSTEXPR XMSHORTN4(uint64_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMSHORTN4(int16_t _x, int16_t _y, int16_t _z, int16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMSHORTN4(uint64_t Packed) noexcept : v(Packed) {}
+            constexpr XMSHORTN4(int16_t _x, int16_t _y, int16_t _z, int16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
             explicit XMSHORTN4(_In_reads_(4) const int16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMSHORTN4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMSHORTN4(_In_reads_(4) const float* pArray) noexcept;
@@ -544,8 +544,8 @@ namespace DirectX
             XMSHORT4(XMSHORT4&&) = default;
             XMSHORT4& operator=(XMSHORT4&&) = default;
 
-            explicit XM_CONSTEXPR XMSHORT4(uint64_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMSHORT4(int16_t _x, int16_t _y, int16_t _z, int16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMSHORT4(uint64_t Packed) noexcept : v(Packed) {}
+            constexpr XMSHORT4(int16_t _x, int16_t _y, int16_t _z, int16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
             explicit XMSHORT4(_In_reads_(4) const int16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMSHORT4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMSHORT4(_In_reads_(4) const float* pArray) noexcept;
@@ -576,8 +576,8 @@ namespace DirectX
             XMUSHORTN4(XMUSHORTN4&&) = default;
             XMUSHORTN4& operator=(XMUSHORTN4&&) = default;
 
-            explicit XM_CONSTEXPR XMUSHORTN4(uint64_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMUSHORTN4(uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMUSHORTN4(uint64_t Packed) noexcept : v(Packed) {}
+            constexpr XMUSHORTN4(uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
             explicit XMUSHORTN4(_In_reads_(4) const uint16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMUSHORTN4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMUSHORTN4(_In_reads_(4) const float* pArray) noexcept;
@@ -608,8 +608,8 @@ namespace DirectX
             XMUSHORT4(XMUSHORT4&&) = default;
             XMUSHORT4& operator=(XMUSHORT4&&) = default;
 
-            explicit XM_CONSTEXPR XMUSHORT4(uint64_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMUSHORT4(uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMUSHORT4(uint64_t Packed) noexcept : v(Packed) {}
+            constexpr XMUSHORT4(uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
             explicit XMUSHORT4(_In_reads_(4) const uint16_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMUSHORT4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMUSHORT4(_In_reads_(4) const float* pArray) noexcept;
@@ -646,7 +646,7 @@ namespace DirectX
             XMXDECN4(XMXDECN4&&) = default;
             XMXDECN4& operator=(XMXDECN4&&) = default;
 
-            explicit XM_CONSTEXPR XMXDECN4(uint32_t Packed) : v(Packed) {}
+            explicit constexpr XMXDECN4(uint32_t Packed) : v(Packed) {}
             XMXDECN4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMXDECN4(_In_reads_(4) const float* pArray) noexcept;
 
@@ -683,7 +683,7 @@ namespace DirectX
             XMXDEC4(XMXDEC4&&) = default;
             XMXDEC4& operator=(XMXDEC4&&) = default;
 
-            explicit XM_CONSTEXPR XMXDEC4(uint32_t Packed) noexcept : v(Packed) {}
+            explicit constexpr XMXDEC4(uint32_t Packed) noexcept : v(Packed) {}
             XMXDEC4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMXDEC4(_In_reads_(4) const float* pArray) noexcept;
 
@@ -720,7 +720,7 @@ namespace DirectX
             XMDECN4(XMDECN4&&) = default;
             XMDECN4& operator=(XMDECN4&&) = default;
 
-            explicit XM_CONSTEXPR XMDECN4(uint32_t Packed) noexcept : v(Packed) {}
+            explicit constexpr XMDECN4(uint32_t Packed) noexcept : v(Packed) {}
             XMDECN4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMDECN4(_In_reads_(4) const float* pArray) noexcept;
 
@@ -757,7 +757,7 @@ namespace DirectX
             XMDEC4(XMDEC4&&) = default;
             XMDEC4& operator=(XMDEC4&&) = default;
 
-            explicit XM_CONSTEXPR XMDEC4(uint32_t Packed) noexcept : v(Packed) {}
+            explicit constexpr XMDEC4(uint32_t Packed) noexcept : v(Packed) {}
             XMDEC4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMDEC4(_In_reads_(4) const float* pArray) noexcept;
 
@@ -794,7 +794,7 @@ namespace DirectX
             XMUDECN4(XMUDECN4&&) = default;
             XMUDECN4& operator=(XMUDECN4&&) = default;
 
-            explicit XM_CONSTEXPR XMUDECN4(uint32_t Packed) noexcept : v(Packed) {}
+            explicit constexpr XMUDECN4(uint32_t Packed) noexcept : v(Packed) {}
             XMUDECN4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMUDECN4(_In_reads_(4) const float* pArray) noexcept;
 
@@ -831,7 +831,7 @@ namespace DirectX
             XMUDEC4(XMUDEC4&&) = default;
             XMUDEC4& operator=(XMUDEC4&&) = default;
 
-            explicit XM_CONSTEXPR XMUDEC4(uint32_t Packed) noexcept : v(Packed) {}
+            explicit constexpr XMUDEC4(uint32_t Packed) noexcept : v(Packed) {}
             XMUDEC4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMUDEC4(_In_reads_(4) const float* pArray) noexcept;
 
@@ -864,8 +864,8 @@ namespace DirectX
             XMBYTEN4(XMBYTEN4&&) = default;
             XMBYTEN4& operator=(XMBYTEN4&&) = default;
 
-            XM_CONSTEXPR XMBYTEN4(int8_t _x, int8_t _y, int8_t _z, int8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XM_CONSTEXPR XMBYTEN4(uint32_t Packed) noexcept : v(Packed) {}
+            constexpr XMBYTEN4(int8_t _x, int8_t _y, int8_t _z, int8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMBYTEN4(uint32_t Packed) noexcept : v(Packed) {}
             explicit XMBYTEN4(_In_reads_(4) const int8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMBYTEN4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMBYTEN4(_In_reads_(4) const float* pArray) noexcept;
@@ -896,8 +896,8 @@ namespace DirectX
             XMBYTE4(XMBYTE4&&) = default;
             XMBYTE4& operator=(XMBYTE4&&) = default;
 
-            XM_CONSTEXPR XMBYTE4(int8_t _x, int8_t _y, int8_t _z, int8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XM_CONSTEXPR XMBYTE4(uint32_t Packed) noexcept : v(Packed) {}
+            constexpr XMBYTE4(int8_t _x, int8_t _y, int8_t _z, int8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMBYTE4(uint32_t Packed) noexcept : v(Packed) {}
             explicit XMBYTE4(_In_reads_(4) const int8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMBYTE4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMBYTE4(_In_reads_(4) const float* pArray) noexcept;
@@ -928,8 +928,8 @@ namespace DirectX
             XMUBYTEN4(XMUBYTEN4&&) = default;
             XMUBYTEN4& operator=(XMUBYTEN4&&) = default;
 
-            XM_CONSTEXPR XMUBYTEN4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XM_CONSTEXPR XMUBYTEN4(uint32_t Packed) noexcept : v(Packed) {}
+            constexpr XMUBYTEN4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMUBYTEN4(uint32_t Packed) noexcept : v(Packed) {}
             explicit XMUBYTEN4(_In_reads_(4) const uint8_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMUBYTEN4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMUBYTEN4(_In_reads_(4) const float* pArray) noexcept;
@@ -960,8 +960,8 @@ namespace DirectX
             XMUBYTE4(XMUBYTE4&&) = default;
             XMUBYTE4& operator=(XMUBYTE4&&) = default;
 
-            XM_CONSTEXPR XMUBYTE4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
-            explicit XM_CONSTEXPR XMUBYTE4(uint32_t Packed)  noexcept : v(Packed) {}
+            constexpr XMUBYTE4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMUBYTE4(uint32_t Packed)  noexcept : v(Packed) {}
             explicit XMUBYTE4(_In_reads_(4) const uint8_t* pArray)  noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMUBYTE4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMUBYTE4(_In_reads_(4) const float* pArray) noexcept;
@@ -993,8 +993,8 @@ namespace DirectX
             XMUNIBBLE4(XMUNIBBLE4&&) = default;
             XMUNIBBLE4& operator=(XMUNIBBLE4&&) = default;
 
-            explicit XM_CONSTEXPR XMUNIBBLE4(uint16_t Packed)  noexcept : v(Packed) {}
-            XM_CONSTEXPR XMUNIBBLE4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w)  noexcept : x(_x), y(_y), z(_z), w(_w) {}
+            explicit constexpr XMUNIBBLE4(uint16_t Packed)  noexcept : v(Packed) {}
+            constexpr XMUNIBBLE4(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w)  noexcept : x(_x), y(_y), z(_z), w(_w) {}
             explicit XMUNIBBLE4(_In_reads_(4) const uint8_t* pArray)  noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
             XMUNIBBLE4(float _x, float _y, float _z, float _w) noexcept;
             explicit XMUNIBBLE4(_In_reads_(4) const float* pArray) noexcept;
@@ -1028,8 +1028,8 @@ namespace DirectX
             XMU555(XMU555&&) = default;
             XMU555& operator=(XMU555&&) = default;
 
-            explicit XM_CONSTEXPR XMU555(uint16_t Packed) noexcept : v(Packed) {}
-            XM_CONSTEXPR XMU555(uint8_t _x, uint8_t _y, uint8_t _z, bool _w) noexcept : x(_x), y(_y), z(_z), w(_w ? 0x1 : 0) {}
+            explicit constexpr XMU555(uint16_t Packed) noexcept : v(Packed) {}
+            constexpr XMU555(uint8_t _x, uint8_t _y, uint8_t _z, bool _w) noexcept : x(_x), y(_y), z(_z), w(_w ? 0x1 : 0) {}
             XMU555(_In_reads_(3) const uint8_t* pArray, _In_ bool _w) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(_w ? 0x1 : 0) {}
             XMU555(float _x, float _y, float _z, bool _w) noexcept;
             XMU555(_In_reads_(3) const float* pArray, _In_ bool _w) noexcept;

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 
 This package contains the DirectXMath library, an all inline SIMD C++ linear algebra library for use in games and graphics apps
 
-This code is designed to build with Visual Studio 2015, Visual Studio 2017, Visual Studio 2019, or clang for Windows. It is recommended  that you make use of the latest updates (VS 2015 Update 3, VS 2017 15.9 update, or VS 2019 Update 4 or later).
+This code is designed to build with Visual Studio 2017, Visual Studio 2019, or clang for Windows. It is recommended  that you make use of the latest updates (VS 2017 15.9 update, or VS 2019 Update 4 or later).
 
 These components are designed to work without requiring any content from the legacy DirectX SDK. For details, see [Where is the DirectX SDK?](https://aka.ms/dxsdk).
 


### PR DESCRIPTION
The ``XM_CONST`` and ``XM_CONSTEXPR`` macros were introduced to work around bugs in VS 2015 RTM (and 2013). These are no longer needed with VS 2015 retirement.

> Note that the Xbox One XDK variant build of this library will still build for VS 2015 Update 3, but otherwise VS 2017 is the minimum for GitHub version