### PR TITLE
clang/GNU compiler support including ARM-NEON

### DIFF
--- a/Extensions/DirectXMathAVX.h
+++ b/Extensions/DirectXMathAVX.h
@@ -28,7 +28,7 @@ inline bool XMVerifyAVXSupport()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid( CPUInfo, 0 );
@@ -37,7 +37,7 @@ inline bool XMVerifyAVXSupport()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1 );

--- a/Extensions/DirectXMathAVX2.h
+++ b/Extensions/DirectXMathAVX2.h
@@ -29,7 +29,7 @@ inline bool XMVerifyAVX2Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ inline bool XMVerifyAVX2Support()
     if ( CPUInfo[0] < 7  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);
@@ -48,7 +48,7 @@ inline bool XMVerifyAVX2Support()
     if ( (CPUInfo[2] & 0x38081001) != 0x38081001 )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuidex(CPUInfo, 7, 0);
@@ -124,7 +124,7 @@ inline XMVECTOR XM_CALLCONV XMVectorPermute( FXMVECTOR V1, FXMVECTOR V2, uint32_
 
     static const XMVECTORU32 three = { { { 3, 3, 3, 3 } } };
 
-    __declspec(align(16)) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
+    XM_ALIGNED_DATA(16) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
     __m128i vControl = _mm_load_si128( reinterpret_cast<const __m128i *>(&elem[0]) );
     
     __m128i vSelect = _mm_cmpgt_epi32( vControl, three );

--- a/Extensions/DirectXMathBE.h
+++ b/Extensions/DirectXMathBE.h
@@ -59,7 +59,7 @@ inline bool XMVerifySSSE3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -68,7 +68,7 @@ inline bool XMVerifySSSE3Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathF16C.h
+++ b/Extensions/DirectXMathF16C.h
@@ -29,7 +29,7 @@ inline bool XMVerifyF16CSupport()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ inline bool XMVerifyF16CSupport()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA3.h
+++ b/Extensions/DirectXMathFMA3.h
@@ -28,7 +28,7 @@ inline bool XMVerifyFMA3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifyFMA3Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -30,7 +30,7 @@ inline bool XMVerifyFMA4Support()
 
    // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
    int CPUInfo[4] = {-1};
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
    __cpuid(CPUInfo, 0);
@@ -39,7 +39,7 @@ inline bool XMVerifyFMA4Support()
    if ( CPUInfo[0] < 1  )
        return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
    __cpuid(CPUInfo, 1);
@@ -49,7 +49,7 @@ inline bool XMVerifyFMA4Support()
     if ( (CPUInfo[2] & 0x18000000) != 0x18000000 )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0x80000000);
@@ -59,7 +59,7 @@ inline bool XMVerifyFMA4Support()
         return false;
 
     // We check for FMA4
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0x80000001, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0x80000001);

--- a/Extensions/DirectXMathSSE3.h
+++ b/Extensions/DirectXMathSSE3.h
@@ -29,7 +29,7 @@ inline bool XMVerifySSE3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifySSE3Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathSSE4.h
+++ b/Extensions/DirectXMathSSE4.h
@@ -29,7 +29,7 @@ inline bool XMVerifySSE4Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifySSE4Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -25,12 +25,18 @@
 
 #if _XM_VECTORCALL_
 #define XM_CALLCONV __vectorcall
+#elif defined(__GNUC__)
+#define XM_CALLCONV
 #else
 #define XM_CALLCONV __fastcall
 #endif
 
 #ifndef XM_DEPRECATED
+#ifdef __GNUC__
+#define XM_DEPRECATED __attribute__ ((deprecated))
+#else
 #define XM_DEPRECATED __declspec(deprecated("This is deprecated and will be removed in a future version."))
+#endif
 #endif
 
 #if !defined(_XM_AVX2_INTRINSICS_) && defined(__AVX2__) && !defined(_XM_NO_INTRINSICS_)
@@ -83,7 +89,7 @@
 #endif
 #endif // !_XM_ARM_NEON_INTRINSICS_ && !_XM_SSE_INTRINSICS_ && !_XM_NO_INTRINSICS_
 
-#if !defined(_XM_NO_XMVECTOR_OVERLOADS_) && defined(__clang__)
+#if !defined(_XM_NO_XMVECTOR_OVERLOADS_) && (defined(__clang__) || defined(__GNUC__))
 #define _XM_NO_XMVECTOR_OVERLOADS_
 #endif
 
@@ -104,7 +110,7 @@
 #pragma warning(pop)
 #endif
 
-#if defined(__clang__) && (__x86_64__ || __i386__)
+#if (defined(__clang__) || defined(__GNUC__)) && (__x86_64__ || __i386__)
 #include <cpuid.h>
 #endif
 
@@ -141,6 +147,14 @@
 // C4005/4668: Old header issue
 #include <stdint.h>
 #pragma warning(pop)
+
+#ifdef __GNUC__
+#define XM_ALIGNED_DATA(x) __attribute__ ((aligned(x)))
+#define XM_ALIGNED_STRUCT(x) struct __attribute__ ((aligned(x)))
+#else
+#define XM_ALIGNED_DATA(x) __declspec(align(x))
+#define XM_ALIGNED_STRUCT(x) __declspec(align(x)) struct
+#endif
 
 /****************************************************************************
  *
@@ -352,7 +366,7 @@ namespace DirectX
 
     //------------------------------------------------------------------------------
     // Conversion types for constants
-    __declspec(align(16)) struct XMVECTORF32
+    XM_ALIGNED_STRUCT(16) XMVECTORF32
     {
         union
         {
@@ -368,7 +382,7 @@ namespace DirectX
 #endif
     };
 
-    __declspec(align(16)) struct XMVECTORI32
+    XM_ALIGNED_STRUCT(16) XMVECTORI32
     {
         union
         {
@@ -383,7 +397,7 @@ namespace DirectX
 #endif
     };
 
-    __declspec(align(16)) struct XMVECTORU8
+    XM_ALIGNED_STRUCT(16) XMVECTORU8
     {
         union
         {
@@ -398,7 +412,7 @@ namespace DirectX
 #endif
     };
 
-    __declspec(align(16)) struct XMVECTORU32
+    XM_ALIGNED_STRUCT(16) XMVECTORU32
     {
         union
         {
@@ -456,7 +470,7 @@ namespace DirectX
 #ifdef _XM_NO_INTRINSICS_
     struct XMMATRIX
 #else
-    __declspec(align(16)) struct XMMATRIX
+    XM_ALIGNED_STRUCT(16) XMMATRIX
 #endif
     {
 #ifdef _XM_NO_INTRINSICS_
@@ -539,7 +553,7 @@ namespace DirectX
     };
 
     // 2D Vector; 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT2A : public XMFLOAT2
+    XM_ALIGNED_STRUCT(16) XMFLOAT2A : public XMFLOAT2
     {
         XMFLOAT2A() = default;
 
@@ -611,7 +625,7 @@ namespace DirectX
     };
 
     // 3D Vector; 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT3A : public XMFLOAT3
+    XM_ALIGNED_STRUCT(16) XMFLOAT3A : public XMFLOAT3
     {
         XMFLOAT3A() = default;
 
@@ -686,7 +700,7 @@ namespace DirectX
     };
 
     // 4D Vector; 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT4A : public XMFLOAT4
+    XM_ALIGNED_STRUCT(16) XMFLOAT4A : public XMFLOAT4
     {
         XMFLOAT4A() = default;
 
@@ -822,7 +836,7 @@ namespace DirectX
     };
 
     // 4x3 Row-major Matrix: 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT4X3A : public XMFLOAT4X3
+    XM_ALIGNED_STRUCT(16) XMFLOAT4X3A : public XMFLOAT4X3
     {
         XMFLOAT4X3A() = default;
 
@@ -877,7 +891,7 @@ namespace DirectX
     };
 
     // 3x4 Column-major Matrix: 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT3X4A : public XMFLOAT3X4
+    XM_ALIGNED_STRUCT(16) XMFLOAT3X4A : public XMFLOAT3X4
     {
         XMFLOAT3X4A() = default;
 
@@ -933,7 +947,7 @@ namespace DirectX
     };
 
     // 4x4 Matrix: 32 bit floating point components aligned on a 16 byte boundary
-    __declspec(align(16)) struct XMFLOAT4X4A : public XMFLOAT4X4
+    XM_ALIGNED_STRUCT(16) XMFLOAT4X4A : public XMFLOAT4X4
     {
         XMFLOAT4X4A() = default;
 
@@ -1919,7 +1933,11 @@ namespace DirectX
      // separate math routine it would be reloaded.
 
 #ifndef XMGLOBALCONST
+#if defined(__GNUC__)
+#define XMGLOBALCONST extern const __attribute__((weak))
+#else
 #define XMGLOBALCONST extern const __declspec(selectany)
+#endif
 #endif
 
     XMGLOBALCONST XMVECTORF32 g_XMSinCoefficients0 = { { { -0.16666667f, +0.0083333310f, -0.00019840874f, +2.7525562e-06f } } };

--- a/Inc/DirectXMathConvert.inl
+++ b/Inc/DirectXMathConvert.inl
@@ -301,7 +301,11 @@ inline XMVECTOR XM_CALLCONV XMLoadInt2A(const uint32_t* pSource) noexcept
     V.vector4_u32[3] = 0;
     return V;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     uint32x2_t x = vld1_u32_ex(pSource, 64);
+#else
+    uint32x2_t x = vld1_u32(pSource);
+#endif
     uint32x2_t zero = vdup_n_u32(0);
     return vcombine_u32(x, zero);
 #elif defined(_XM_SSE_INTRINSICS_)
@@ -344,7 +348,11 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat2A(const XMFLOAT2A* pSource) noexcept
     V.vector4_f32[3] = 0.f;
     return V;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     float32x2_t x = vld1_f32_ex(reinterpret_cast<const float*>(pSource), 64);
+#else
+    float32x2_t x = vld1_f32(reinterpret_cast<const float*>(pSource));
+#endif
     float32x2_t zero = vdup_n_f32(0);
     return vcombine_f32(x, zero);
 #elif defined(_XM_SSE_INTRINSICS_)
@@ -453,7 +461,11 @@ inline XMVECTOR XM_CALLCONV XMLoadInt3A(const uint32_t* pSource) noexcept
     return V;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     // Reads an extra integer which is zero'd
+#ifdef _MSC_VER
     uint32x4_t V = vld1q_u32_ex(pSource, 128);
+#else
+    uint32x4_t V = vld1q_u32(pSource);
+#endif
     return vsetq_lane_u32(0, V, 3);
 #elif defined(_XM_SSE4_INTRINSICS_)
     __m128 xy = _mm_castpd_ps(_mm_load_sd(reinterpret_cast<const double*>(pSource)));
@@ -509,7 +521,11 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat3A(const XMFLOAT3A* pSource) noexcept
     return V;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     // Reads an extra float which is zero'd
+#ifdef _MSC_VER
     float32x4_t V = vld1q_f32_ex(reinterpret_cast<const float*>(pSource), 128);
+#else
+    float32x4_t V = vld1q_f32(reinterpret_cast<const float*>(pSource));
+#endif
     return vsetq_lane_f32(0, V, 3);
 #elif defined(_XM_SSE_INTRINSICS_)
     // Reads an extra float which is zero'd
@@ -619,7 +635,11 @@ inline XMVECTOR XM_CALLCONV XMLoadInt4A(const uint32_t* pSource) noexcept
     V.vector4_u32[3] = pSource[3];
     return V;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     return vld1q_u32_ex(pSource, 128);
+#else
+    return vld1q_u32(pSource);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     __m128i V = _mm_load_si128(reinterpret_cast<const __m128i*>(pSource));
     return _mm_castsi128_ps(V);
@@ -659,7 +679,11 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat4A(const XMFLOAT4A* pSource) noexcept
     V.vector4_f32[3] = pSource->w;
     return V;
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     return vld1q_f32_ex(reinterpret_cast<const float*>(pSource), 128);
+#else
+    return vld1q_f32(reinterpret_cast<const float*>(pSource));
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     return _mm_load_ps(&pSource->x);
 #endif
@@ -891,9 +915,15 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat4x3A(const XMFLOAT4X3A* pSource) noexcept
     return M;
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     float32x4_t v0 = vld1q_f32_ex(&pSource->m[0][0], 128);
     float32x4_t v1 = vld1q_f32_ex(&pSource->m[1][1], 128);
     float32x4_t v2 = vld1q_f32_ex(&pSource->m[2][2], 128);
+#else
+    float32x4_t v0 = vld1q_f32(&pSource->m[0][0]);
+    float32x4_t v1 = vld1q_f32(&pSource->m[1][1]);
+    float32x4_t v2 = vld1q_f32(&pSource->m[2][2]);
+#endif
 
     float32x4_t T1 = vextq_f32(v0, v1, 3);
     float32x4_t T2 = vcombine_f32(vget_high_f32(v1), vget_low_f32(v2));
@@ -1047,8 +1077,13 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat3x4A(const XMFLOAT3X4A* pSource) noexcept
     return M;
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     float32x2x4_t vTemp0 = vld4_f32_ex(&pSource->_11, 128);
     float32x4_t vTemp1 = vld1q_f32_ex(&pSource->_31, 128);
+#else
+    float32x2x4_t vTemp0 = vld4_f32(&pSource->_11);
+    float32x4_t vTemp1 = vld1q_f32(&pSource->_31);
+#endif
 
     float32x2_t l = vget_low_f32(vTemp1);
     float32x4_t T0 = vcombine_f32(vTemp0.val[0], l);
@@ -1173,10 +1208,17 @@ inline XMMATRIX XM_CALLCONV XMLoadFloat4x4A(const XMFLOAT4X4A* pSource) noexcept
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     XMMATRIX M;
+#ifdef _MSC_VER
     M.r[0] = vld1q_f32_ex(reinterpret_cast<const float*>(&pSource->_11), 128);
     M.r[1] = vld1q_f32_ex(reinterpret_cast<const float*>(&pSource->_21), 128);
     M.r[2] = vld1q_f32_ex(reinterpret_cast<const float*>(&pSource->_31), 128);
     M.r[3] = vld1q_f32_ex(reinterpret_cast<const float*>(&pSource->_41), 128);
+#else
+    M.r[0] = vld1q_f32(reinterpret_cast<const float*>(&pSource->_11));
+    M.r[1] = vld1q_f32(reinterpret_cast<const float*>(&pSource->_21));
+    M.r[2] = vld1q_f32(reinterpret_cast<const float*>(&pSource->_31));
+    M.r[3] = vld1q_f32(reinterpret_cast<const float*>(&pSource->_41));
+#endif
     return M;
 #elif defined(_XM_SSE_INTRINSICS_)
     XMMATRIX M;
@@ -1263,7 +1305,11 @@ inline void XM_CALLCONV XMStoreInt2A
     pDestination[1] = V.vector4_u32[1];
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     uint32x2_t VL = vget_low_u32(V);
+#ifdef _MSC_VER
     vst1_u32_ex(pDestination, VL, 64);
+#else
+    vst1_u32(pDestination, VL);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     _mm_store_sd(reinterpret_cast<double*>(pDestination), _mm_castps_pd(V));
 #endif
@@ -1304,7 +1350,11 @@ inline void XM_CALLCONV XMStoreFloat2A
     pDestination->y = V.vector4_f32[1];
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     float32x2_t VL = vget_low_f32(V);
+#ifdef _MSC_VER
     vst1_f32_ex(reinterpret_cast<float*>(pDestination), VL, 64);
+#else
+    vst1_f32(reinterpret_cast<float*>(pDestination), VL);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     _mm_store_sd(reinterpret_cast<double*>(pDestination), _mm_castps_pd(V));
 #endif
@@ -1419,7 +1469,11 @@ inline void XM_CALLCONV XMStoreInt3A
     pDestination[2] = V.vector4_u32[2];
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     uint32x2_t VL = vget_low_u32(V);
+#ifdef _MSC_VER
     vst1_u32_ex(pDestination, VL, 64);
+#else
+    vst1_u32(pDestination, VL);
+#endif
     vst1q_lane_u32(pDestination + 2, *reinterpret_cast<const uint32x4_t*>(&V), 2);
 #elif defined(_XM_SSE_INTRINSICS_)
     _mm_store_sd(reinterpret_cast<double*>(pDestination), _mm_castps_pd(V));
@@ -1472,7 +1526,11 @@ inline void XM_CALLCONV XMStoreFloat3A
     pDestination->z = V.vector4_f32[2];
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     float32x2_t VL = vget_low_f32(V);
+#ifdef _MSC_VER
     vst1_f32_ex(reinterpret_cast<float*>(pDestination), VL, 64);
+#else
+    vst1_f32(reinterpret_cast<float*>(pDestination), VL);
+#endif
     vst1q_lane_f32(reinterpret_cast<float*>(pDestination) + 2, V, 2);
 #elif defined(_XM_SSE4_INTRINSICS_)
     _mm_store_sd(reinterpret_cast<double*>(pDestination), _mm_castps_pd(V));
@@ -1598,7 +1656,11 @@ inline void XM_CALLCONV XMStoreInt4A
     pDestination[2] = V.vector4_u32[2];
     pDestination[3] = V.vector4_u32[3];
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     vst1q_u32_ex(pDestination, V, 128);
+#else
+    vst1q_u32(pDestination, V);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     _mm_store_si128(reinterpret_cast<__m128i*>(pDestination), _mm_castps_si128(V));
 #endif
@@ -1641,7 +1703,11 @@ inline void XM_CALLCONV XMStoreFloat4A
     pDestination->z = V.vector4_f32[2];
     pDestination->w = V.vector4_f32[3];
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     vst1q_f32_ex(reinterpret_cast<float*>(pDestination), V, 128);
+#else
+    vst1q_f32(reinterpret_cast<float*>(pDestination), V);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     _mm_store_ps(&pDestination->x, V);
 #endif
@@ -1847,6 +1913,7 @@ inline void XM_CALLCONV XMStoreFloat4x3A
     pDestination->m[3][2] = M.r[3].vector4_f32[2];
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     float32x4_t T1 = vextq_f32(M.r[0], M.r[1], 1);
     float32x4_t T2 = vbslq_f32(g_XMMask3, M.r[0], T1);
     vst1q_f32_ex(&pDestination->m[0][0], T2, 128);
@@ -1858,6 +1925,19 @@ inline void XM_CALLCONV XMStoreFloat4x3A
     T1 = vdupq_lane_f32(vget_high_f32(M.r[2]), 0);
     T2 = vextq_f32(T1, M.r[3], 3);
     vst1q_f32_ex(&pDestination->m[2][2], T2, 128);
+#else
+    float32x4_t T1 = vextq_f32(M.r[0], M.r[1], 1);
+    float32x4_t T2 = vbslq_f32(g_XMMask3, M.r[0], T1);
+    vst1q_f32(&pDestination->m[0][0], T2);
+
+    T1 = vextq_f32(M.r[1], M.r[1], 1);
+    T2 = vcombine_f32(vget_low_f32(T1), vget_low_f32(M.r[2]));
+    vst1q_f32(&pDestination->m[1][1], T2);
+
+    T1 = vdupq_lane_f32(vget_high_f32(M.r[2]), 0);
+    T2 = vextq_f32(T1, M.r[3], 3);
+    vst1q_f32(&pDestination->m[2][2], T2);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     // x1,y1,z1,w1
     XMVECTOR vTemp1 = M.r[0];
@@ -1977,9 +2057,15 @@ inline void XM_CALLCONV XMStoreFloat3x4A
     float32x4x2_t T0 = vzipq_f32(P0.val[0], P1.val[0]);
     float32x4x2_t T1 = vzipq_f32(P0.val[1], P1.val[1]);
 
+#ifdef _MSC_VER
     vst1q_f32_ex(&pDestination->m[0][0], T0.val[0], 128);
     vst1q_f32_ex(&pDestination->m[1][0], T0.val[1], 128);
     vst1q_f32_ex(&pDestination->m[2][0], T1.val[0], 128);
+#else
+    vst1q_f32(&pDestination->m[0][0], T0.val[0]);
+    vst1q_f32(&pDestination->m[1][0], T0.val[1]);
+    vst1q_f32(&pDestination->m[2][0], T1.val[0]);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     // x.x,x.y,y.x,y.y
     XMVECTOR vTemp1 = _mm_shuffle_ps(M.r[0], M.r[1], _MM_SHUFFLE(1, 0, 1, 0));
@@ -2080,10 +2166,17 @@ inline void XM_CALLCONV XMStoreFloat4x4A
     pDestination->m[3][3] = M.r[3].vector4_f32[3];
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
+#ifdef _MSC_VER
     vst1q_f32_ex(reinterpret_cast<float*>(&pDestination->_11), M.r[0], 128);
     vst1q_f32_ex(reinterpret_cast<float*>(&pDestination->_21), M.r[1], 128);
     vst1q_f32_ex(reinterpret_cast<float*>(&pDestination->_31), M.r[2], 128);
     vst1q_f32_ex(reinterpret_cast<float*>(&pDestination->_41), M.r[3], 128);
+#else
+    vst1q_f32(reinterpret_cast<float*>(&pDestination->_11), M.r[0]);
+    vst1q_f32(reinterpret_cast<float*>(&pDestination->_21), M.r[1]);
+    vst1q_f32(reinterpret_cast<float*>(&pDestination->_31), M.r[2]);
+    vst1q_f32(reinterpret_cast<float*>(&pDestination->_41), M.r[3]);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     _mm_store_ps(&pDestination->_11, M.r[0]);
     _mm_store_ps(&pDestination->_21, M.r[1]);

--- a/Inc/DirectXMathMatrix.inl
+++ b/Inc/DirectXMathMatrix.inl
@@ -21,7 +21,7 @@
 
  //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -87,7 +87,7 @@ inline bool XM_CALLCONV XMMatrixIsNaN(FXMMATRIX M) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(pop)
 #endif
 

--- a/Inc/DirectXMathMatrix.inl
+++ b/Inc/DirectXMathMatrix.inl
@@ -21,7 +21,7 @@
 
  //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -87,7 +87,7 @@ inline bool XM_CALLCONV XMMatrixIsNaN(FXMMATRIX M) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(pop)
 #endif
 

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -1905,7 +1905,7 @@ inline bool XMVerifyCPUSupport() noexcept
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     int CPUInfo[4] = { -1 };
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -1919,7 +1919,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false;
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);
@@ -1954,7 +1954,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false; // No SSE2/SSE support
 
 #if defined(__AVX2__) || defined(_XM_AVX2_INTRINSICS_)
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
     __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuidex(CPUInfo, 7, 0);

--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -1297,7 +1297,7 @@ inline XMVECTOR XM_CALLCONV XMVectorPermute
 #elif defined(_XM_AVX_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     static const XMVECTORU32 three = { { { 3, 3, 3, 3 } } };
 
-    __declspec(align(16)) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
+    XM_ALIGNED_DATA(16) unsigned int elem[4] = { PermuteX, PermuteY, PermuteZ, PermuteW };
     __m128i vControl = _mm_load_si128(reinterpret_cast<const __m128i*>(&elem[0]));
 
     __m128i vSelect = _mm_cmpgt_epi32(vControl, three);
@@ -1733,8 +1733,12 @@ inline XMVECTOR XM_CALLCONV XMVectorNearEqual
     return Control.v;
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
-    XMVECTOR vDelta = vsubq_f32(V1, V2);
+    float32x4_t vDelta = vsubq_f32(V1, V2);
+#ifdef _MSC_VER
     return vacleq_f32(vDelta, Epsilon);
+#else
+    return vcleq_f32(vabsq_f32(vDelta), Epsilon);
+#endif
 #elif defined(_XM_SSE_INTRINSICS_)
     // Get the difference
     XMVECTOR vDelta = _mm_sub_ps(V1, V2);
@@ -2149,7 +2153,7 @@ inline XMVECTOR XM_CALLCONV XMVectorInBoundsR
 
 //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -2177,7 +2181,7 @@ inline XMVECTOR XM_CALLCONV XMVectorIsNaN(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(pop)
 #endif
 
@@ -2291,7 +2295,7 @@ namespace Internal
     }
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -2337,7 +2341,7 @@ inline XMVECTOR XM_CALLCONV XMVectorRound(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(pop)
 #endif
 
@@ -4020,8 +4024,8 @@ inline XMVECTOR XM_CALLCONV XMVectorPow
         } } };
     return vResult.v;
 #elif defined(_XM_SSE_INTRINSICS_)
-    __declspec(align(16)) float a[4];
-    __declspec(align(16)) float b[4];
+    XM_ALIGNED_DATA(16) float a[4];
+    XM_ALIGNED_DATA(16) float b[4];
     _mm_store_ps(a, V1);
     _mm_store_ps(b, V2);
     XMVECTOR vResult = _mm_setr_ps(
@@ -6198,7 +6202,11 @@ inline bool XM_CALLCONV XMVector2NearEqual
         (dy <= Epsilon.vector4_f32[1]));
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     float32x2_t vDelta = vsub_f32(vget_low_u32(V1), vget_low_u32(V2));
+#ifdef _MSC_VER
     uint32x2_t vTemp = vacle_f32(vDelta, vget_low_u32(Epsilon));
+#else
+    uint32x2_t vTemp = vcle_f32(vabs_f32(vDelta), vget_low_u32(Epsilon));
+#endif
     uint64_t r = vget_lane_u64(vTemp, 0);
     return (r == 0xFFFFFFFFFFFFFFFFU);
 #elif defined(_XM_SSE_INTRINSICS_)
@@ -6474,7 +6482,7 @@ inline bool XM_CALLCONV XMVector2InBounds
 
 //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -6498,7 +6506,7 @@ inline bool XM_CALLCONV XMVector2IsNaN(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(pop)
 #endif
 
@@ -8923,7 +8931,11 @@ inline bool XM_CALLCONV XMVector3NearEqual
         (dz <= Epsilon.vector4_f32[2])) != 0);
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     float32x4_t vDelta = vsubq_f32(V1, V2);
+#ifdef _MSC_VER
     uint32x4_t vResult = vacleq_f32(vDelta, Epsilon);
+#else
+    uint32x4_t vResult = vcleq_f32(vabsq_f32(vDelta), Epsilon);
+#endif
     uint8x8x2_t vTemp = vzip_u8(vget_low_u8(vResult), vget_high_u8(vResult));
     uint16x4x2_t vTemp2 = vzip_u16(vTemp.val[0], vTemp.val[1]);
     return ((vget_lane_u32(vTemp2.val[1], 1) & 0xFFFFFFU) == 0xFFFFFFU);
@@ -9222,7 +9234,7 @@ inline bool XM_CALLCONV XMVector3InBounds
 
 //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -9250,7 +9262,7 @@ inline bool XM_CALLCONV XMVector3IsNaN(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(pop)
 #endif
 
@@ -12784,7 +12796,11 @@ inline bool XM_CALLCONV XMVector4NearEqual
         (dw <= Epsilon.vector4_f32[3])) != 0);
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
     float32x4_t vDelta = vsubq_f32(V1, V2);
+#ifdef _MSC_VER
     uint32x4_t vResult = vacleq_f32(vDelta, Epsilon);
+#else
+    uint32x4_t vResult = vcleq_f32(vabsq_f32(vDelta), Epsilon);
+#endif
     uint8x8x2_t vTemp = vzip_u8(vget_low_u8(vResult), vget_high_u8(vResult));
     uint16x4x2_t vTemp2 = vzip_u16(vTemp.val[0], vTemp.val[1]);
     return (vget_lane_u32(vTemp2.val[1], 1) == 0xFFFFFFFFU);
@@ -13098,7 +13114,7 @@ inline bool XM_CALLCONV XMVector4InBounds
 
 //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -13125,7 +13141,7 @@ inline bool XM_CALLCONV XMVector4IsNaN(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
 #pragma float_control(pop)
 #endif
 

--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -2153,7 +2153,7 @@ inline XMVECTOR XM_CALLCONV XMVectorInBoundsR
 
 //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -2181,7 +2181,7 @@ inline XMVECTOR XM_CALLCONV XMVectorIsNaN(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(pop)
 #endif
 
@@ -2295,7 +2295,7 @@ namespace Internal
     }
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -2341,7 +2341,7 @@ inline XMVECTOR XM_CALLCONV XMVectorRound(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(pop)
 #endif
 
@@ -6482,7 +6482,7 @@ inline bool XM_CALLCONV XMVector2InBounds
 
 //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -6506,7 +6506,7 @@ inline bool XM_CALLCONV XMVector2IsNaN(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(pop)
 #endif
 
@@ -9234,7 +9234,7 @@ inline bool XM_CALLCONV XMVector3InBounds
 
 //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -9262,7 +9262,7 @@ inline bool XM_CALLCONV XMVector3IsNaN(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(pop)
 #endif
 
@@ -13114,7 +13114,7 @@ inline bool XM_CALLCONV XMVector4InBounds
 
 //------------------------------------------------------------------------------
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(push)
 #pragma float_control(precise, on)
 #endif
@@ -13141,7 +13141,7 @@ inline bool XM_CALLCONV XMVector4IsNaN(FXMVECTOR V) noexcept
 #endif
 }
 
-#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER)
+#if !defined(_XM_NO_INTRINSICS_) && defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma float_control(pop)
 #endif
 

--- a/Inc/DirectXPackedVector.inl
+++ b/Inc/DirectXPackedVector.inl
@@ -1164,7 +1164,7 @@ inline XMVECTOR XM_CALLCONV XMLoadFloat3PK(const XMFLOAT3PK* pSource) noexcept
 {
     assert(pSource);
 
-    __declspec(align(16)) uint32_t Result[4];
+    XM_ALIGNED_DATA(16) uint32_t Result[4];
     uint32_t Mantissa;
     uint32_t Exponent;
 
@@ -2481,7 +2481,7 @@ inline void XM_CALLCONV XMStoreFloat3PK
 {
     assert(pDestination);
 
-    __declspec(align(16)) uint32_t IValue[4];
+    XM_ALIGNED_DATA(16) uint32_t IValue[4];
     XMStoreFloat3A(reinterpret_cast<XMFLOAT3A*>(&IValue), V);
 
     uint32_t Result[3];


### PR DESCRIPTION
In verifying the ARM-NEON paths with an ARM64 supporting clang compiler, I made two sets of changes:

* Some things I used in the ARM-NEON paths were actually MSVC-specific. In particular, the ``_ex`` memory alignment versions are MSVC specific as is the intrinsic for the ``VACLE`` pseudo-instruction.

* The Android NDK was the easiest way to validate the ARM paths with clang/LLVM, and that was easier done with "GNUC" support. The bulk of the changes were cherry-picked from [this pull request](https://github.com/microsoft/DirectXMath/pull/86).