### PR TITLE
CMake update for version 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.14)
+cmake_minimum_required (VERSION 3.20)
 
 set(DIRECTXMATH_VERSION 3.1.8)
 
@@ -10,6 +10,8 @@ project(DirectXMath
   DESCRIPTION "DirectXMath SIMD C++ math library"
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
   LANGUAGES CXX)
+
+option(BUILD_TESTING "Build test suite (if present)" ON)
 
 include(GNUInstallDirs)
 
@@ -67,3 +69,23 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config-version.cmake
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})
+
+#--- Test suite
+if (DEFINED VCPKG_TARGET_ARCHITECTURE)
+    set(DXMATH_ARCHITECTURE ${VCPKG_TARGET_ARCHITECTURE})
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Ww][Ii][Nn]32$")
+    set(DXMATH_ARCHITECTURE x86)
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Xx]64$")
+    set(DXMATH_ARCHITECTURE x64)
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]$")
+    set(DXMATH_ARCHITECTURE arm)
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
+    set(DXMATH_ARCHITECTURE arm64)
+elseif(NOT DXMATH_ARCHITECTURE)
+    set(DXMATH_ARCHITECTURE "x64")
+endif()
+
+if(BUILD_TESTING AND WIN32 AND (NOT WINDOWS_STORE) AND (EXISTS "${CMAKE_CURRENT_LIST_DIR}/Tests/CMakeLists.txt"))
+  enable_testing()
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/Tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ elseif(NOT DXMATH_ARCHITECTURE)
     set(DXMATH_ARCHITECTURE "x64")
 endif()
 
+#--- Test suite
 include(CTest)
 if(BUILD_TESTING AND WIN32 AND (NOT WINDOWS_STORE) AND (EXISTS "${CMAKE_CURRENT_LIST_DIR}/Tests/CMakeLists.txt"))
   enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ project(DirectXMath
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
   LANGUAGES CXX)
 
-option(BUILD_TESTING "Build test suite (if present)" ON)
-
 include(GNUInstallDirs)
 
 #--- Library
@@ -85,6 +83,7 @@ elseif(NOT DXMATH_ARCHITECTURE)
     set(DXMATH_ARCHITECTURE "x64")
 endif()
 
+include(CTest)
 if(BUILD_TESTING AND WIN32 AND (NOT WINDOWS_STORE) AND (EXISTS "${CMAKE_CURRENT_LIST_DIR}/Tests/CMakeLists.txt"))
   enable_testing()
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/Tests)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -150,101 +150,12 @@
     { "name": "arm64-Debug"  , "description": "MSVC for ARM64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug", "MSVC" ] },
     { "name": "arm64-Release", "description": "MSVC for ARM64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "MSVC" ] },
 
-    { "name": "x64-Debug-AVX"   , "description": "MSVC for x64 (Debug) - AVX", "inherits": [ "base", "x64", "Debug", "AVX", "MSVC" ] },
-    { "name": "x64-Release-AVX" , "description": "MSVC for x64 (Release) - AVX", "inherits": [ "base", "x64", "Release", "AVX", "MSVC" ] },
-    { "name": "x86-Debug-AVX"   , "description": "MSVC for x86 (Debug) - AVX", "inherits": [ "base", "x86", "Debug", "AVX", "MSVC" ] },
-    { "name": "x86-Release-AVX" , "description": "MSVC for x86 (Release) - AVX", "inherits": [ "base", "x86", "Release", "AVX", "MSVC" ] },
-
-    { "name": "x64-Debug-AVX2"   , "description": "MSVC for x64 (Debug) - AVX2", "inherits": [ "base", "x64", "Debug", "AVX2", "MSVC" ] },
-    { "name": "x64-Release-AVX2" , "description": "MSVC for x64 (Release) - AVX2", "inherits": [ "base", "x64", "Release", "AVX2", "MSVC" ] },
-    { "name": "x86-Debug-AVX2"   , "description": "MSVC for x86 (Debug) - AVX2", "inherits": [ "base", "x86", "Debug", "AVX2", "MSVC" ] },
-    { "name": "x86-Release-AVX2" , "description": "MSVC for x86 (Release) - AVX2", "inherits": [ "base", "x86", "Release", "AVX2", "MSVC" ] },
-
-    { "name": "x64-Debug-NI"    , "description": "MSVC for x64 (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "MSVC" ] },
-    { "name": "x64-Release-NI"  , "description": "MSVC for x64 (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "MSVC" ] },
-    { "name": "x86-Debug-NI"    , "description": "MSVC for x86 (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "MSVC" ] },
-    { "name": "x86-Release-NI"  , "description": "MSVC for x86 (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "MSVC" ] },
-    { "name": "arm64-Debug-NI"  , "description": "MSVC for ARM64 (Debug) - no intrinsics", "inherits": [ "base", "ARM64", "Debug", "NI", "MSVC" ] },
-    { "name": "arm64-Release-NI", "description": "MSVC for ARM64 (Release) - no intrinsics", "inherits": [ "base", "ARM64", "Release", "NI", "MSVC" ] },
-
-    { "name": "x64-Debug-OneCore"    , "description": "OneCore x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "MSVC", "OneCore" ] },
-    { "name": "x64-Release-OneCore"  , "description": "OneCore x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "MSVC", "OneCore" ] },
-    { "name": "x86-Debug-OneCore"    , "description": "OneCore x86 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "MSVC", "OneCore" ] },
-    { "name": "x86-Release-OneCore"  , "description": "OneCore x86 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "MSVC", "OneCore" ] },
-    { "name": "arm-Debug-OneCore"    , "description": "OneCore ARM (Debug) - ARM-NEON", "inherits": [ "base", "ARM", "Debug", "MSVC", "OneCore" ] },
-    { "name": "arm-Release-OneCore"  , "description": "OneCore ARM (Release) - ARM-NEON", "inherits": [ "base", "ARM", "Release", "MSVC", "OneCore" ] },
-    { "name": "arm64-Debug-OneCore"  , "description": "OneCore ARM64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug", "MSVC", "OneCore" ] },
-    { "name": "arm64-Release-OneCore", "description": "OneCore ARM64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "MSVC", "OneCore" ] },
-
-    { "name": "x64-Debug-XboxOne"    , "description": "Xbox One (Debug)", "inherits": [ "base", "x64", "Debug", "F16C", "MSVC", "OneCore" ] },
-    { "name": "x64-Release-XboxOne"  , "description": "Xbox One (Release)", "inherits": [ "base", "x64", "Release", "F16C", "MSVC", "OneCore" ] },
-
-    { "name": "x64-Debug-Scarlett"   , "description": "Xbox Series X|S (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "AVX2", "MSVC", "OneCore" ] },
-    { "name": "x64-Release-Scarlett" , "description": "Xbox Series X|S (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "AVX2", "MSVC", "OneCore" ] },
-
     { "name": "x64-Debug-Clang"    , "description": "Clang/LLVM for x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "Clang" ] },
     { "name": "x64-Release-Clang"  , "description": "Clang/LLVM for x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "Clang" ] },
     { "name": "x86-Debug-Clang"    , "description": "Clang/LLVM for x86 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
     { "name": "x86-Release-Clang"  , "description": "Clang/LLVM for x86 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
     { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-
-    { "name": "x64-Debug-AVX-Clang"   , "description": "Clang/LLVM for x64 (Debug) - AVX", "inherits": [ "base", "x64", "Debug", "AVX", "Clang" ] },
-    { "name": "x64-Release-AVX-Clang" , "description": "Clang/LLVM for x64 (Release) - AVX", "inherits": [ "base", "x64", "Release", "AVX", "Clang" ] },
-    { "name": "x86-Debug-AVX-Clang"   , "description": "Clang/LLVM for x86 (Debug) - AVX", "inherits": [ "base", "x86", "Debug", "AVX", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "x86-Release-AVX-Clang" , "description": "Clang/LLVM for x86 (Release) - AVX", "inherits": [ "base", "x86", "Release", "AVX", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-
-    { "name": "x64-Debug-AVX2-Clang"  , "description": "Clang/LLVM for x64 (Debug) - AVX2", "inherits": [ "base", "x64", "Debug", "AVX2", "Clang" ] },
-    { "name": "x64-Release-AVX2-Clang", "description": "Clang/LLVM for x64 (Release) - AVX2", "inherits": [ "base", "x64", "Release", "AVX2", "Clang" ] },
-    { "name": "x86-Debug-AVX2-Clang"  , "description": "Clang/LLVM for x86 (Debug) - AVX2", "inherits": [ "base", "x86", "Debug", "AVX2", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "x86-Release-AVX2-Clang", "description": "Clang/LLVM for x86 (Release) - AVX2", "inherits": [ "base", "x86", "Release", "AVX2", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-
-    { "name": "x64-Debug-NI-Clang"    , "description": "Clang/LLVM for x64 (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "Clang" ] },
-    { "name": "x64-Release-NI-Clang"  , "description": "Clang/LLVM for x64 (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "Clang" ] },
-    { "name": "x86-Debug-NI-Clang"    , "description": "Clang/LLVM for x86 (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "x86-Release-NI-Clang"  , "description": "Clang/LLVM for x86 (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "arm64-Debug-NI-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) - no intrinsics", "inherits": [ "base", "ARM64", "Debug", "NI", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-NI-Clang", "description": "Clang/LLVM for AArch64 (Release) - no intrinsics", "inherits": [ "base", "ARM64", "Release", "NI", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-
-    { "name": "x64-Debug-ICC"     , "description": "Intel Classic Compiler (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "Intel" ] },
-    { "name": "x64-Release-ICC"   , "description": "Intel Classic Compiler (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "Intel" ] },
-    { "name": "x64-Debug-NI-ICC"  , "description": "Intel Classic Compiler (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "Intel" ] },
-    { "name": "x64-Release-NI-ICC", "description": "Intel Classic Compiler (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "Intel" ] },
-
-    { "name": "x86-Debug-ICC"     , "description": "Intel Classic Compiler (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "Intel" ] },
-    { "name": "x86-Release-ICC"   , "description": "Intel Classic Compiler (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "Intel" ] },
-    { "name": "x86-Debug-NI-ICC"  , "description": "Intel Classic Compiler (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "Intel" ] },
-    { "name": "x86-Release-NI-ICC", "description": "Intel Classic Compiler (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "Intel" ] },
-
-    { "name": "x64-Debug-ICX"     , "description": "Intel oneAPI Compiler (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "IntelLLVM" ] },
-    { "name": "x64-Release-ICX"   , "description": "Intel oneAPI Compiler (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "IntelLLVM" ] },
-    { "name": "x64-Debug-NI-ICX"  , "description": "Intel oneAPI Compiler (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "IntelLLVM" ] },
-    { "name": "x64-Release-NI-ICX", "description": "Intel oneAPI Compiler (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "IntelLLVM" ] },
-
-    { "name": "x86-Debug-ICX"     , "description": "Intel oneAPI Compiler (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "IntelLLVM" ] },
-    { "name": "x86-Release-ICX"   , "description": "Intel oneAPI Compiler (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "IntelLLVM" ] },
-    { "name": "x86-Debug-NI-ICX"  , "description": "Intel oneAPI Compiler (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "IntelLLVM" ] },
-    { "name": "x86-Release-NI-ICX", "description": "Intel oneAPI Compiler (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "IntelLLVM" ] },
-
-    { "name": "x64-Debug-MinGW"     , "description": "MinG-W64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
-    { "name": "x64-Release-MinGW"   , "description": "MinG-W64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
-    { "name": "x64-Debug-NI-MinGW"  , "description": "MinG-W64 (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
-    { "name": "x64-Release-NI-MinGW", "description": "MinG-W64 (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
-
-    { "name": "x86-Debug-MinGW"     , "description": "MinG-W32 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
-    { "name": "x86-Release-MinGW"   , "description": "MinG-W32 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
-    { "name": "x86-Debug-NI-MinGW"  , "description": "MinG-W32 (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
-    { "name": "x86-Release-NI-MinGW", "description": "MinG-W32 (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
-
-    { "name": "x64-Debug-WSL"     , "description": "WSL x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug" ] },
-    { "name": "x64-Release-WSL"   , "description": "WSL x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release" ] },
-    { "name": "x64-Debug-NI-WSL"  , "description": "WSL x64 (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI" ] },
-    { "name": "x64-Release-NI-WSL", "description": "WSL x64 (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI" ] },
-
-    { "name": "arm64-Debug-WSL"     , "description": "WSL AArch64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug" ] },
-    { "name": "arm64-Release-WSL"   , "description": "WSL AArch64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release" ] },
-    { "name": "arm64-Debug-NI-WSL"  , "description": "WSL AArch64 (Debug) - no intrinsics", "inherits": [ "base", "ARM64", "Debug", "NI" ] },
-    { "name": "arm64-Release-NI-WSL", "description": "WSL AArch64 (Release) - no intrinsics", "inherits": [ "base", "ARM64", "Release", "NI" ] }
+    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } }
   ],
   "testPresets": [
     { "name": "x64-Debug"    , "configurePreset": "x64-Debug" },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,12 +17,71 @@
         "value": "x64",
         "strategy": "external"
       },
+      "cacheVariables": { "DXMATH_ARCHITECTURE": "x64" },
+      "hidden": true
+    },
+    {
+      "name": "x86",
+      "architecture": {
+        "value": "x86",
+        "strategy": "external"
+      },
+      "cacheVariables": { "DXMATH_ARCHITECTURE": "x86" },
+      "hidden": true
+    },
+    {
+      "name": "ARM",
+      "architecture": {
+        "value": "arm",
+        "strategy": "external"
+      },
+      "cacheVariables": { "DXMATH_ARCHITECTURE": "arm" },
+      "hidden": true
+    },
+    {
+      "name": "ARM64",
+      "architecture": {
+        "value": "arm64",
+        "strategy": "external"
+      },
+      "cacheVariables": { "DXMATH_ARCHITECTURE": "arm64" },
       "hidden": true
     },
 
     {
       "name": "Debug",
       "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" },
+      "hidden": true
+    },
+    {
+      "name": "Release",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "hidden": true
+    },
+
+    {
+      "name": "OneCore",
+      "cacheVariables": { "BUILD_FOR_ONECORE": true },
+      "hidden": true
+    },
+    {
+      "name": "AVX",
+      "cacheVariables": { "BUILD_AVX_TEST": true },
+      "hidden": true
+    },
+    {
+      "name": "AVX2",
+      "cacheVariables": { "BUILD_AVX2_TEST": true },
+      "hidden": true
+    },
+    {
+      "name": "F16C",
+      "cacheVariables": { "BUILD_F16C_TEST": true },
+      "hidden": true
+    },
+    {
+      "name": "NI",
+      "cacheVariables": { "BUILD_NO_INTRINSICS": true },
       "hidden": true
     },
 
@@ -37,7 +96,169 @@
         "strategy": "external"
       }
     },
+    {
+      "name": "Clang",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang-cl.exe"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "GNUC",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++.exe"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "Intel",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "icl.exe"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "IntelLLVM",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "icx.exe"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      }
+    },
 
-    { "name": "x64-Debug"    , "description": "MSVC for x64 (Debug) for Windows 8", "inherits": [ "base", "x64", "Debug", "MSVC" ] }
+    { "name": "x64-Debug"    , "description": "MSVC for x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "MSVC" ] },
+    { "name": "x64-Release"  , "description": "MSVC for x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "MSVC" ] },
+    { "name": "x86-Debug"    , "description": "MSVC for x86 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "MSVC" ] },
+    { "name": "x86-Release"  , "description": "MSVC for x86 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "MSVC" ] },
+    { "name": "arm-Debug"    , "description": "MSVC for ARM (Debug) - ARM-NEON", "inherits": [ "base", "ARM", "Debug", "MSVC" ] },
+    { "name": "arm-Release"  , "description": "MSVC for ARM (Release) - ARM-NEON", "inherits": [ "base", "ARM", "Release", "MSVC" ] },
+    { "name": "arm64-Debug"  , "description": "MSVC for ARM64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug", "MSVC" ] },
+    { "name": "arm64-Release", "description": "MSVC for ARM64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "MSVC" ] },
+
+    { "name": "x64-Debug-AVX"   , "description": "MSVC for x64 (Debug) - AVX", "inherits": [ "base", "x64", "Debug", "AVX", "MSVC" ] },
+    { "name": "x64-Release-AVX" , "description": "MSVC for x64 (Release) - AVX", "inherits": [ "base", "x64", "Release", "AVX", "MSVC" ] },
+    { "name": "x86-Debug-AVX"   , "description": "MSVC for x86 (Debug) - AVX", "inherits": [ "base", "x86", "Debug", "AVX", "MSVC" ] },
+    { "name": "x86-Release-AVX" , "description": "MSVC for x86 (Release) - AVX", "inherits": [ "base", "x86", "Release", "AVX", "MSVC" ] },
+
+    { "name": "x64-Debug-AVX2"   , "description": "MSVC for x64 (Debug) - AVX2", "inherits": [ "base", "x64", "Debug", "AVX2", "MSVC" ] },
+    { "name": "x64-Release-AVX2" , "description": "MSVC for x64 (Release) - AVX2", "inherits": [ "base", "x64", "Release", "AVX2", "MSVC" ] },
+    { "name": "x86-Debug-AVX2"   , "description": "MSVC for x86 (Debug) - AVX2", "inherits": [ "base", "x86", "Debug", "AVX2", "MSVC" ] },
+    { "name": "x86-Release-AVX2" , "description": "MSVC for x86 (Release) - AVX2", "inherits": [ "base", "x86", "Release", "AVX2", "MSVC" ] },
+
+    { "name": "x64-Debug-NI"    , "description": "MSVC for x64 (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "MSVC" ] },
+    { "name": "x64-Release-NI"  , "description": "MSVC for x64 (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "MSVC" ] },
+    { "name": "x86-Debug-NI"    , "description": "MSVC for x86 (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "MSVC" ] },
+    { "name": "x86-Release-NI"  , "description": "MSVC for x86 (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "MSVC" ] },
+    { "name": "arm64-Debug-NI"  , "description": "MSVC for ARM64 (Debug) - no intrinsics", "inherits": [ "base", "ARM64", "Debug", "NI", "MSVC" ] },
+    { "name": "arm64-Release-NI", "description": "MSVC for ARM64 (Release) - no intrinsics", "inherits": [ "base", "ARM64", "Release", "NI", "MSVC" ] },
+
+    { "name": "x64-Debug-OneCore"    , "description": "OneCore x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "MSVC", "OneCore" ] },
+    { "name": "x64-Release-OneCore"  , "description": "OneCore x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "MSVC", "OneCore" ] },
+    { "name": "x86-Debug-OneCore"    , "description": "OneCore x86 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "MSVC", "OneCore" ] },
+    { "name": "x86-Release-OneCore"  , "description": "OneCore x86 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "MSVC", "OneCore" ] },
+    { "name": "arm-Debug-OneCore"    , "description": "OneCore ARM (Debug) - ARM-NEON", "inherits": [ "base", "ARM", "Debug", "MSVC", "OneCore" ] },
+    { "name": "arm-Release-OneCore"  , "description": "OneCore ARM (Release) - ARM-NEON", "inherits": [ "base", "ARM", "Release", "MSVC", "OneCore" ] },
+    { "name": "arm64-Debug-OneCore"  , "description": "OneCore ARM64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug", "MSVC", "OneCore" ] },
+    { "name": "arm64-Release-OneCore", "description": "OneCore ARM64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "MSVC", "OneCore" ] },
+
+    { "name": "x64-Debug-XboxOne"    , "description": "Xbox One (Debug)", "inherits": [ "base", "x64", "Debug", "F16C", "MSVC", "OneCore" ] },
+    { "name": "x64-Release-XboxOne"  , "description": "Xbox One (Release)", "inherits": [ "base", "x64", "Release", "F16C", "MSVC", "OneCore" ] },
+
+    { "name": "x64-Debug-Scarlett"   , "description": "Xbox Series X|S (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "AVX2", "MSVC", "OneCore" ] },
+    { "name": "x64-Release-Scarlett" , "description": "Xbox Series X|S (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "AVX2", "MSVC", "OneCore" ] },
+
+    { "name": "x64-Debug-Clang"    , "description": "Clang/LLVM for x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "Clang" ] },
+    { "name": "x64-Release-Clang"  , "description": "Clang/LLVM for x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "Clang" ] },
+    { "name": "x86-Debug-Clang"    , "description": "Clang/LLVM for x86 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "x86-Release-Clang"  , "description": "Clang/LLVM for x86 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+
+    { "name": "x64-Debug-AVX-Clang"   , "description": "Clang/LLVM for x64 (Debug) - AVX", "inherits": [ "base", "x64", "Debug", "AVX", "Clang" ] },
+    { "name": "x64-Release-AVX-Clang" , "description": "Clang/LLVM for x64 (Release) - AVX", "inherits": [ "base", "x64", "Release", "AVX", "Clang" ] },
+    { "name": "x86-Debug-AVX-Clang"   , "description": "Clang/LLVM for x86 (Debug) - AVX", "inherits": [ "base", "x86", "Debug", "AVX", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "x86-Release-AVX-Clang" , "description": "Clang/LLVM for x86 (Release) - AVX", "inherits": [ "base", "x86", "Release", "AVX", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
+
+    { "name": "x64-Debug-AVX2-Clang"  , "description": "Clang/LLVM for x64 (Debug) - AVX2", "inherits": [ "base", "x64", "Debug", "AVX2", "Clang" ] },
+    { "name": "x64-Release-AVX2-Clang", "description": "Clang/LLVM for x64 (Release) - AVX2", "inherits": [ "base", "x64", "Release", "AVX2", "Clang" ] },
+    { "name": "x86-Debug-AVX2-Clang"  , "description": "Clang/LLVM for x86 (Debug) - AVX2", "inherits": [ "base", "x86", "Debug", "AVX2", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "x86-Release-AVX2-Clang", "description": "Clang/LLVM for x86 (Release) - AVX2", "inherits": [ "base", "x86", "Release", "AVX2", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
+
+    { "name": "x64-Debug-NI-Clang"    , "description": "Clang/LLVM for x64 (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "Clang" ] },
+    { "name": "x64-Release-NI-Clang"  , "description": "Clang/LLVM for x64 (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "Clang" ] },
+    { "name": "x86-Debug-NI-Clang"    , "description": "Clang/LLVM for x86 (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "x86-Release-NI-Clang"  , "description": "Clang/LLVM for x86 (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
+    { "name": "arm64-Debug-NI-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) - no intrinsics", "inherits": [ "base", "ARM64", "Debug", "NI", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "arm64-Release-NI-Clang", "description": "Clang/LLVM for AArch64 (Release) - no intrinsics", "inherits": [ "base", "ARM64", "Release", "NI", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+
+    { "name": "x64-Debug-ICC"     , "description": "Intel Classic Compiler (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "Intel" ] },
+    { "name": "x64-Release-ICC"   , "description": "Intel Classic Compiler (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "Intel" ] },
+    { "name": "x64-Debug-NI-ICC"  , "description": "Intel Classic Compiler (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "Intel" ] },
+    { "name": "x64-Release-NI-ICC", "description": "Intel Classic Compiler (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "Intel" ] },
+
+    { "name": "x86-Debug-ICC"     , "description": "Intel Classic Compiler (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "Intel" ] },
+    { "name": "x86-Release-ICC"   , "description": "Intel Classic Compiler (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "Intel" ] },
+    { "name": "x86-Debug-NI-ICC"  , "description": "Intel Classic Compiler (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "Intel" ] },
+    { "name": "x86-Release-NI-ICC", "description": "Intel Classic Compiler (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "Intel" ] },
+
+    { "name": "x64-Debug-ICX"     , "description": "Intel oneAPI Compiler (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "IntelLLVM" ] },
+    { "name": "x64-Release-ICX"   , "description": "Intel oneAPI Compiler (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "IntelLLVM" ] },
+    { "name": "x64-Debug-NI-ICX"  , "description": "Intel oneAPI Compiler (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "IntelLLVM" ] },
+    { "name": "x64-Release-NI-ICX", "description": "Intel oneAPI Compiler (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "IntelLLVM" ] },
+
+    { "name": "x86-Debug-ICX"     , "description": "Intel oneAPI Compiler (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "IntelLLVM" ] },
+    { "name": "x86-Release-ICX"   , "description": "Intel oneAPI Compiler (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "IntelLLVM" ] },
+    { "name": "x86-Debug-NI-ICX"  , "description": "Intel oneAPI Compiler (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "IntelLLVM" ] },
+    { "name": "x86-Release-NI-ICX", "description": "Intel oneAPI Compiler (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "IntelLLVM" ] },
+
+    { "name": "x64-Debug-MinGW"     , "description": "MinG-W64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
+    { "name": "x64-Release-MinGW"   , "description": "MinG-W64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
+    { "name": "x64-Debug-NI-MinGW"  , "description": "MinG-W64 (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
+    { "name": "x64-Release-NI-MinGW", "description": "MinG-W64 (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
+
+    { "name": "x86-Debug-MinGW"     , "description": "MinG-W32 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
+    { "name": "x86-Release-MinGW"   , "description": "MinG-W32 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
+    { "name": "x86-Debug-NI-MinGW"  , "description": "MinG-W32 (Debug) - no intrinsics", "inherits": [ "base", "x86", "Debug", "NI", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
+    { "name": "x86-Release-NI-MinGW", "description": "MinG-W32 (Release) - no intrinsics", "inherits": [ "base", "x86", "Release", "NI", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
+
+    { "name": "x64-Debug-WSL"     , "description": "WSL x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug" ] },
+    { "name": "x64-Release-WSL"   , "description": "WSL x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release" ] },
+    { "name": "x64-Debug-NI-WSL"  , "description": "WSL x64 (Debug) - no intrinsics", "inherits": [ "base", "x64", "Debug", "NI" ] },
+    { "name": "x64-Release-NI-WSL", "description": "WSL x64 (Release) - no intrinsics", "inherits": [ "base", "x64", "Release", "NI" ] },
+
+    { "name": "arm64-Debug-WSL"     , "description": "WSL AArch64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug" ] },
+    { "name": "arm64-Release-WSL"   , "description": "WSL AArch64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release" ] },
+    { "name": "arm64-Debug-NI-WSL"  , "description": "WSL AArch64 (Debug) - no intrinsics", "inherits": [ "base", "ARM64", "Debug", "NI" ] },
+    { "name": "arm64-Release-NI-WSL", "description": "WSL AArch64 (Release) - no intrinsics", "inherits": [ "base", "ARM64", "Release", "NI" ] }
+  ],
+  "testPresets": [
+    { "name": "x64-Debug"    , "configurePreset": "x64-Debug" },
+    { "name": "x64-Release"  , "configurePreset": "x64-Release" },
+    { "name": "x86-Debug"    , "configurePreset": "x86-Debug" },
+    { "name": "x86-Release"  , "configurePreset": "x86-Release" },
+    { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug" },
+    { "name": "arm64-Release", "configurePreset": "arm64-Release" },
+
+    { "name": "x64-Debug-Clang"    , "configurePreset": "x64-Debug-Clang" },
+    { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },
+    { "name": "x86-Debug-Clang"    , "configurePreset": "x86-Debug-Clang" },
+    { "name": "x86-Release-Clang"  , "configurePreset": "x86-Release-Clang" },
+    { "name": "arm64-Debug-Clang"  , "configurePreset": "arm64-Debug-Clang" },
+    { "name": "arm64-Release-Clang", "configurePreset": "arm64-Release-Clang" }
   ]
 }


### PR DESCRIPTION
CMake 3.20 allows the removal of some string hacks for ``/Wall`` and ``/GR-`` for ``CMAKE_CXX_FLAGS``.

Also integrates the test suite if present. CTest support added to the test suite in this PR: https://github.com/walbourn/directxmathtest/pull/13