### PR TITLE
CMake update for MinGW

### DIFF
--- a/.azuredevops/pipelines/DirectXMath-GitHub-CMake-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-CMake-Dev17.yml
@@ -139,3 +139,205 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out5 -v --config RelWithDebInfo
+
+- job: CMAKE_BUILD_XDSP
+  displayName: CMake using VS Generator BUILD_XDSP=ON
+  cancelTimeoutInMinutes: 1
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DBUILD_XDSP=ON
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x86'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A Win32 -B out2 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DBUILD_XDSP=ON
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x86 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x86 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config ARM64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DBUILD_XDSP=ON
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build ARM64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build ARM64 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Config x64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -T clangcl -B out4 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DBUILD_XDSP=ON
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Build x64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Build x64 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Config ARM64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out5 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
+        -DBUILD_XDSP=ON
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Build ARM64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out5 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Build ARM64 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out5 -v --config RelWithDebInfo
+
+- job: CMAKE_BUILD_SHMATH
+  displayName: CMake using VS Generator BUILD_SHMATH=ON
+  cancelTimeoutInMinutes: 1
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DBUILD_SHMATH=ON -DBUILD_DX11=ON -DBUILD_DX12=ON
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x64 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config x86'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A Win32 -B out2 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DBUILD_SHMATH=ON -DBUILD_DX11=ON -DBUILD_DX12=ON
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x86 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build x86 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out2 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Config ARM64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DBUILD_SHMATH=ON -DBUILD_DX11=ON -DBUILD_DX12=ON
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build ARM64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (MSVC): Build ARM64 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out3 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Config x64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A x64 -T clangcl -B out4 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+        -DBUILD_SHMATH=ON -DBUILD_DX11=ON -DBUILD_DX12=ON
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Build x64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Build x64 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out4 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Config ARM64'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: >
+        -G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out5 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
+        -DBUILD_SHMATH=ON -DBUILD_DX11=ON -DBUILD_DX12=ON
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Build ARM64 Debug'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out5 -v --config Debug
+  - task: CMake@1
+    displayName: 'CMake (ClangCl): Build ARM64 Release'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out5 -v --config RelWithDebInfo

--- a/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
@@ -41,6 +41,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
   - repository: testRepo
     name: walbourn/directxmathtest
     type: github
@@ -54,6 +59,9 @@ pool:
 
 variables:
   Codeql.Enabled: false
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   URL_MINGW32: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
   HASH_MINGW32: 'fcd1e11b896190da01c83d5b5fb0d37b7c61585e53446c2dab0009debc3915e757213882c35e35396329338de6f0222ba012e23a5af86932db45186a225d1272'
 
@@ -66,12 +74,27 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: 's'
+  - checkout: vcpkgRepo
+    displayName: Fetch VCPKG
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - checkout: testRepo
     displayName: Fetch Tests
     clean: true
     fetchTags: false
     fetchDepth: 1
     path: 's/Tests'
+  - task: CmdLine@2
+    displayName: VCPKG Bootstrap
+    inputs:
+      script: |
+        call bootstrap-vcpkg.bat
+        echo ##vso[task.setvariable variable=VCPKG_DEFAULT_TRIPLET;]x86-mingw-static
+        echo ##vso[task.setvariable variable=VCPKG_DEFAULT_HOST_TRIPLET;]x86-mingw-static
+
+      workingDirectory: $(Build.SourcesDirectory)\vcpkg
   - task: PowerShell@2
     displayName: Install MinGW32
     inputs:
@@ -102,7 +125,9 @@ jobs:
     displayName: CMake (MinGW32) Dbg
     inputs:
       cwd: Tests
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86 -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
   - task: CMake@1
     displayName: CMake (MinGW32) Build Dbg
     inputs:
@@ -112,7 +137,9 @@ jobs:
     displayName: CMake (MinGW32) Rel
     inputs:
       cwd: Tests
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DDXMATH_ARCHITECTURE=x86 -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DDXMATH_ARCHITECTURE=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
   - task: CMake@1
     displayName: CMake (MinGW32) Build Rel
     inputs:
@@ -122,12 +149,59 @@ jobs:
     displayName: CMake (MinGW32) Dbg NI
     inputs:
       cwd: Tests
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE="Debug" -DBUILD_NO_INTRINSICS=ON -DDXMATH_ARCHITECTURE=x86 -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DBUILD_NO_INTRINSICS=ON
   - task: CMake@1
     displayName: CMake (MinGW32) Build Dbg NI
     inputs:
       cwd: Tests
       cmakeArgs: --build out3
+  - task: CMake@1
+    displayName: CMake (MinGW32; XDSP) Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: >
+        -B out4 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DBUILD_XDSP=ON
+  - task: CMake@1
+    displayName: CMake (MinGW32; XDSP) Build Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: --build out4
+  - task: CMake@1
+    displayName: CMake (MinGW32; SH DX11) Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: >
+        -B out5 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DBUILD_SHMATH=ON -DBUILD_DX11=ON
+  - task: CMake@1
+    displayName: CMake (MinGW32; SH DX11) Build Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: --build out5
+  - task: CmdLine@2
+    displayName: VCPKG install packages
+    inputs:
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x86-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
+  - task: CMake@1
+    displayName: CMake (MinGW32; SH DX12) Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: >
+        -B out6 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86 -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DBUILD_SHMATH=ON -DBUILD_DX12=ON
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
+  - task: CMake@1
+    displayName: CMake (MinGW32; SH DX12) Build Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: --build out6
 
 - job: MINGW64_BUILD
   displayName: 'Minimalist GNU for Windows (MinGW-W64)'
@@ -137,12 +211,27 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: 's'
+  - checkout: vcpkgRepo
+    displayName: Fetch VCPKG
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - checkout: testRepo
     displayName: Fetch Tests
     clean: true
     fetchTags: false
     fetchDepth: 1
     path: 's/Tests'
+  - task: CmdLine@2
+    displayName: VCPKG Bootstrap
+    inputs:
+      script: |
+        call bootstrap-vcpkg.bat
+        echo ##vso[task.setvariable variable=VCPKG_DEFAULT_TRIPLET;]x64-mingw-static
+        echo ##vso[task.setvariable variable=VCPKG_DEFAULT_HOST_TRIPLET;]x64-mingw-static
+
+      workingDirectory: $(Build.SourcesDirectory)\vcpkg
   - task: CmdLine@2
     displayName: GCC version
     inputs:
@@ -151,7 +240,9 @@ jobs:
     displayName: CMake (MinGW-W64) Dbg
     inputs:
       cwd: Tests
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64 -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build Dbg
     inputs:
@@ -161,7 +252,9 @@ jobs:
     displayName: CMake (MinGW-W64) Rel
     inputs:
       cwd: Tests
-      cmakeArgs: -B out2 -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DDXMATH_ARCHITECTURE=x64 -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+      cmakeArgs: >
+        -B out2 -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DDXMATH_ARCHITECTURE=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build Rel
     inputs:
@@ -171,9 +264,57 @@ jobs:
     displayName: CMake (MinGW-W64) Dbg NI
     inputs:
       cwd: Tests
-      cmakeArgs: -B out3 -DCMAKE_BUILD_TYPE="Debug" -DBUILD_NO_INTRINSICS=ON -DDXMATH_ARCHITECTURE=x64 -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+      cmakeArgs: >
+        -B out3 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DBUILD_NO_INTRINSICS=ON
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build Dbg NI
     inputs:
       cwd: Tests
       cmakeArgs: --build out3
+  - task: CMake@1
+    displayName: CMake (MinGW-W64; XDSP) Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: >
+        -B out4 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DBUILD_XDSP=ON
+  - task: CMake@1
+    displayName: CMake (MinGW-W64; XDSP) Build Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: --build out4
+  - task: CMake@1
+    displayName: CMake (MinGW-W64; SH DX11) Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: >
+        -B out5 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DBUILD_SHMATH=ON -DBUILD_DX11=ON
+  - task: CMake@1
+    displayName: CMake (MinGW-W64; SH DX11) Build Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: --build out5
+  - task: CmdLine@2
+    displayName: VCPKG install packages
+    inputs:
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
+  - task: CMake@1
+    displayName: CMake (MinGW-W64; SH DX12) Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: >
+        -B out6 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DBUILD_SHMATH=ON -DBUILD_DX12=ON
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
+  - task: CMake@1
+    displayName: CMake (MinGW-W64; SH DX12) Build Dbg
+    inputs:
+      cwd: Tests
+      cmakeArgs: --build out6

--- a/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
@@ -170,7 +170,7 @@ jobs:
     displayName: CMake (MinGW32; XDSP) Build Dbg
     inputs:
       cwd: Tests
-      cmakeArgs: --build out4 -v
+      cmakeArgs: --build out4
   - task: CMake@1
     displayName: CMake (MinGW32; SH DX11) Dbg
     inputs:
@@ -285,7 +285,7 @@ jobs:
     displayName: CMake (MinGW-W64; XDSP) Build Dbg
     inputs:
       cwd: Tests
-      cmakeArgs: --build out4 -v
+      cmakeArgs: --build out4
   - task: CMake@1
     displayName: CMake (MinGW-W64; SH DX11) Dbg
     inputs:

--- a/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
@@ -124,31 +124,31 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW32) Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
   - task: CMake@1
     displayName: CMake (MinGW32) Build Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out
   - task: CMake@1
     displayName: CMake (MinGW32) Rel
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out2 -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DDXMATH_ARCHITECTURE=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
   - task: CMake@1
     displayName: CMake (MinGW32) Build Rel
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out2
   - task: CMake@1
     displayName: CMake (MinGW32) Dbg NI
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out3 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
@@ -156,12 +156,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW32) Build Dbg NI
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out3
   - task: CMake@1
     displayName: CMake (MinGW32; XDSP) Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out4 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
@@ -169,12 +169,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW32; XDSP) Build Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out4
   - task: CMake@1
     displayName: CMake (MinGW32; SH DX11) Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out5 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
@@ -182,7 +182,7 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW32; SH DX11) Build Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out5
   - task: CmdLine@2
     displayName: VCPKG install packages
@@ -192,7 +192,7 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW32; SH DX12) Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out6 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86 -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
         -DBUILD_SHMATH=ON -DBUILD_DX12=ON
@@ -200,7 +200,7 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW32; SH DX12) Build Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out6
 
 - job: MINGW64_BUILD
@@ -239,31 +239,31 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW-W64) Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out
   - task: CMake@1
     displayName: CMake (MinGW-W64) Rel
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out2 -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DDXMATH_ARCHITECTURE=x64
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build Rel
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out2
   - task: CMake@1
     displayName: CMake (MinGW-W64) Dbg NI
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out3 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
@@ -271,12 +271,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build Dbg NI
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out3
   - task: CMake@1
     displayName: CMake (MinGW-W64; XDSP) Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out4 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
@@ -284,12 +284,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW-W64; XDSP) Build Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out4
   - task: CMake@1
     displayName: CMake (MinGW-W64; SH DX11) Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out5 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
@@ -297,7 +297,7 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW-W64; SH DX11) Build Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out5
   - task: CmdLine@2
     displayName: VCPKG install packages
@@ -307,7 +307,7 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW-W64; SH DX12) Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: >
         -B out6 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x64
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
@@ -316,5 +316,5 @@ jobs:
   - task: CMake@1
     displayName: CMake (MinGW-W64; SH DX12) Build Dbg
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build out6

--- a/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
@@ -170,7 +170,7 @@ jobs:
     displayName: CMake (MinGW32; XDSP) Build Dbg
     inputs:
       cwd: Tests
-      cmakeArgs: --build out4
+      cmakeArgs: --build out4 -v
   - task: CMake@1
     displayName: CMake (MinGW32; SH DX11) Dbg
     inputs:
@@ -285,7 +285,7 @@ jobs:
     displayName: CMake (MinGW-W64; XDSP) Build Dbg
     inputs:
       cwd: Tests
-      cmakeArgs: --build out4
+      cmakeArgs: --build out4 -v
   - task: CMake@1
     displayName: CMake (MinGW-W64; SH DX11) Dbg
     inputs:

--- a/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
@@ -166,6 +166,10 @@ jobs:
         -B out4 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
         -DBUILD_XDSP=ON
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: Write-Host "##vso[build.uploadlog]$env:BUILD_SOURCESDIRECTORY/Tests/out4/CMakeFiles/xdsptest.dir/includes_CXX.rsp"
   - task: CMake@1
     displayName: CMake (MinGW32; XDSP) Build Dbg
     inputs:

--- a/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
@@ -166,10 +166,6 @@ jobs:
         -B out4 -DCMAKE_BUILD_TYPE="Debug" -DDXMATH_ARCHITECTURE=x86
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
         -DBUILD_XDSP=ON
-  - task: PowerShell@2
-    inputs:
-      targetType: inline
-      script: Write-Host "##vso[build.uploadlog]$env:BUILD_SOURCESDIRECTORY/Tests/out4/CMakeFiles/xdsptest.dir/includes_CXX.rsp"
   - task: CMake@1
     displayName: CMake (MinGW32; XDSP) Build Dbg
     inputs:

--- a/.azuredevops/pipelines/DirectXMath-GitHub-WSL-11.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-WSL-11.yml
@@ -63,8 +63,8 @@ jobs:
   - task: CMake@1
     displayName: DirectXMath Tests
     inputs:
-      cwd: Tests
-      cmakeArgs: .
+      cwd: .
+      cmakeArgs: -B out -DBUILD_XDSP=ON -DBUILD_SHMATH=ON
   - task: PowerShell@2
     displayName: Fetch SAL.H
     inputs:
@@ -82,5 +82,5 @@ jobs:
   - task: CMake@1
     displayName: DirectXMath Tests Build
     inputs:
-      cwd: Tests
-      cmakeArgs: --build . -v
+      cwd: .
+      cmakeArgs: --build out -v

--- a/.azuredevops/pipelines/DirectXMath-GitHub-WSL-13.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-WSL-13.yml
@@ -83,4 +83,4 @@ jobs:
     displayName: DirectXMath Tests Build
     inputs:
       cwd: .
-      cmakeArgs: --build . -v
+      cmakeArgs: --build out -v

--- a/.azuredevops/pipelines/DirectXMath-GitHub-WSL-13.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-WSL-13.yml
@@ -63,8 +63,8 @@ jobs:
   - task: CMake@1
     displayName: DirectXMath Tests
     inputs:
-      cwd: Tests
-      cmakeArgs: .
+      cwd: .
+      cmakeArgs: -B out -DBUILD_XDSP=ON -DBUILD_SHMATH=ON
   - task: PowerShell@2
     displayName: Fetch SAL.H
     inputs:
@@ -82,5 +82,5 @@ jobs:
   - task: CMake@1
     displayName: DirectXMath Tests Build
     inputs:
-      cwd: Tests
+      cwd: .
       cmakeArgs: --build . -v

--- a/SHMath/CMakeLists.txt
+++ b/SHMath/CMakeLists.txt
@@ -217,3 +217,13 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         target_compile_options(${PROJECT_NAME} PRIVATE $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 endif()
+
+if(NOT WIN32)
+    file(DOWNLOAD
+        https://raw.githubusercontent.com/dotnet/runtime/v9.0.2/src/coreclr/pal/inc/rt/sal.h
+        "${CMAKE_CURRENT_BINARY_DIR}/sal/sal.h"
+        EXPECTED_HASH SHA512=8085f67bfa4ce01ae89461cadf72454a9552fde3f08b2dcc3de36b9830e29ce7a6192800f8a5cb2a66af9637be0017e85719826a4cfdade508ae97f319e0ee8e
+    )
+
+    target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/sal")
+endif()

--- a/SHMath/CMakeLists.txt
+++ b/SHMath/CMakeLists.txt
@@ -3,15 +3,30 @@
 
 cmake_minimum_required (VERSION 3.20)
 
-if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-  message(FATAL_ERROR "SHMath should be built by the main CMakeLists using BUILD_SHMATH")
+if(DEFINED DIRECTXMATH_VERSION)
+   set(SHMATH_VERSION ${DIRECTXMATH_VERSION})
+else()
+   set(SHMATH_VERSION 1.0.6)
 endif()
 
 project(DirectXSH
-  VERSION ${DIRECTXMATH_VERSION}
+  VERSION ${SHMATH_VERSION}
   DESCRIPTION "C++ Spherical Harmonics Math Library"
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
   LANGUAGES CXX)
+
+if(CMAKE_VERSION VERSION_LESS 3.21)
+  get_property(not_top DIRECTORY PROPERTY PARENT_DIRECTORY)
+  if(not_top)
+    set(PROJECT_IS_TOP_LEVEL false)
+  else()
+    set(PROJECT_IS_TOP_LEVEL true)
+  endif()
+endif()
+
+if(PROJECT_IS_TOP_LEVEL)
+  message(FATAL_ERROR "SHMath should be built by the main CMakeLists using BUILD_SHMATH")
+endif()
 
 option(BUILD_DX11 "Build with DirectX11 support" OFF)
 
@@ -95,7 +110,7 @@ cmake_path(GET CMAKE_CURRENT_LIST_DIR PARENT_PATH DIRECTXMATH_PATH)
 
 write_basic_package_version_file(
   ${PACKAGE_NAME}-config-version.cmake
-  VERSION ${DIRECTXMATH_VERSION}
+  VERSION ${SHMATH_VERSION}
   COMPATIBILITY AnyNewerVersion
   ARCH_INDEPENDENT)
 

--- a/SHMath/CMakeLists.txt
+++ b/SHMath/CMakeLists.txt
@@ -73,7 +73,7 @@ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE DirectXMath)
 
-if(MINGW)
+if(MINGW AND BUILD_DX12)
     find_package(directx-headers CONFIG REQUIRED)
     target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
     target_compile_definitions(${PROJECT_NAME} PUBLIC USING_DIRECTX_HEADERS)

--- a/XDSP/CMakeLists.txt
+++ b/XDSP/CMakeLists.txt
@@ -3,15 +3,30 @@
 
 cmake_minimum_required (VERSION 3.20)
 
-if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-  message(FATAL_ERROR "XSDP should be built by the main CMakeLists using BUILD_XDSP")
+if(DEFINED DIRECTXMATH_VERSION)
+   set(XDSP_VERSION ${DIRECTXMATH_VERSION})
+else()
+   set(XDSP_VERSION 3.0.0)
 endif()
 
 project(XDSP
-  VERSION ${DIRECTXMATH_VERSION}
+  VERSION ${XDSP_VERSION}
   DESCRIPTION "XDSP Digital Signal Processing (DSP) for DirectXMath"
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
   LANGUAGES CXX)
+
+if(CMAKE_VERSION VERSION_LESS 3.21)
+  get_property(not_top DIRECTORY PROPERTY PARENT_DIRECTORY)
+  if(not_top)
+    set(PROJECT_IS_TOP_LEVEL false)
+  else()
+    set(PROJECT_IS_TOP_LEVEL true)
+  endif()
+endif()
+
+if(PROJECT_IS_TOP_LEVEL)
+  message(FATAL_ERROR "XSDP should be built by the main CMakeLists using BUILD_XDSP")
+endif()
 
 #--- Library
 set(LIBRARY_HEADERS XDSP.h)
@@ -32,7 +47,7 @@ cmake_path(GET CMAKE_CURRENT_LIST_DIR PARENT_PATH DIRECTXMATH_PATH)
 
 write_basic_package_version_file(
   ${PACKAGE_NAME}-config-version.cmake
-  VERSION ${DIRECTXMATH_VERSION}
+  VERSION ${XDSP_VERSION}
   COMPATIBILITY AnyNewerVersion
   ARCH_INDEPENDENT)
 

--- a/build/vcpkg.json
+++ b/build/vcpkg.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "dependencies": [
+      "directx-headers"
+    ]
+}


### PR DESCRIPTION
The MinGW header set is a odd mixture of WINE headers, but it does work for Direct3D 11. It just doesn't work for Direct3D 12 so it needs to use **directx-headers** in that case. It does not need to use it for DX11 only.

> Added more ADO coverage for new CMake build options as well.