### PR TITLE
Do not disable overloads for XMVECTOR for GNUC/clang when building with no-intrinsics

### DIFF
--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -93,7 +93,9 @@
 #define _XM_SVML_INTRINSICS_
 #endif
 
-#if !defined(_XM_NO_XMVECTOR_OVERLOADS_) && (defined(__clang__) || defined(__GNUC__))
+#if !defined(_XM_NO_XMVECTOR_OVERLOADS_) && \
+    (defined(__clang__) || (defined(__GNUC__) && __GNUC__ < 9)) && \
+    !defined(_XM_FORCE_VECTOR_OVERLOADS_)
 #define _XM_NO_XMVECTOR_OVERLOADS_
 #endif
 


### PR DESCRIPTION
In my experience, these work completely fine on a modern GCC.

This also adds a force macro to disable this functionality.