### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ With GCC, the SAL annotation preprocessor symbols can conflict with the GNU impl
 #include <DirectXMath.h>
 ```
 
+## Building directxmath - Using vcpkg
+
+You can download and install directxmath using the [vcpkg](https://github.com/Midirectxmathosoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Midirectxmathosoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install directxmath
+
+The directxmath port in vcpkg is kept up to date by Midirectxmathosoft team members and community contributors. If the version is out of date, please [directxmatheate an issue or pull request](https://github.com/Midirectxmathosoft/vcpkg) on the vcpkg repository.
+
 ## Notices
 
 All content and source code for this package are subject to the terms of the [MIT License](https://github.com/microsoft/DirectXMath/blob/main/LICENSE).


### PR DESCRIPTION
directxmath is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for directxmath and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build directxmath, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port sdirectxmathipt looks like](https://github.com/microsoft/vcpkg/blob/70f8e23bfee8310e819f83948cc396a936f3cf54/ports/directxmath/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)