### PR TITLE
GHA Linux runner updated

### DIFF
--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -26,7 +26,7 @@ jobs:
 
       matrix:
         build_type: [x64-Debug-Linux, x64-Release-Linux]
-        gcc: [10, 11, 12]
+        gcc: [12, 13, 14]
         # x64-Debug-NI-Linux, x64-Release-NI-Linux trigger issue with GCC
 
     steps:


### PR DESCRIPTION
GNUC 10 and 11 not included in Linux runner image anymore. Now has GNUC 12, 13, and 14.