### PR TITLE
SDL pipelines should run even if no code changes

### DIFF
--- a/build/DirectXMath-SDL.yml
+++ b/build/DirectXMath-SDL.yml
@@ -8,9 +8,6 @@
 schedules:
 - cron: "0 3 * * 0,3,5"
   displayName: 'Three times a week'
-  branches:
-    include:
-    - main
   always: true
 
 # GitHub Actions handles CodeQL and PREFAST for CI/PR


### PR DESCRIPTION
The `cron` statement with `always: true` is not in fact running every 3 days even if the code is unchanged. I believe it is the `include` statement that is causing the problem.