### PR TITLE
December 2022

### DIFF
--- a/.nuget/directxmath.nuspec
+++ b/.nuget/directxmath.nuspec
@@ -8,7 +8,7 @@
         <owners>microsoft,directxtk</owners>
         <summary>DirectXMath is an all inline SIMD C++ linear algebra library for use in games and graphics apps.</summary>
         <description>The DirectXMath API provides SIMD-friendly C++ types and functions for common linear algebra and graphics math operations common to DirectX applications. The library provides optimized versions for Windows 32-bit (x86), Windows 64-bit (x64), and Windows on ARM through SSE2 and ARM-NEON intrinsics support in the Visual Studio compiler.</description>
-        <releaseNotes>Matches the November 2022 release.</releaseNotes>
+        <releaseNotes>Matches the December 2022 release.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=615560</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMath.git" />
         <icon>images\icon.jpg</icon>
@@ -28,6 +28,6 @@
         <file src=".nuget/directxmath.targets" target="build\native" />
 
         <file src=".nuget/icon.jpg" target="images\" />
-      
+
     </files>
 </package>

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXM
 * C++20 spaceship operators for XMFLOAT2, XMFLOAT3, etc. when building with ``/std:c++20 /Zc:_cplusplus``
 * Improved conformance for ARM64 when using `/Zc:arm64-aliased-neon-types-`
 * Minor code review and CMake project updates
+* CMake project updated to require 3.20 or later
+* Added Azure Dev Ops Pipeline YAML files
 
 ### May 2022 (3.17b)
 * Hot-fix to address ``-Wreserved-identifier`` warnings with clang v13

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,7 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXM
 ### December 2022 (3.18)
 * C++20 spaceship operators for XMFLOAT2, XMFLOAT3, etc. when building with ``/std:c++20 /Zc:_cplusplus``
 * Improved conformance for ARM64 when using `/Zc:arm64-aliased-neon-types-`
-* Minor code review and CMake project updates
+* Minor code review
 * CMake project updated to require 3.20 or later
 * Added Azure Dev Ops Pipeline YAML files
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXM
 
 ## Release History
 
-### November 2022 (3.18)
+### December 2022 (3.18)
 * C++20 spaceship operators for XMFLOAT2, XMFLOAT3, etc. when building with ``/std:c++20 /Zc:_cplusplus``
 * Improved conformance for ARM64 when using `/Zc:arm64-aliased-neon-types-`
 * Minor code review and CMake project updates
@@ -109,8 +109,8 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXM
 
 ### April 2015 (3.07)
 * Fix customer reported bugs in BoundingBox methods
-* Fix customer reported bug in XMStoreFloat3SE  
-* Fix customer reported bug in XMVectorATan2, XMVectorATan2Est  
+* Fix customer reported bug in XMStoreFloat3SE
+* Fix customer reported bug in XMVectorATan2, XMVectorATan2Est
 * Fix customer reported bug in XMVectorRound
 
 ### October 2013 (3.06)
@@ -122,14 +122,14 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXM
 * Use x86/x64 ``__vectorcall`` calling-convention when available (``XM_CALLCONV``, ``HXMVECTOR``, ``FXMMATRIX`` introduced)
 * Fixed bug with XMVectorFloor and XMVectorCeiling when given whole odd numbers (i.e. 105.0)
 * Improved XMVectorRound algorithm
-* ARM-NEON optimizations for XMVectorExp2, XMVectorLog2, XMVectorExpE, and XMVectorLogE  
+* ARM-NEON optimizations for XMVectorExp2, XMVectorLog2, XMVectorExpE, and XMVectorLogE
 * ARM-NEON code paths use multiply-by-scalar intrinsics when supported
 * Additional optimizations for ARM-NEON Stream functions
 * Fixed potential warning C4723 using ``operator/`` or ``operator/=``
 
 ### March 2013 (3.04)
 * ``XMVectorExp2``, ``XMVectorLog2``, ``XMVectorExpE``, and ``XMVectorLogE`` functions added to provide base-e support in addition to the existing base-2 support
-* ``XMVectorExp`` and ``XMVectorLog`` are now aliases for XMVectorExp2 and XMVectorLog2  
+* ``XMVectorExp`` and ``XMVectorLog`` are now aliases for XMVectorExp2 and XMVectorLog2
 * Additional optimizations for Stream functions
 * XMVector3Cross now ensures w component is zero on ARM
 * XMConvertHalfToFloat and XMConvertFloatToHalf  now use IEEE 754 standard float16 behavior for INF/QNAN

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ https://github.com/Microsoft/DirectXMath
 
 Copyright (c) Microsoft Corporation.
 
-**November 2022**
+**December 2022**
 
 This package contains the DirectXMath library, an all inline SIMD C++ linear algebra library for use in games and graphics apps.
 
-This code is designed to build with Visual Studio 2019, Visual Studio 2022, or clang/LLVM for Windows. It is recommended that you make use of the latest updates (VS 2019 16.11).
+This code is designed to build with Visual Studio 2019 (16.11), Visual Studio 2022, or clang/LLVM for Windows. It is recommended that you make use of the latest updates.
 
 These components are designed to work without requiring any content from the legacy DirectX SDK. For details, see [Where is the DirectX SDK?](https://aka.ms/dxsdk).
 


### PR DESCRIPTION
### December 2022 (3.18)
* C++20 spaceship operators for XMFLOAT2, XMFLOAT3, etc. when building with ``/std:c++20 /Zc:_cplusplus``
* Improved conformance for ARM64 when using `/Zc:arm64-aliased-neon-types-`
* Minor code review
* CMake project updated to require 3.20 or later
* Added Azure Dev Ops Pipeline YAML files

> This version of DirectXMath is in the Windows SDK Preview build 25262 or later.