### PR TITLE
Add C++20 defaulted comparisions to structs to support all comparisons

### DIFF
--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -171,6 +171,10 @@
 #define XM_ALIGNED_STRUCT(x) __declspec(align(x)) struct
 #endif
 
+#if (__cplusplus >= 202002L)
+#include <compare>
+#endif
+
 /****************************************************************************
  *
  * Conditional intrinsics

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -593,6 +593,11 @@ namespace DirectX
 
         constexpr XMFLOAT2(float _x, float _y) noexcept : x(_x), y(_y) {}
         explicit XMFLOAT2(_In_reads_(2) const float* pArray)  noexcept : x(pArray[0]), y(pArray[1]) {}
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMFLOAT2&) const = default;
+        auto operator <=> (const XMFLOAT2&) const = default;
+#endif
     };
 
     // 2D Vector; 32 bit floating point components aligned on a 16 byte boundary
@@ -618,6 +623,11 @@ namespace DirectX
 
         constexpr XMINT2(int32_t _x, int32_t _y) noexcept : x(_x), y(_y) {}
         explicit XMINT2(_In_reads_(2) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMINT2&) const = default;
+        auto operator <=> (const XMINT2&) const = default;
+#endif
     };
 
     // 2D Vector; 32 bit unsigned integer components
@@ -636,6 +646,11 @@ namespace DirectX
 
         constexpr XMUINT2(uint32_t _x, uint32_t _y) noexcept : x(_x), y(_y) {}
         explicit XMUINT2(_In_reads_(2) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]) {}
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMUINT2&) const = default;
+        auto operator <=> (const XMUINT2&) const = default;
+#endif
     };
 
     //------------------------------------------------------------------------------
@@ -682,6 +697,11 @@ namespace DirectX
 
         constexpr XMINT3(int32_t _x, int32_t _y, int32_t _z) noexcept : x(_x), y(_y), z(_z) {}
         explicit XMINT3(_In_reads_(3) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMINT3&) const = default;
+        auto operator <=> (const XMINT3&) const = default;
+#endif
     };
 
     // 3D Vector; 32 bit unsigned integer components
@@ -701,6 +721,11 @@ namespace DirectX
 
         constexpr XMUINT3(uint32_t _x, uint32_t _y, uint32_t _z) noexcept : x(_x), y(_y), z(_z) {}
         explicit XMUINT3(_In_reads_(3) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]) {}
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMUINT3&) const = default;
+        auto operator <=> (const XMUINT3&) const = default;
+#endif
     };
 
     //------------------------------------------------------------------------------
@@ -722,6 +747,11 @@ namespace DirectX
 
         constexpr XMFLOAT4(float _x, float _y, float _z, float _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
         explicit XMFLOAT4(_In_reads_(4) const float* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMFLOAT4&) const = default;
+        auto operator <=> (const XMFLOAT4&) const = default;
+#endif
     };
 
     // 4D Vector; 32 bit floating point components aligned on a 16 byte boundary
@@ -749,6 +779,11 @@ namespace DirectX
 
         constexpr XMINT4(int32_t _x, int32_t _y, int32_t _z, int32_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
         explicit XMINT4(_In_reads_(4) const int32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMINT4&) const = default;
+        auto operator <=> (const XMINT4&) const = default;
+#endif
     };
 
     // 4D Vector; 32 bit unsigned integer components
@@ -769,6 +804,11 @@ namespace DirectX
 
         constexpr XMUINT4(uint32_t _x, uint32_t _y, uint32_t _z, uint32_t _w) noexcept : x(_x), y(_y), z(_z), w(_w) {}
         explicit XMUINT4(_In_reads_(4) const uint32_t* pArray) noexcept : x(pArray[0]), y(pArray[1]), z(pArray[2]), w(pArray[3]) {}
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMUINT4&) const = default;
+        auto operator <=> (const XMUINT4&) const = default;
+#endif
     };
 
 #ifdef __clang__
@@ -808,8 +848,13 @@ namespace DirectX
             _31(m20), _32(m21), _33(m22) {}
         explicit XMFLOAT3X3(_In_reads_(9) const float* pArray) noexcept;
 
-        float       operator() (size_t Row, size_t Column) const  noexcept { return m[Row][Column]; }
+        float  operator() (size_t Row, size_t Column) const  noexcept { return m[Row][Column]; }
         float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMFLOAT3X3&) const = default;
+        auto operator <=> (const XMFLOAT3X3&) const = default;
+#endif
     };
 
     //------------------------------------------------------------------------------
@@ -847,8 +892,13 @@ namespace DirectX
             _41(m30), _42(m31), _43(m32) {}
         explicit XMFLOAT4X3(_In_reads_(12) const float* pArray) noexcept;
 
-        float       operator() (size_t Row, size_t Column) const  noexcept { return m[Row][Column]; }
+        float  operator() (size_t Row, size_t Column) const  noexcept { return m[Row][Column]; }
         float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMFLOAT4X3&) const = default;
+        auto operator <=> (const XMFLOAT4X3&) const = default;
+#endif
     };
 
     // 4x3 Row-major Matrix: 32 bit floating point components aligned on a 16 byte boundary
@@ -889,8 +939,13 @@ namespace DirectX
             _31(m20), _32(m21), _33(m22), _34(m23) {}
         explicit XMFLOAT3X4(_In_reads_(12) const float* pArray) noexcept;
 
-        float       operator() (size_t Row, size_t Column) const noexcept { return m[Row][Column]; }
+        float  operator() (size_t Row, size_t Column) const noexcept { return m[Row][Column]; }
         float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMFLOAT3X4&) const = default;
+        auto operator <=> (const XMFLOAT3X4&) const = default;
+#endif
     };
 
     // 3x4 Column-major Matrix: 32 bit floating point components aligned on a 16 byte boundary
@@ -933,8 +988,13 @@ namespace DirectX
             _41(m30), _42(m31), _43(m32), _44(m33) {}
         explicit XMFLOAT4X4(_In_reads_(16) const float* pArray) noexcept;
 
-        float       operator() (size_t Row, size_t Column) const noexcept { return m[Row][Column]; }
+        float  operator() (size_t Row, size_t Column) const noexcept { return m[Row][Column]; }
         float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
+
+#if (__cplusplus >= 202002L)
+        bool operator == (const XMFLOAT4X4&) const = default;
+        auto operator <=> (const XMFLOAT4X4&) const = default;
+#endif
     };
 
     // 4x4 Matrix: 32 bit floating point components aligned on a 16 byte boundary


### PR DESCRIPTION
C++20 supports defaulted comparisons, and the recommendation is to define just the two primary operators. The complier can derive all other comparison operators from those.