### PR TITLE
256-bit wide AVX register optimizations

### DIFF
--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -152,9 +152,11 @@
 
 #if defined(_XM_NO_MOVNT_)
 #define XM_STREAM_PS( p, a ) _mm_store_ps((p), (a))
+#define XM256_STREAM_PS( p, a ) _mm256_store_ps((p), (a))
 #define XM_SFENCE()
 #else
 #define XM_STREAM_PS( p, a ) _mm_stream_ps((p), (a))
+#define XM256_STREAM_PS( p, a ) _mm256_stream_ps((p), (a))
 #define XM_SFENCE() _mm_sfence()
 #endif
 

--- a/Inc/DirectXMathMatrix.inl
+++ b/Inc/DirectXMathMatrix.inl
@@ -293,6 +293,50 @@ inline XMMATRIX XM_CALLCONV XMMatrixMultiply
     vW = vmlaq_lane_f32(vY, M2.r[3], VH, 1);
     mResult.r[3] = vaddq_f32(vZ, vW);
     return mResult;
+#elif defined(_XM_AVX2_INTRINSICS_)
+    __m256 t0 = _mm256_castps128_ps256(M1.r[0]);
+    t0 = _mm256_insertf128_ps(t0, M1.r[1], 1);
+    __m256 t1 = _mm256_castps128_ps256(M1.r[2]);
+    t1 = _mm256_insertf128_ps(t1, M1.r[3], 1);
+
+    __m256 u0 = _mm256_castps128_ps256(M2.r[0]);
+    u0 = _mm256_insertf128_ps(u0, M2.r[1], 1);
+    __m256 u1 = _mm256_castps128_ps256(M2.r[2]);
+    u1 = _mm256_insertf128_ps(u1, M2.r[3], 1);
+
+    __m256 a0 = _mm256_shuffle_ps(t0, t0, _MM_SHUFFLE(0, 0, 0, 0));
+    __m256 a1 = _mm256_shuffle_ps(t1, t1, _MM_SHUFFLE(0, 0, 0, 0));
+    __m256 b0 = _mm256_permute2f128_ps(u0, u0, 0x00);
+    __m256 c0 = _mm256_mul_ps(a0, b0);
+    __m256 c1 = _mm256_mul_ps(a1, b0);
+
+    a0 = _mm256_shuffle_ps(t0, t0, _MM_SHUFFLE(1, 1, 1, 1));
+    a1 = _mm256_shuffle_ps(t1, t1, _MM_SHUFFLE(1, 1, 1, 1));
+    b0 = _mm256_permute2f128_ps(u0, u0, 0x11);
+    __m256 c2 = _mm256_fmadd_ps(a0, b0, c0);
+    __m256 c3 = _mm256_fmadd_ps(a1, b0, c1);
+
+    a0 = _mm256_shuffle_ps(t0, t0, _MM_SHUFFLE(2, 2, 2, 2));
+    a1 = _mm256_shuffle_ps(t1, t1, _MM_SHUFFLE(2, 2, 2, 2));
+    __m256 b1 = _mm256_permute2f128_ps(u1, u1, 0x00);
+    __m256 c4 = _mm256_mul_ps(a0, b1);
+    __m256 c5 = _mm256_mul_ps(a1, b1);
+
+    a0 = _mm256_shuffle_ps(t0, t0, _MM_SHUFFLE(3, 3, 3, 3));
+    a1 = _mm256_shuffle_ps(t1, t1, _MM_SHUFFLE(3, 3, 3, 3));
+    b1 = _mm256_permute2f128_ps(u1, u1, 0x11);
+    __m256 c6 = _mm256_fmadd_ps(a0, b1, c4);
+    __m256 c7 = _mm256_fmadd_ps(a1, b1, c5);
+
+    t0 = _mm256_add_ps(c2, c6);
+    t1 = _mm256_add_ps(c3, c7);
+
+    XMMATRIX mResult;
+    mResult.r[0] = _mm256_castps256_ps128(t0);
+    mResult.r[1] = _mm256_extractf128_ps(t0, 1);
+    mResult.r[2] = _mm256_castps256_ps128(t1);
+    mResult.r[3] = _mm256_extractf128_ps(t1, 1);
+    return mResult;
 #elif defined(_XM_SSE_INTRINSICS_)
     XMMATRIX mResult;
     // Splat the component X,Y,Z then W

--- a/Inc/DirectXMathMatrix.inl
+++ b/Inc/DirectXMathMatrix.inl
@@ -869,7 +869,18 @@ inline XMMATRIX XM_CALLCONV XMMatrixInverse
     return Result;
 
 #elif defined(_XM_SSE_INTRINSICS_)
-    XMMATRIX MT = XMMatrixTranspose(M);
+    // Transpose matrix
+    XMVECTOR vTemp1 = _mm_shuffle_ps(M.r[0], M.r[1], _MM_SHUFFLE(1, 0, 1, 0));
+    XMVECTOR vTemp3 = _mm_shuffle_ps(M.r[0], M.r[1], _MM_SHUFFLE(3, 2, 3, 2));
+    XMVECTOR vTemp2 = _mm_shuffle_ps(M.r[2], M.r[3], _MM_SHUFFLE(1, 0, 1, 0));
+    XMVECTOR vTemp4 = _mm_shuffle_ps(M.r[2], M.r[3], _MM_SHUFFLE(3, 2, 3, 2));
+
+    XMMATRIX MT;
+    MT.r[0] = _mm_shuffle_ps(vTemp1, vTemp2, _MM_SHUFFLE(2, 0, 2, 0));
+    MT.r[1] = _mm_shuffle_ps(vTemp1, vTemp2, _MM_SHUFFLE(3, 1, 3, 1));
+    MT.r[2] = _mm_shuffle_ps(vTemp3, vTemp4, _MM_SHUFFLE(2, 0, 2, 0));
+    MT.r[3] = _mm_shuffle_ps(vTemp3, vTemp4, _MM_SHUFFLE(3, 1, 3, 1));
+
     XMVECTOR V00 = XM_PERMUTE_PS(MT.r[2], _MM_SHUFFLE(1, 1, 0, 0));
     XMVECTOR V10 = XM_PERMUTE_PS(MT.r[3], _MM_SHUFFLE(3, 2, 3, 2));
     XMVECTOR V01 = XM_PERMUTE_PS(MT.r[0], _MM_SHUFFLE(1, 1, 0, 0));
@@ -972,7 +983,7 @@ inline XMMATRIX XM_CALLCONV XMMatrixInverse
     C2 = XM_PERMUTE_PS(C2, _MM_SHUFFLE(3, 1, 2, 0));
     C4 = XM_PERMUTE_PS(C4, _MM_SHUFFLE(3, 1, 2, 0));
     C6 = XM_PERMUTE_PS(C6, _MM_SHUFFLE(3, 1, 2, 0));
-    // Get the determinate
+    // Get the determinant
     XMVECTOR vTemp = XMVector4Dot(C0, MT.r[0]);
     if (pDeterminant != nullptr)
         *pDeterminant = vTemp;
@@ -3406,4 +3417,3 @@ inline XMFLOAT4X4::XMFLOAT4X4(const float* pArray) noexcept
     m[3][2] = pArray[14];
     m[3][3] = pArray[15];
 }
-


### PR DESCRIPTION
These add some ``__m256`` use cases for ``XMMatrixMultiply``, ``XMMatrixMultiplyTranspose``, and ``XMMatrixTranspose`` plus the ``Stream`` methods.

While these implementations can technically work on systems with just AVX in some cases, this class of hardware often doesn't have a fully 256-bit wide bus so it's not really much of a win. Therefore, I'm only doing ``__m256`` register usage when building for ``/arch:AVX2``.

> It might be worthwhile to look at ``XMMatrixInverse`` for this optimization, but for now I'm just focused on the scenarios above.