### PR TITLE
Minor edits for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,4 +99,4 @@ jobs:
       timeout-minutes: 10
       name: 'Test'
       working-directory: ${{ github.workspace }}
-      run: ctest --preset=${{ matrix.build_type }}
+      run: ctest --preset=${{ matrix.build_type }} --output-on-failure

--- a/build/DirectXMath-GitHub-CMake-Dev17.yml
+++ b/build/DirectXMath-GitHub-CMake-Dev17.yml
@@ -31,6 +31,11 @@ resources:
     type: git
     ref: refs/heads/main
     trigger: none
+  - repository: testRepo
+    name: walbourn/directxmathtest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -39,7 +44,6 @@ variables:
   VS_GENERATOR: 'Visual Studio 17 2022'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 pool:
   vmImage: windows-2022
@@ -52,10 +56,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: 'CMake (MSVC): Config x64'
     inputs:

--- a/build/DirectXMath-GitHub-CMake.yml
+++ b/build/DirectXMath-GitHub-CMake.yml
@@ -40,6 +40,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxmathtest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -47,7 +52,6 @@ variables:
   Codeql.Enabled: false
   VS_GENERATOR: 'Visual Studio 16 2019'
   WIN10_SDK: '10.0.19041.0'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 pool:
   vmImage: windows-2019
@@ -60,10 +64,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: CMake (MSVC x64)
     inputs:

--- a/build/DirectXMath-GitHub-Dev17.yml
+++ b/build/DirectXMath-GitHub-Dev17.yml
@@ -27,6 +27,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxmathtest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -36,7 +41,6 @@ pool:
 variables:
   Codeql.Enabled: false
   VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 jobs:
 - job: BUILD_DEV17
@@ -46,17 +50,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
     displayName: Build solution math3_2022.sln x86dbg
     inputs:
@@ -339,19 +340,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:
@@ -417,19 +413,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:

--- a/build/DirectXMath-GitHub-MinGW.yml
+++ b/build/DirectXMath-GitHub-MinGW.yml
@@ -41,6 +41,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxmathtest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -49,7 +54,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   URL_MINGW32: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
   HASH_MINGW32: 'fcd1e11b896190da01c83d5b5fb0d37b7c61585e53446c2dab0009debc3915e757213882c35e35396329338de6f0222ba012e23a5af86932db45186a225d1272'
 
@@ -60,11 +64,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: PowerShell@2
     displayName: Install MinGW32
     inputs:
@@ -123,16 +130,19 @@ jobs:
       cmakeArgs: --build out3
 
 - job: MINGW64_BUILD
-  displayName: 'Minimalist GNU for Windows (MinGW-W64) BUILD_TESTING=ON'
+  displayName: 'Minimalist GNU for Windows (MinGW-W64)'
   steps:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: GCC version
     inputs:

--- a/build/DirectXMath-GitHub-WSL-11.yml
+++ b/build/DirectXMath-GitHub-WSL-11.yml
@@ -31,6 +31,11 @@ resources:
     type: git
     ref: refs/heads/main
     trigger: none
+  - repository: testRepo
+    name: walbourn/directxmathtest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -39,7 +44,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 jobs:
 - job: BUILD_WSL
@@ -48,10 +52,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    displayName: Fetch tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: DirectXMath Tests
     inputs:

--- a/build/DirectXMath-GitHub-WSL.yml
+++ b/build/DirectXMath-GitHub-WSL.yml
@@ -41,6 +41,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxmathtest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -49,7 +54,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 jobs:
 - job: BUILD_WSL
@@ -58,10 +62,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    displayName: Fetch tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: DirectXMath Tests
     inputs:

--- a/build/DirectXMath-GitHub.yml
+++ b/build/DirectXMath-GitHub.yml
@@ -27,6 +27,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxmathtest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -35,7 +40,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 jobs:
 - job: BUILD_DEV16
@@ -45,17 +49,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
     displayName: Build solution math3_2019.sln x86dbg
     inputs:
@@ -329,10 +330,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
     displayName: Build solution math3_2017.sln x86dbg
     inputs:

--- a/build/DirectXMath-SDL.yml
+++ b/build/DirectXMath-SDL.yml
@@ -27,6 +27,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxmathtest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -35,7 +40,6 @@ variables:
   Codeql.Language: cpp
   VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
   VS_GENERATOR: 'Visual Studio 17 2022'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 pool:
   vmImage: windows-2022
@@ -49,6 +53,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NodeTool@0
     displayName: 'NPM install'
     inputs:
@@ -62,10 +74,6 @@ jobs:
     displayName: 'Run PoliCheck'
     inputs:
       result: PoliCheck.xml
-  - task: CmdLine@2
-    displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
   - task: Armory@2
     displayName: Run ARMory
   - task: CMake@1
@@ -103,10 +111,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxmathtest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:


### PR DESCRIPTION
Adds `--output-on-failure` to ctest usage.

> Includes ADO YAML code review to clean up use of PATs.

> Also sets the dependabot to not spam quite so often for GHA.