### PR TITLE
Use two-argument cpuid when using recent MinGW

### DIFF
--- a/Extensions/DirectXMathAVX.h
+++ b/Extensions/DirectXMathAVX.h
@@ -28,7 +28,7 @@ inline bool XMVerifyAVXSupport()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid( CPUInfo, 0 );
@@ -37,7 +37,7 @@ inline bool XMVerifyAVXSupport()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1 );

--- a/Extensions/DirectXMathAVX2.h
+++ b/Extensions/DirectXMathAVX2.h
@@ -29,7 +29,7 @@ inline bool XMVerifyAVX2Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ inline bool XMVerifyAVX2Support()
     if ( CPUInfo[0] < 7  )
         return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathBE.h
+++ b/Extensions/DirectXMathBE.h
@@ -59,7 +59,7 @@ inline bool XMVerifySSSE3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -68,7 +68,7 @@ inline bool XMVerifySSSE3Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathF16C.h
+++ b/Extensions/DirectXMathF16C.h
@@ -29,7 +29,7 @@ inline bool XMVerifyF16CSupport()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ inline bool XMVerifyF16CSupport()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA3.h
+++ b/Extensions/DirectXMathFMA3.h
@@ -28,7 +28,7 @@ inline bool XMVerifyFMA3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifyFMA3Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -33,7 +33,7 @@ inline bool XMVerifyFMA4Support()
 
    // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
    int CPUInfo[4] = {-1};
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
    __cpuid(CPUInfo, 0);
@@ -42,7 +42,7 @@ inline bool XMVerifyFMA4Support()
    if ( CPUInfo[0] < 1  )
        return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
    __cpuid(CPUInfo, 1);
@@ -52,7 +52,7 @@ inline bool XMVerifyFMA4Support()
     if ( (CPUInfo[2] & 0x18000000) != 0x18000000 )
         return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0x80000000);
@@ -62,7 +62,7 @@ inline bool XMVerifyFMA4Support()
         return false;
 
     // We check for FMA4
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0x80000001, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0x80000001);

--- a/Extensions/DirectXMathSSE3.h
+++ b/Extensions/DirectXMathSSE3.h
@@ -29,7 +29,7 @@ inline bool XMVerifySSE3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifySSE3Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathSSE4.h
+++ b/Extensions/DirectXMathSSE4.h
@@ -29,7 +29,7 @@ inline bool XMVerifySSE4Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ inline bool XMVerifySSE4Support()
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -1973,7 +1973,7 @@ inline bool XMVerifyCPUSupport() noexcept
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     int CPUInfo[4] = { -1 };
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -1987,7 +1987,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false;
 #endif
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);


### PR DESCRIPTION
Since 2021, when building with MinGW if `intrin.h` is included (directly or indirectly), it will redefine `__cpuid` to use the
intrinsic version of it, instead of the macro defined by GCC's (and clang's) `cpuid.h`. Detect when `__cpuid` is a define, and use the 5-argument version only in that case.                                                          

https://github.com/mingw-w64/mingw-w64/commit/d2374f898457b0f4ea8bd4084a94f2dafc87a99a

This change does not apply to Clang.