### PR TITLE
Add build options to CMake for XDSP and SHMath

### DIFF
--- a/.azuredevops/policies/approvercountpolicy.yml
+++ b/.azuredevops/policies/approvercountpolicy.yml
@@ -1,0 +1,20 @@
+name: approver_count
+description: Approver count policy for mscodehub/DirectXMath/DirectXMath repository
+resource: repository
+where: 
+configuration:
+  approverCountPolicySettings:
+    isBlocking: true
+    requireMinimumApproverCount: 1
+    creatorVoteCounts: false
+    allowDownvotes: false
+    sourcePushOptions:
+      resetOnSourcePush: false
+      requireVoteOnLastIteration: true
+      requireVoteOnEachIteration: false
+      resetRejectionsOnSourcePush: false
+    blockLastPusherVote: true
+    branchNames:
+    - refs/heads/release
+    - refs/heads/main
+    displayName: mscodehub/DirectXMath/DirectXMath Approver Count Policy

--- a/.github/workflows/shmath.yml
+++ b/.github/workflows/shmath.yml
@@ -88,8 +88,8 @@ jobs:
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}
-      run: cmake --preset=${{ matrix.build_type }}
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_SHMATH=ON -DBUILD_DX11=ON -DBUILD_DX12=ON
 
     - name: 'Build'
       working-directory: ${{ github.workspace }}
-      run: cmake --build out\build\${{ matrix.build_type }} -DBUILD_SHMATH=ON
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/shmath.yml
+++ b/.github/workflows/shmath.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkID=615560
 
-name: 'CMake (Windows)'
+name: 'CMake (SHMath)'
 
 on:
   push:
@@ -92,4 +92,4 @@ jobs:
 
     - name: 'Build'
       working-directory: ${{ github.workspace }}
-      run: cmake --build out\build\${{ matrix.build_type }}
+      run: cmake --build out\build\${{ matrix.build_type }} -DBUILD_SHMATH=ON

--- a/.github/workflows/xdsp.yml
+++ b/.github/workflows/xdsp.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkID=615560
 
-name: 'CMake (Windows)'
+name: 'CMake (XDSP)'
 
 on:
   push:
@@ -92,4 +92,5 @@ jobs:
 
     - name: 'Build'
       working-directory: ${{ github.workspace }}
-      run: cmake --build out\build\${{ matrix.build_type }}
+      run: cmake --build out\build\${{ matrix.build_type }} -DBUILD_XDSP=ON
+

--- a/.github/workflows/xdsp.yml
+++ b/.github/workflows/xdsp.yml
@@ -88,9 +88,8 @@ jobs:
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}
-      run: cmake --preset=${{ matrix.build_type }}
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_XDSP=ON
 
     - name: 'Build'
       working-directory: ${{ github.workspace }}
-      run: cmake --build out\build\${{ matrix.build_type }} -DBUILD_XDSP=ON
-
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ project(DirectXMath
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
   LANGUAGES CXX)
 
+option(BUILD_XDSP "Build XDSP math" OFF)
+
+option(BUILD_SHMATH "Build Spherical Harmonics math" OFF)
+
 include(GNUInstallDirs)
 
 #--- Library
@@ -86,31 +90,13 @@ configure_file(
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DirectXMath.pc"
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-#--- Test suite
-if(DEFINED VCPKG_TARGET_ARCHITECTURE)
-    set(DXMATH_ARCHITECTURE ${VCPKG_TARGET_ARCHITECTURE})
-elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Ww][Ii][Nn]32$")
-    set(DXMATH_ARCHITECTURE x86)
-elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Xx]64$")
-    set(DXMATH_ARCHITECTURE x64)
-elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]$")
-    set(DXMATH_ARCHITECTURE arm)
-elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
-    set(DXMATH_ARCHITECTURE arm64)
-elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64EC$")
-    set(DXMATH_ARCHITECTURE arm64ec)
-elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Ww][Ii][Nn]32$")
-    set(DXMATH_ARCHITECTURE x86)
-elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Xx]64$")
-    set(DXMATH_ARCHITECTURE x64)
-elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Aa][Rr][Mm]$")
-    set(DXMATH_ARCHITECTURE arm)
-elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Aa][Rr][Mm]64$")
-    set(DXMATH_ARCHITECTURE arm64)
-elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Aa][Rr][Mm]64EC$")
-    set(DXMATH_ARCHITECTURE arm64ec)
-elseif(NOT (DEFINED DXMATH_ARCHITECTURE))
-    set(DXMATH_ARCHITECTURE "x64")
+#--- Optional extension libraries
+if(BUILD_XDSP)
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/XDSP)
+endif()
+
+if(BUILD_SHMATH)
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/SHMath)
 endif()
 
 #--- Test suite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,10 +92,12 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DirectXMath.pc"
 
 #--- Optional extension libraries
 if(BUILD_XDSP)
+  message(STATUS "Including XDSP Digital Signal Processing (DSP)")
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/XDSP)
 endif()
 
 if(BUILD_SHMATH)
+  message(STATUS "Including C++ Spherical Harmonics Math")
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/SHMath)
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -148,6 +148,20 @@
       }
     },
     {
+      "name": "MinGW32",
+      "hidden": true,
+      "environment": {
+        "PATH": "$penv{PATH};c:/mingw32/bin;c:/mingw32/libexec/gcc/i686-w64-mingw32/12.2.0"
+      }
+    },
+    {
+      "name": "MinGW64",
+      "hidden": true,
+      "environment": {
+        "PATH": "$penv{PATH};c:/mingw64/bin;c:/mingw64/libexec/gcc/x86_64-w64-mingw32/12.2.0"
+      }
+    },
+    {
       "name": "Intel",
       "hidden": true,
       "cacheVariables": {
@@ -186,7 +200,15 @@
     { "name": "x86-Debug-Clang"    , "description": "Clang/LLVM for x86 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "Clang", "Clang-X86" ] },
     { "name": "x86-Release-Clang"  , "description": "Clang/LLVM for x86 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "Clang", "Clang-X86" ] },
     { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug", "Clang", "Clang-AArch64" ] },
-    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "Clang", "Clang-AArch64" ] }
+    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "Clang", "Clang-AArch64" ] },
+
+    { "name": "x64-Debug-MinGW"     , "description": "MinG-W64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug", "GNUC", "MinGW64" ] },
+    { "name": "x64-Release-MinGW"   , "description": "MinG-W64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release", "GNUC", "MinGW64" ] },
+    { "name": "x86-Debug-MinGW"     , "description": "MinG-W32 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "GNUC", "MinGW32" ] },
+    { "name": "x86-Release-MinGW"   , "description": "MinG-W32 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "GNUC", "MinGW32" ] },
+
+    { "name": "x64-Debug-Linux"     , "description": "WSL x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug" ] },
+    { "name": "x64-Release-Linux"   , "description": "WSL x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release" ] }
   ],
   "testPresets": [
     { "name": "x64-Debug"      , "configurePreset": "x64-Debug" },

--- a/SHMath/CMakeLists.txt
+++ b/SHMath/CMakeLists.txt
@@ -59,7 +59,7 @@ if(WIN32 AND BUILD_DX11)
   set(LIBRARY_SOURCES ${LIBRARY_SOURCES} DirectXSHD3D11.cpp)
 endif()
 
-if(BUILD_DX12)
+if(WIN32 AND BUILD_DX12)
   set(LIBRARY_SOURCES ${LIBRARY_SOURCES} DirectXSHD3D12.cpp)
 endif()
 
@@ -70,6 +70,20 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+
+if(MINGW)
+    find_package(directx-headers CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC USING_DIRECTX_HEADERS)
+else()
+    find_package(directx-headers CONFIG QUIET)
+endif()
+
+if(directx-headers_FOUND)
+    message(STATUS "Using DirectX-Headers package")
+    target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectX-Headers)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USING_DIRECTX_HEADERS)
+endif()
 
 #--- Package
 include(CMakePackageConfigHelpers)

--- a/SHMath/CMakeLists.txt
+++ b/SHMath/CMakeLists.txt
@@ -71,6 +71,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
 
+target_link_libraries(${PROJECT_NAME} PRIVATE DirectXMath)
+
 if(MINGW)
     find_package(directx-headers CONFIG REQUIRED)
     target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)

--- a/SHMath/CMakeLists.txt
+++ b/SHMath/CMakeLists.txt
@@ -1,0 +1,188 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cmake_minimum_required (VERSION 3.20)
+
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  message(FATAL_ERROR "SHMath should be built by the main CMakeLists using BUILD_SHMATH")
+endif()
+
+project(DirectXSH
+  VERSION ${DIRECTXMATH_VERSION}
+  DESCRIPTION "C++ Spherical Harmonics Math Library"
+  HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
+  LANGUAGES CXX)
+
+option(BUILD_DX11 "Build with DirectX11 support" OFF)
+
+option(BUILD_DX12 "Build with DirectX12 support" OFF)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(DEFINED VCPKG_TARGET_ARCHITECTURE)
+    set(DXMATH_ARCHITECTURE ${VCPKG_TARGET_ARCHITECTURE})
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Ww][Ii][Nn]32$")
+    set(DXMATH_ARCHITECTURE x86)
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Xx]64$")
+    set(DXMATH_ARCHITECTURE x64)
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]$")
+    set(DXMATH_ARCHITECTURE arm)
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$")
+    set(DXMATH_ARCHITECTURE arm64)
+elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64EC$")
+    set(DXMATH_ARCHITECTURE arm64ec)
+elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Ww][Ii][Nn]32$")
+    set(DXMATH_ARCHITECTURE x86)
+elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Xx]64$")
+    set(DXMATH_ARCHITECTURE x64)
+elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Aa][Rr][Mm]$")
+    set(DXMATH_ARCHITECTURE arm)
+elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Aa][Rr][Mm]64$")
+    set(DXMATH_ARCHITECTURE arm64)
+elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Aa][Rr][Mm]64EC$")
+    set(DXMATH_ARCHITECTURE arm64ec)
+elseif(NOT (DEFINED DXMATH_ARCHITECTURE))
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Mm]64|aarch64|arm64")
+        set(DXMATH_ARCHITECTURE arm64)
+    else()
+        set(DXMATH_ARCHITECTURE x64)
+    endif()
+endif()
+
+#--- Library
+set(LIBRARY_HEADERS DirectXSH.h)
+set(LIBRARY_SOURCES DirectXSH.cpp)
+
+if(WIN32 AND BUILD_DX11)
+  set(LIBRARY_SOURCES ${LIBRARY_SOURCES} DirectXSHD3D11.cpp)
+endif()
+
+if(BUILD_DX12)
+  set(LIBRARY_SOURCES ${LIBRARY_SOURCES} DirectXSHD3D12.cpp)
+endif()
+
+add_library(${PROJECT_NAME} STATIC ${LIBRARY_SOURCES} ${LIBRARY_HEADERS})
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+
+#--- Package
+include(CMakePackageConfigHelpers)
+
+string(TOLOWER ${PROJECT_NAME} PACKAGE_NAME)
+cmake_path(GET CMAKE_CURRENT_LIST_DIR PARENT_PATH DIRECTXMATH_PATH)
+
+write_basic_package_version_file(
+  ${PACKAGE_NAME}-config-version.cmake
+  VERSION ${DIRECTXMATH_VERSION}
+  COMPATIBILITY AnyNewerVersion
+  ARCH_INDEPENDENT)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+configure_package_config_file(${DIRECTXMATH_PATH}/build/DirectXMath-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})
+
+install(EXPORT ${PROJECT_NAME}-targets
+  FILE ${PROJECT_NAME}-targets.cmake
+  NAMESPACE Microsoft::
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})
+
+install(FILES ${LIBRARY_HEADERS}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config-version.cmake
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})
+
+#--- Compiler switches
+if(MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Wall /EHsc /GR "$<$<NOT:$<CONFIG:DEBUG>>:/guard:cf>")
+
+    if((MSVC_VERSION GREATER_EQUAL 1928)
+       AND (CMAKE_SIZEOF_VOID_P EQUAL 8)
+       AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")) OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)))
+        target_compile_options(${PROJECT_NAME} PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
+    endif()
+else()
+    target_compile_definitions(${PROJECT_NAME} PRIVATE $<IF:$<CONFIG:DEBUG>,_DEBUG,NDEBUG>)
+endif()
+
+if(NOT (${DXMATH_ARCHITECTURE} MATCHES "^arm"))
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(ARCH_SSE2 $<$<CXX_COMPILER_ID:MSVC,Intel>:/arch:SSE2> $<$<NOT:$<CXX_COMPILER_ID:MSVC,Intel>>:-msse2>)
+    else()
+        set(ARCH_SSE2 $<$<NOT:$<CXX_COMPILER_ID:MSVC,Intel>>:-msse2>)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        list(APPEND ARCH_SSE2 -mfpmath=sse)
+    endif()
+
+    target_compile_options(${PROJECT_NAME} PRIVATE ${ARCH_SSE2})
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0)
+        target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256 "-Wno-unsafe-buffer-usage")
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wno-ignored-attributes)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus /Zc:inline /fp:fast /Qdiag-disable:161)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(${PROJECT_NAME} PRIVATE
+         /sdl /Zc:inline /fp:fast
+         "/wd4061" "/wd4365" "/wd4514" "/wd4571" "/wd4668" "/wd4710" "/wd4820" "/wd5039" "/wd5045")
+
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE $<$<NOT:$<CONFIG:DEBUG>>:/Gy /Gw>)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.10)
+        target_compile_options(${PROJECT_NAME} PRIVATE /permissive-)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.14)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
+        target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.26)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:preprocessor /wd5105)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.28)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:lambda)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.29)
+        target_compile_options(${PROJECT_NAME} PRIVATE /external:W4)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
+        target_compile_options(${PROJECT_NAME} PRIVATE /wd5262 /wd5264)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+          target_compile_options(${PROJECT_NAME} PRIVATE $<$<NOT:$<CONFIG:DEBUG>>:/Zc:checkGwOdr>)
+        endif()
+
+        target_compile_options(${PROJECT_NAME} PRIVATE $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
+    endif()
+endif()

--- a/SHMath/DirectXSH.h
+++ b/SHMath/DirectXSH.h
@@ -11,7 +11,7 @@
 
 #define DIRECTX_SHMATH_VERSION 106
 
-#include <DirectXMath.h>
+#include "DirectXMath.h"
 
 namespace DirectX
 {

--- a/SHMath/DirectXSHD3D12.cpp
+++ b/SHMath/DirectXSHD3D12.cpp
@@ -16,7 +16,11 @@
 // C5039 pointer or reference to potentially throwing function passed to extern C function under - EHc
 #endif
 
+#ifdef USING_DIRECTX_HEADERS
+#include <directx/d3d12.h>
+#else
 #include <d3d12.h>
+#endif
 
 #include "DirectXSH.h"
 
@@ -224,7 +228,7 @@ HRESULT DirectX::SHProjectCubeMap(
 
     // index from [0,W-1], f(0) maps to -1 + 1/W, f(W-1) maps to 1 - 1/w
     // linear function x*S +B, 1st constraint means B is (-1+1/W), plug into
-    // second and solve for S: S = 2*(1-1/W)/(W-1). The old code that did 
+    // second and solve for S: S = 2*(1-1/W)/(W-1). The old code that did
     // this was incorrect - but only for computing the differential solid
     // angle, where the final value was 1.0 instead of 1-1/w...
 

--- a/SHMath/DirectXSHD3D12.cpp
+++ b/SHMath/DirectXSHD3D12.cpp
@@ -16,6 +16,10 @@
 // C5039 pointer or reference to potentially throwing function passed to extern C function under - EHc
 #endif
 
+#ifdef __MINGW32__
+#include <unknwn.h>
+#endif
+
 #ifdef USING_DIRECTX_HEADERS
 #include <directx/d3d12.h>
 #else

--- a/XDSP/CMakeLists.txt
+++ b/XDSP/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cmake_minimum_required (VERSION 3.20)
+
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  message(FATAL_ERROR "XSDP should be built by the main CMakeLists using BUILD_XDSP")
+endif()
+
+project(XDSP
+  VERSION ${DIRECTXMATH_VERSION}
+  DESCRIPTION "XDSP Digital Signal Processing (DSP) for DirectXMath"
+  HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
+  LANGUAGES CXX)
+
+#--- Library
+set(LIBRARY_HEADERS XDSP.h)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+
+#--- Package
+include(CMakePackageConfigHelpers)
+
+string(TOLOWER ${PROJECT_NAME} PACKAGE_NAME)
+cmake_path(GET CMAKE_CURRENT_LIST_DIR PARENT_PATH DIRECTXMATH_PATH)
+
+write_basic_package_version_file(
+  ${PACKAGE_NAME}-config-version.cmake
+  VERSION ${DIRECTXMATH_VERSION}
+  COMPATIBILITY AnyNewerVersion
+  ARCH_INDEPENDENT)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+configure_package_config_file(${DIRECTXMATH_PATH}/build/DirectXMath-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})
+
+install(EXPORT ${PROJECT_NAME}-targets
+  FILE ${PROJECT_NAME}-targets.cmake
+  NAMESPACE Microsoft::
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})
+
+install(FILES ${LIBRARY_HEADERS}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config-version.cmake
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})

--- a/XDSP/XDSP.h
+++ b/XDSP/XDSP.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cassert>
-#include <DirectXMath.h>
+#include "DirectXMath.h"
 
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
Add `BUILD_XDSP` and `BUILD_SHMATH` options and CMake support.

* `BUILD_XDSP` includes installing the XDSP header

* `BUILD_SHMATH` builds a library and installs the SHMath headers/lib

* `BUILD_SHMATH` has `BUILD_DX11` and `BUILD_DX12` to control the SHMath support for Direct3D project cubemap.

> Also includes an AzureDevOps policy file.
