### PR TITLE
Make DirectXMath configurable to fix the __cpuid function conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,9 +65,9 @@ int main () {
 	return(0);
 }")
 
-    try_compile(USE_CPUID_H_CPUID
-      ${CMAKE_BINARY_DIR}/CMakeTmp
-      ${CMAKE_BINARY_DIR}/CMakeTmp/testcpuid.cpp)
+  try_compile(USE_CPUID_H_CPUID
+    ${CMAKE_BINARY_DIR}/CMakeTmp
+    ${CMAKE_BINARY_DIR}/CMakeTmp/testcpuid.cpp)
 
   if(USE_CPUID_H_CPUID)
      message(STATUS "Configure __cpuid:  cpuid.h - 5 parameters")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
 elseif(NOT DXMATH_ARCHITECTURE)
     set(DXMATH_ARCHITECTURE "x64")
 endif()
+set(DXMATH_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 #--- Test suite
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ set(LIBRARY_HEADERS
     Inc/DirectXMathMisc.inl
     Inc/DirectXMathVector.inl
     Inc/DirectXPackedVector.h
-    Inc/DirectXPackedVector.inl)
+    Inc/DirectXPackedVector.inl
+	${CMAKE_CURRENT_BINARY_DIR}/DirectXMathConfig.h)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
@@ -33,6 +34,49 @@ target_include_directories(${PROJECT_NAME} INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/directxmath>)
 
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+
+#--- configure DirectXMathConfig.h
+
+#---------- 2 parameter __cpuid from intrin.h
+file(WRITE ${CMAKE_BINARY_DIR}/CMakeTmp/testcpuid.cpp
+"#include <intrin.h>
+int main () {
+	int CPUInfo[4] = { -1 };
+	__cpuid(CPUInfo, 0);
+	return(0);
+}")
+
+try_compile(USE_INTRIN_H_CPUID
+   ${CMAKE_BINARY_DIR}/CMakeTmp
+   ${CMAKE_BINARY_DIR}/CMakeTmp/testcpuid.cpp)
+
+if(USE_INTRIN_H_CPUID)
+   set(USE_CPUID_H_CPUID FALSE)
+   message(STATUS "Configure __cpuid:  intrin.h - 2 parameters")
+endif()
+
+if(NOT(USE_INTRIN_H_CPUID))
+#--------- 5 parameter __cpuid.h
+  file(WRITE ${CMAKE_BINARY_DIR}/CMakeTmp/testcpuid.cpp
+"#include <cpuid.h>
+int main () {
+	int CPUInfo[4] = { -1 };
+	__cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+	return(0);
+}")
+
+    try_compile(USE_CPUID_H_CPUID
+      ${CMAKE_BINARY_DIR}/CMakeTmp
+      ${CMAKE_BINARY_DIR}/CMakeTmp/testcpuid.cpp)
+
+  if(USE_CPUID_H_CPUID)
+     message(STATUS "Configure __cpuid:  cpuid.h - 5 parameters")
+  endif()
+endif()
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/build/DirectXMathConfig.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/DirectXMathConfig.h" @ONLY)
 
 #--- Package
 include(CMakePackageConfigHelpers)

--- a/Extensions/DirectXMathAVX.h
+++ b/Extensions/DirectXMathAVX.h
@@ -28,19 +28,19 @@ inline bool XMVerifyAVXSupport()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid( CPUInfo, 0 );
+#else
+    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 1 );
+#else
+    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     // We check for AVX, OSXSAVE, SSSE4.1, and SSE3

--- a/Extensions/DirectXMathAVX2.h
+++ b/Extensions/DirectXMathAVX2.h
@@ -29,19 +29,19 @@ inline bool XMVerifyAVX2Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 0);
+#else
+    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     if ( CPUInfo[0] < 7  )
         return false;
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 1);
+#else
+    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     // We check for F16C, FMA3, AVX, OSXSAVE, SSSE4.1, and SSE3

--- a/Extensions/DirectXMathF16C.h
+++ b/Extensions/DirectXMathF16C.h
@@ -29,19 +29,19 @@ inline bool XMVerifyF16CSupport()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 0);
+#else
+    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 1);
+#else
+    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     // We check for F16C, AVX, OSXSAVE, and SSE4.1

--- a/Extensions/DirectXMathFMA3.h
+++ b/Extensions/DirectXMathFMA3.h
@@ -28,19 +28,19 @@ inline bool XMVerifyFMA3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = {-1};
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 0);
+#else
+    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 1);
+#else
+    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     // We check for FMA3, AVX, OSXSAVE

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -37,8 +37,6 @@ inline bool XMVerifyFMA4Support()
    __cpuid(CPUInfo, 0);
 #else
    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
-
 #endif
 
    if ( CPUInfo[0] < 1  )

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -33,39 +33,41 @@ inline bool XMVerifyFMA4Support()
 
    // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
    int CPUInfo[4] = {-1};
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+#if defined(USE_INTRIN_H_CPUID)
+   __cpuid(CPUInfo, 0);
+#else
    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
-   __cpuid(CPUInfo, 0);
+
 #endif
 
    if ( CPUInfo[0] < 1  )
        return false;
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-   __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
    __cpuid(CPUInfo, 1);
+#else
+   __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     // We check for AVX, OSXSAVE (required to access FMA4)
     if ( (CPUInfo[2] & 0x18000000) != 0x18000000 )
         return false;
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 0x80000000);
+#else
+    __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     if ( uint32_t(CPUInfo[0]) < 0x80000001u )
         return false;
 
     // We check for FMA4
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0x80000001, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 0x80000001);
+#else
+    __cpuid(0x80000001, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     return ( CPUInfo[2] & 0x10000 );

--- a/Extensions/DirectXMathSSE3.h
+++ b/Extensions/DirectXMathSSE3.h
@@ -29,18 +29,18 @@ inline bool XMVerifySSE3Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+#if defined(USE_INTRIN_H_CPUID)
+	__cpuid(CPUInfo, 0);
 #else
-    __cpuid(CPUInfo, 0);
+    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);   
 #endif
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 1);
+#else
+    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     // We only check for SSE3 instruction set. SSSE3 instructions are not used.

--- a/Extensions/DirectXMathSSE4.h
+++ b/Extensions/DirectXMathSSE4.h
@@ -29,18 +29,18 @@ inline bool XMVerifySSE4Support()
 
     // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
     int CPUInfo[4] = { -1 };
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 0);
+#else
+    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
     if ( CPUInfo[0] < 1  )
         return false;
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 1);
+#else
+    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
     // We only check for SSE4.1 instruction set. SSE4.2 instructions are not used.

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -123,7 +123,7 @@
 #pragma warning(pop)
 #endif
 
-#if (USE_CPUID_H_CPUID) && (__x86_64__ || __i386__)
+#if defined(USE_CPUID_H_CPUID) && (__x86_64__ || __i386__)
 #include <cpuid.h>
 #endif
 

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -110,15 +110,20 @@
 
 #ifndef _XM_NO_INTRINSICS_
 
+#include <DirectXMathConfig.h>
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4987)
 // C4987: Off by default noise
+#endif
+#ifdef USE_INTRIN_H_CPUID
 #include <intrin.h>
+#endif
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-#if (defined(__clang__) || defined(__GNUC__)) && (__x86_64__ || __i386__)
+#if (USE_CPUID_H_CPUID) && (__x86_64__ || __i386__)
 #include <cpuid.h>
 #endif
 

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -1973,10 +1973,10 @@ inline bool XMVerifyCPUSupport() noexcept
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(_XM_NO_INTRINSICS_)
     int CPUInfo[4] = { -1 };
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
-#else
+#if defined(USE_INTRIN_H_CPUID)
     __cpuid(CPUInfo, 0);
+#else
+    __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
 #ifdef __AVX2__
@@ -1987,10 +1987,10 @@ inline bool XMVerifyCPUSupport() noexcept
         return false;
 #endif
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
-    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+#if defined(USE_INTRIN_H_CPUID)
+   __cpuid(CPUInfo, 1);
 #else
-    __cpuid(CPUInfo, 1);
+    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);  
 #endif
 
 #if defined(__AVX2__) || defined(_XM_AVX2_INTRINSICS_)

--- a/build/DirectXMathConfig.h.in
+++ b/build/DirectXMathConfig.h.in
@@ -1,0 +1,6 @@
+/* Define if this to use the 2-parameter __cpuid
+ in intrin.h. */
+#cmakedefine USE_INTRIN_H_CPUID
+/* Define if this to use the 5-parameter __cpuid
+ in cpuid.h. */
+#cmakedefine USE_CPUID_H_CPUID


### PR DESCRIPTION
This fixes the issue with 2 conflicting `__cpuid `functions.  The idea is to inspect the user's system using CMake (see: https://cmake.org/cmake/help/book/mastering-cmake/chapter/System%20Inspection.html ) and configure defines in a "DirectXMathConfig.h" file appropriately.  The defines are then used throughout DirectXMath.  This should fix the issue with some old MINGW versions where the users are stuck with GCC's 5-parameter `__cpuid` function while supporting the `__cpuid` function in `intrin.h` (see: https://learn.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex?view=msvc-170 ).  This "configure" approach may also help by making things a little more flexible than simply using `#defines` in the code.  The idea can probably be expanded more but that is an exercise for the reader.

This is an alternative to https://github.com/microsoft/DirectXMath/pull/176 which has been sitting for a few weeks that requires the 2-parameter `__cpuid` function in MINGW.