### PR TITLE
Suppress new clang v16 warnings

### DIFF
--- a/Inc/DirectXCollision.h
+++ b/Inc/DirectXCollision.h
@@ -340,14 +340,25 @@ namespace DirectX
      // C4365: Off by default noise
      // C6001: False positives
 #endif
+
 #ifdef _PREFAST_
 #pragma prefast(push)
 #pragma prefast(disable : 25000, "FXMVECTOR is 16 bytes")
 #pragma prefast(disable : 26495, "Union initialization confuses /analyze")
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+
 #include "DirectXCollision.inl"
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #ifdef _PREFAST_
 #pragma prefast(pop)
 #endif

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -819,6 +819,8 @@ namespace DirectX
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #pragma clang diagnostic ignored "-Wnested-anon-types"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
     //------------------------------------------------------------------------------
@@ -2167,7 +2169,10 @@ namespace DirectX
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
 #pragma clang diagnostic ignored "-Wundefined-reinterpret-cast"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
 //------------------------------------------------------------------------------

--- a/Inc/DirectXPackedVector.h
+++ b/Inc/DirectXPackedVector.h
@@ -1210,8 +1210,17 @@ namespace DirectX
 #pragma prefast(disable : 26495, "Union initialization confuses /analyze")
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+
 #include "DirectXPackedVector.inl"
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #ifdef _PREFAST_
 #pragma prefast(pop)
 #endif

--- a/SHMath/DirectXSH.cpp
+++ b/SHMath/DirectXSH.cpp
@@ -19,6 +19,8 @@
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wunused-const-variable"
 #pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
 #include "DirectXSH.h"

--- a/SHMath/DirectXSHD3D11.cpp
+++ b/SHMath/DirectXSHD3D11.cpp
@@ -36,6 +36,8 @@
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 #pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
 using namespace DirectX;

--- a/SHMath/DirectXSHD3D12.cpp
+++ b/SHMath/DirectXSHD3D12.cpp
@@ -31,6 +31,8 @@
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 #pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
 using namespace DirectX;

--- a/XDSP/XDSP.h
+++ b/XDSP/XDSP.h
@@ -27,6 +27,12 @@
 #pragma warning(disable: 6001 6262)
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+
 namespace XDSP
 {
     using XMVECTOR = DirectX::XMVECTOR;
@@ -866,6 +872,9 @@ namespace XDSP
 
 } // namespace XDSP
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
Clang version 16.0.0 is expected to ship in a future Visual Studio update, and when you build with ``/Wall`` it produces many new ``-Wunsafe-buffer-usage`` warnings for basically all use of raw pointers.
