### PR TITLE
April 2, 2025 (3.20b)

### DIFF
--- a/.github/workflows/cxx.yml
+++ b/.github/workflows/cxx.yml
@@ -1,0 +1,114 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615560
+
+name: 'CMake (Windows /std)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/*'
+      - '.nuget/*'
+      - build/*.ps1
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-2022
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [x64-Debug, x64-Release, x64-Debug-Clang, x64-Release-Clang]
+        arch: [amd64]
+        include:
+          - build_type: x86-Debug
+            arch: amd64_x86
+          - build_type: x86-Release
+            arch: amd64_x86
+          - build_type: arm64-Debug
+            arch: amd64_arm64
+          - build_type: arm64-Release
+            arch: amd64_arm64
+          - build_type: arm64ec-Debug
+            arch: amd64_arm64
+          - build_type: arm64ec-Release
+            arch: amd64_arm64
+          - build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - build_type: x86-Release-Clang
+            arch: amd64_x86
+          - build_type: arm64-Debug-Clang
+            arch: amd64_arm64
+          - build_type: arm64-Release-Clang
+            arch: amd64_arm64
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Clone test repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: walbourn/directxmathtest
+        path: Tests
+        ref: main
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Configure CMake (C++17)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }}
+
+    - name: 'Build (C++17)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}
+
+    - name: 'Clean up'
+      working-directory: ${{ github.workspace }}
+      run: Remove-Item -Path out -Recurse -Force
+
+    - name: 'Configure CMake (C++11)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX11=ON
+
+    - name: 'Build (C++11)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}
+
+    - name: 'Clean up'
+      working-directory: ${{ github.workspace }}
+      run: Remove-Item -Path out -Recurse -Force
+
+    - name: 'Configure CMake (C++14)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX14=ON
+
+    - name: 'Build (C++14)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}
+
+    - name: 'Clean up'
+      working-directory: ${{ github.workspace }}
+      run: Remove-Item -Path out -Recurse -Force
+
+    - name: 'Configure CMake (C++20)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX20=ON
+
+    - name: 'Build (C++20)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/wslcxx.yml
+++ b/.github/workflows/wslcxx.yml
@@ -56,7 +56,20 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: rm -rf out
 
-    # Can't build C++11 with GNU because tests use std::size which is C++14
+    - name: 'Configure CMake (C++11)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX11=ON
+      env:
+        CC: gcc-${{ matrix.gcc }}
+        CXX: g++-${{ matrix.gcc }}
+
+    - name: 'Build (C++11)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --build out/build/${{ matrix.build_type }}
+
+    - name: 'Clean up'
+      working-directory: ${{ github.workspace }}
+      run: rm -rf out
 
     - name: 'Configure CMake (C++14)'
       working-directory: ${{ github.workspace }}/Tests

--- a/.github/workflows/wslcxx.yml
+++ b/.github/workflows/wslcxx.yml
@@ -56,20 +56,7 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: rm -rf out
 
-    - name: 'Configure CMake (C++11)'
-      working-directory: ${{ github.workspace }}/Tests
-      run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX11=ON
-      env:
-        CC: gcc-${{ matrix.gcc }}
-        CXX: g++-${{ matrix.gcc }}
-
-    - name: 'Build (C++11)'
-      working-directory: ${{ github.workspace }}/Tests
-      run: cmake --build out/build/${{ matrix.build_type }}
-
-    - name: 'Clean up'
-      working-directory: ${{ github.workspace }}
-      run: rm -rf out
+    # Can't build C++11 with GNU because tests use std::size which is C++14
 
     - name: 'Configure CMake (C++14)'
       working-directory: ${{ github.workspace }}/Tests

--- a/.github/workflows/wslcxx.yml
+++ b/.github/workflows/wslcxx.yml
@@ -1,0 +1,98 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615560
+
+name: 'CMake (WSL -std)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/*'
+      - '.nuget/*'
+      - build/*.ps1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [x64-Debug-Linux, x64-Release-Linux]
+        gcc: [12, 13, 14]
+        # x64-Debug-NI-Linux, x64-Release-NI-Linux trigger issue with GCC
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Clone test repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: walbourn/directxmathtest
+        path: Tests
+        ref: main
+
+    - uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
+
+    - name: 'Configure CMake (C++17)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --preset=${{ matrix.build_type }}
+      env:
+        CC: gcc-${{ matrix.gcc }}
+        CXX: g++-${{ matrix.gcc }}
+
+    - name: 'Build (C++17)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --build out/build/${{ matrix.build_type }}
+
+    - name: 'Clean up'
+      working-directory: ${{ github.workspace }}
+      run: rm -rf out
+
+    - name: 'Configure CMake (C++11)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX11=ON
+      env:
+        CC: gcc-${{ matrix.gcc }}
+        CXX: g++-${{ matrix.gcc }}
+
+    - name: 'Build (C++11)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --build out/build/${{ matrix.build_type }}
+
+    - name: 'Clean up'
+      working-directory: ${{ github.workspace }}
+      run: rm -rf out
+
+    - name: 'Configure CMake (C++14)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX14=ON
+      env:
+        CC: gcc-${{ matrix.gcc }}
+        CXX: g++-${{ matrix.gcc }}
+
+    - name: 'Build (C++14)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --build out/build/${{ matrix.build_type }}
+
+    - name: 'Clean up'
+      working-directory: ${{ github.workspace }}
+      run: rm -rf out
+
+    - name: 'Configure CMake (C++20)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX20=ON
+      env:
+        CC: gcc-${{ matrix.gcc }}
+        CXX: g++-${{ matrix.gcc }}
+
+    - name: 'Build (C++20)'
+      working-directory: ${{ github.workspace }}/Tests
+      run: cmake --build out/build/${{ matrix.build_type }}

--- a/.github/workflows/wslcxx.yml
+++ b/.github/workflows/wslcxx.yml
@@ -56,34 +56,35 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: rm -rf out
 
+    # Test suite requires C++17 features on Linux, so we only test the headers for C++11/C++14
     - name: 'Configure CMake (C++11)'
-      working-directory: ${{ github.workspace }}/Tests
+      working-directory: ${{ github.workspace }}/Tests/headertest
       run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX11=ON
       env:
         CC: gcc-${{ matrix.gcc }}
         CXX: g++-${{ matrix.gcc }}
 
     - name: 'Build (C++11)'
-      working-directory: ${{ github.workspace }}/Tests
+      working-directory: ${{ github.workspace }}/Tests/headertest
       run: cmake --build out/build/${{ matrix.build_type }}
 
     - name: 'Clean up'
-      working-directory: ${{ github.workspace }}
+      working-directory: ${{ github.workspace }}/Tests/headertest
       run: rm -rf out
 
     - name: 'Configure CMake (C++14)'
-      working-directory: ${{ github.workspace }}/Tests
+      working-directory: ${{ github.workspace }}/Tests/headertest
       run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX14=ON
       env:
         CC: gcc-${{ matrix.gcc }}
         CXX: g++-${{ matrix.gcc }}
 
     - name: 'Build (C++14)'
-      working-directory: ${{ github.workspace }}/Tests
+      working-directory: ${{ github.workspace }}/Tests/headertest
       run: cmake --build out/build/${{ matrix.build_type }}
 
     - name: 'Clean up'
-      working-directory: ${{ github.workspace }}
+      working-directory: ${{ github.workspace }}/Tests/headertest
       run: rm -rf out
 
     - name: 'Configure CMake (C++20)'

--- a/.nuget/directxmath.nuspec
+++ b/.nuget/directxmath.nuspec
@@ -8,7 +8,7 @@
         <owners>microsoft,directxtk</owners>
         <summary>DirectXMath is an all inline SIMD C++ linear algebra library for use in games and graphics apps.</summary>
         <description>The DirectXMath API provides SIMD-friendly C++ types and functions for common linear algebra and graphics math operations common to DirectX applications. The library provides optimized versions for Windows 32-bit (x86), Windows 64-bit (x64), and Windows on ARM through SSE2 and ARM-NEON intrinsics support in the Visual Studio compiler.</description>
-        <releaseNotes>Matches the October 2024 release.</releaseNotes>
+        <releaseNotes>Matches the April 2025 release.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkID=615560</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXMath.git" />
         <icon>images\icon.jpg</icon>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXM
 
 ## Release History
 
+### April 2025 (3.20b)
+* `XM_DEPRECATED` macro uses C++14 ``[[deprecated]]`` standard attribute when supported
+* Cmake project updates with build options for XDSP and SHMath
+
 ### October 2024 (3.20)
 * Fixed close-to-zero bug in the implementation of `TriangleTests::Intersects`
 * Renamed implementation namespace from `DirectX::Internal` to `DirectX::MathInternal` to avoid some conformance issues with other libraries

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Documentation is available on the [Microsoft Docs](https://docs.microsoft.com/en
 
 ## Compiler support
 
-Officially the library is supported with Microsoft Visual C++ 2019 or later, clang/LLVM v12 or later, and GCC 9 or later. It should also compile with the Intel C++ and MinGW compilers.
+Officially the library is supported with Microsoft Visual C++ 2019 (16.11) or later, clang/LLVM v12 or later, and GCC 10 or later. It should also compile with the Intel C++ and MinGW compilers.
 
 When building with clang/LLVM or other GNU C compilers, the ``_XM_NO_XMVECTOR_OVERLOADS_`` control define is set because these compilers do not support creating operator overloads for the ``XMVECTOR`` type. You can choose to enable this preprocessor define explicitly to do the same thing with Visual C++ for improved portability.
 
@@ -69,7 +69,10 @@ With GCC, the SAL annotation preprocessor symbols can conflict with the GNU impl
 
 ```
 #include <algorithm>
+#include <iterator>
 #include <utility>
+
+#include <format> // C++20 header
 
 #include <DirectXMath.h>
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/Microsoft/DirectXMath
 
 Copyright (c) Microsoft Corporation.
 
-**October 2024**
+**April 2025**
 
 This package contains the DirectXMath library, an all inline SIMD C++ linear algebra library for use in games and graphics apps.
 


### PR DESCRIPTION
* `XM_DEPRECATED` macro uses C++14 ``[[deprecated]]`` standard attribute when supported
* Cmake project updates with build options for XDSP and SHMath