### PR TITLE
Use C++17 deprecated attribute when supported

### DIFF
--- a/.nuget/directxmath.nuspec
+++ b/.nuget/directxmath.nuspec
@@ -8,7 +8,7 @@
         <owners>microsoft,directxtk</owners>
         <summary>DirectXMath is an all inline SIMD C++ linear algebra library for use in games and graphics apps.</summary>
         <description>The DirectXMath API provides SIMD-friendly C++ types and functions for common linear algebra and graphics math operations common to DirectX applications. The library provides optimized versions for Windows 32-bit (x86), Windows 64-bit (x64), and Windows on ARM through SSE2 and ARM-NEON intrinsics support in the Visual Studio compiler.</description>
-        <releaseNotes>Matches the February 2024 release.</releaseNotes>
+        <releaseNotes>Matches the October 2024 release.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=615560</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMath.git" />
         <icon>images\icon.jpg</icon>

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -32,7 +32,9 @@
 #endif
 
 #ifndef XM_DEPRECATED
-#ifdef __GNUC__
+#if (__cplusplus >= 201402L)
+#define XM_DEPRECATED [[deprecated]]
+#elif defined(__GNUC__)
 #define XM_DEPRECATED __attribute__ ((deprecated))
 #else
 #define XM_DEPRECATED __declspec(deprecated("This is deprecated and will be removed in a future version."))
@@ -164,7 +166,7 @@
 #pragma warning(pop)
 #endif
 
-#if __cplusplus >= 201703L
+#if (__cplusplus >= 201703L)
 #define XM_ALIGNED_DATA(x) alignas(x)
 #define XM_ALIGNED_STRUCT(x) struct alignas(x)
 #elif defined(__GNUC__)

--- a/Inc/DirectXPackedVector.h
+++ b/Inc/DirectXPackedVector.h
@@ -1124,9 +1124,14 @@ namespace DirectX
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        XMVECTOR    XM_CALLCONV XM_DEPRECATED XMLoadDecN4(_In_ const XMDECN4* pSource) noexcept;
-        XMVECTOR    XM_CALLCONV XM_DEPRECATED XMLoadDec4(_In_ const XMDEC4* pSource) noexcept;
-        XMVECTOR    XM_CALLCONV XM_DEPRECATED XMLoadXDec4(_In_ const XMXDEC4* pSource) noexcept;
+        XM_DEPRECATED
+        XMVECTOR    XM_CALLCONV XMLoadDecN4(_In_ const XMDECN4* pSource) noexcept;
+
+        XM_DEPRECATED
+        XMVECTOR    XM_CALLCONV XMLoadDec4(_In_ const XMDEC4* pSource) noexcept;
+
+        XM_DEPRECATED
+        XMVECTOR    XM_CALLCONV XMLoadXDec4(_In_ const XMXDEC4* pSource) noexcept;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
@@ -1192,9 +1197,14 @@ namespace DirectX
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        void    XM_CALLCONV XM_DEPRECATED XMStoreDecN4(_Out_ XMDECN4* pDestination, _In_ FXMVECTOR V) noexcept;
-        void    XM_CALLCONV XM_DEPRECATED XMStoreDec4(_Out_ XMDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
-        void    XM_CALLCONV XM_DEPRECATED XMStoreXDec4(_Out_ XMXDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
+        XM_DEPRECATED
+        void    XM_CALLCONV XMStoreDecN4(_Out_ XMDECN4* pDestination, _In_ FXMVECTOR V) noexcept;
+
+        XM_DEPRECATED
+        void    XM_CALLCONV XMStoreDec4(_Out_ XMDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
+
+        XM_DEPRECATED
+        void    XM_CALLCONV XMStoreXDec4(_Out_ XMXDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/Inc/DirectXPackedVector.h
+++ b/Inc/DirectXPackedVector.h
@@ -668,7 +668,7 @@ namespace DirectX
         // z, y, and x components.  The w component is stored in the
         // most significant bits and the x component in the least significant bits
         // (W2Z10Y10X10): [32] wwzzzzzz zzzzyyyy yyyyyyxx xxxxxxxx [0]
-        struct XMXDEC4
+        struct XM_DEPRECATED XMXDEC4
         {
             union
             {
@@ -705,7 +705,7 @@ namespace DirectX
         // integers for the z, y, and x components.  The w component is stored in the
         // most significant bits and the x component in the least significant bits
         // (W2Z10Y10X10): [32] wwzzzzzz zzzzyyyy yyyyyyxx xxxxxxxx [0]
-        struct XMDECN4
+        struct XM_DEPRECATED XMDECN4
         {
             union
             {
@@ -742,7 +742,7 @@ namespace DirectX
         // z, y, and x components.  The w component is stored in the
         // most significant bits and the x component in the least significant bits
         // (W2Z10Y10X10): [32] wwzzzzzz zzzzyyyy yyyyyyxx xxxxxxxx [0]
-        struct XMDEC4
+        struct XM_DEPRECATED XMDEC4
         {
             union
             {

--- a/Inc/DirectXPackedVector.h
+++ b/Inc/DirectXPackedVector.h
@@ -668,7 +668,7 @@ namespace DirectX
         // z, y, and x components.  The w component is stored in the
         // most significant bits and the x component in the least significant bits
         // (W2Z10Y10X10): [32] wwzzzzzz zzzzyyyy yyyyyyxx xxxxxxxx [0]
-        struct XM_DEPRECATED XMXDEC4
+        struct XMXDEC4
         {
             union
             {
@@ -705,7 +705,7 @@ namespace DirectX
         // integers for the z, y, and x components.  The w component is stored in the
         // most significant bits and the x component in the least significant bits
         // (W2Z10Y10X10): [32] wwzzzzzz zzzzyyyy yyyyyyxx xxxxxxxx [0]
-        struct XM_DEPRECATED XMDECN4
+        struct XMDECN4
         {
             union
             {
@@ -742,7 +742,7 @@ namespace DirectX
         // z, y, and x components.  The w component is stored in the
         // most significant bits and the x component in the least significant bits
         // (W2Z10Y10X10): [32] wwzzzzzz zzzzyyyy yyyyyyxx xxxxxxxx [0]
-        struct XM_DEPRECATED XMDEC4
+        struct XMDEC4
         {
             union
             {

--- a/Inc/DirectXPackedVector.h
+++ b/Inc/DirectXPackedVector.h
@@ -1114,17 +1114,25 @@ namespace DirectX
         // C4996: ignore deprecation warning
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadDecN4(_In_ const XMDECN4* pSource) noexcept;
-        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadDec4(_In_ const XMDEC4* pSource) noexcept;
-        XMVECTOR    XM_DEPRECATED XM_CALLCONV XMLoadXDec4(_In_ const XMXDEC4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV XM_DEPRECATED XMLoadDecN4(_In_ const XMDECN4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV XM_DEPRECATED XMLoadDec4(_In_ const XMDEC4* pSource) noexcept;
+        XMVECTOR    XM_CALLCONV XM_DEPRECATED XMLoadXDec4(_In_ const XMXDEC4* pSource) noexcept;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -1174,17 +1182,25 @@ namespace DirectX
         // C4996: ignore deprecation warning
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        void    XM_DEPRECATED XM_CALLCONV XMStoreDecN4(_Out_ XMDECN4* pDestination, _In_ FXMVECTOR V) noexcept;
-        void    XM_DEPRECATED XM_CALLCONV XMStoreDec4(_Out_ XMDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
-        void    XM_DEPRECATED XM_CALLCONV XMStoreXDec4(_Out_ XMXDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV XM_DEPRECATED XMStoreDecN4(_Out_ XMDECN4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV XM_DEPRECATED XMStoreDec4(_Out_ XMDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
+        void    XM_CALLCONV XM_DEPRECATED XMStoreXDec4(_Out_ XMXDEC4* pDestination, _In_ FXMVECTOR V) noexcept;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/Inc/DirectXPackedVector.inl
+++ b/Inc/DirectXPackedVector.inl
@@ -1506,6 +1506,11 @@ inline XMVECTOR XM_CALLCONV XMLoadXDecN4(const XMXDECN4* pSource) noexcept
 // C4996: ignore deprecation warning
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -1559,6 +1564,9 @@ inline XMVECTOR XM_CALLCONV XMLoadXDec4(const XMXDEC4* pSource) noexcept
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -1705,6 +1713,11 @@ inline XMVECTOR XM_CALLCONV XMLoadUDec4(const XMUDEC4* pSource) noexcept
 // C4996: ignore deprecation warning
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -1805,6 +1818,9 @@ inline XMVECTOR XM_CALLCONV XMLoadDec4(const XMDEC4* pSource) noexcept
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -2915,6 +2931,11 @@ inline void XM_CALLCONV XMStoreXDecN4
 // C4996: ignore deprecation warning
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -2989,6 +3010,9 @@ inline void XM_CALLCONV XMStoreXDec4
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -3209,6 +3233,11 @@ inline void XM_CALLCONV XMStoreUDec4
 // C4996: ignore deprecation warning
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -3337,6 +3366,9 @@ inline void XM_CALLCONV XMStoreDec4
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -4160,6 +4192,11 @@ inline XMXDECN4::XMXDECN4(const float* pArray) noexcept
  // C4996: ignore deprecation warning
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -4239,6 +4276,9 @@ inline XMDEC4::XMDEC4(const float* pArray) noexcept
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
`XM_DEPRECATED` macro already handled MSVC-like vs. GNU. It should use C++17 standard ``[[deprecated]]`` attribute for C++17 or later compilation for better conformance.