### PR TITLE
Cleanup of ADO pipeline YAML files

### DIFF
--- a/.azuredevops/pipelines/DirectXMath-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-CMake.yml
@@ -32,7 +32,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
 
 resources:

--- a/.azuredevops/pipelines/DirectXMath-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-CMake.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.ps1
 

--- a/.azuredevops/pipelines/DirectXMath-GitHub-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-Dev17.yml
@@ -46,6 +46,28 @@ jobs:
 - job: BUILD_DEV17
   displayName: 'Visual Studio 2022 (v143)'
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 6
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+
   steps:
   - checkout: self
     clean: true
@@ -59,276 +81,118 @@ jobs:
     fetchDepth: 1
     path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86dbg
+    displayName: Build solution math3_2022.sln
     inputs:
       solution: Tests/math3/math3_2022.sln
       vsVersion: 17.0
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
   - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86rel
+    displayName: Build solution math3_2022.sln no-intrinsics
     inputs:
       solution: Tests/math3/math3_2022.sln
       vsVersion: 17.0
-      platform: x86
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: 'NI $(BuildConfiguration)'
       msbuildArchitecture: x64
   - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64dbg
+    displayName: Build solution math3_2022.sln SSE3
     inputs:
       solution: Tests/math3/math3_2022.sln
       vsVersion: 17.0
-      platform: x64
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: 'SSE3 $(BuildConfiguration)'
       msbuildArchitecture: x64
+    condition: ne(variables['BuildPlatform'], 'ARM64')
   - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64rel
+    displayName: Build solution math3_2022.sln SSE4
     inputs:
       solution: Tests/math3/math3_2022.sln
       vsVersion: 17.0
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: 'SSE4 $(BuildConfiguration)'
       msbuildArchitecture: x64
+    condition: ne(variables['BuildPlatform'], 'ARM64')
   - task: VSBuild@1
-    displayName: Build solution math3_2022.sln arm64dbg
+    displayName: Build solution math3_2022.sln AVX
     inputs:
       solution: Tests/math3/math3_2022.sln
       vsVersion: 17.0
-      platform: ARM64
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: 'AVX $(BuildConfiguration)'
       msbuildArchitecture: x64
+    condition: ne(variables['BuildPlatform'], 'ARM64')
   - task: VSBuild@1
-    displayName: Build solution math3_2022.sln arm64rel
+    displayName: Build solution math3_2022.sln AVX2
     inputs:
       solution: Tests/math3/math3_2022.sln
       vsVersion: 17.0
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: 'AVX2 $(BuildConfiguration)'
       msbuildArchitecture: x64
+    condition: ne(variables['BuildPlatform'], 'ARM64')
   - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86dbg sse3
+    displayName: Build solution math3_2022.sln x87
     inputs:
       solution: Tests/math3/math3_2022.sln
       vsVersion: 17.0
-      platform: x86
-      configuration: SSE3 Debug
+      platform: '$(BuildPlatform)'
+      configuration: 'x87 $(BuildConfiguration)'
       msbuildArchitecture: x64
+    condition: eq(variables['BuildPlatform'], 'x86')
+
+- job: BUILD_EXTS
+  displayName: 'Visual Studio 2022 (v143) SHMath and XDSP'
+  cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 2
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86rel sse3
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: SSE3 Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64dbg sse3
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: SSE3 Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64rel sse3
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: SSE3 Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86dbg sse4
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: SSE4 Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86rel sse4
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: SSE4 Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64dbg sse4
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: SSE4 Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64rel sse4
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: SSE4 Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86dbg avx
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: AVX Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86rel avx
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: AVX Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64dbg avx
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: AVX Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64rel avx
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: AVX Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86dbg avx2
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: AVX2 Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86rel avx2
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: AVX2 Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64dbg avx2
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: AVX2 Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64rel avx2
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: AVX2 Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86dbg nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: NI Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86rel nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: NI Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64dbg nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: NI Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x64rel nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: NI Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln arm64dbg nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: ARM64
-      configuration: NI Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln arm86rel nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: ARM64
-      configuration: NI Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86dbg x87
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: x87 Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution math3_2022.sln x86rel x87
-    inputs:
-      solution: Tests/math3/math3_2022.sln
-      vsVersion: 17.0
-      platform: x86
-      configuration: x87 Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution shmath_2022.sln x64dbg
+    displayName: Build solution shmath_2022.sln
     inputs:
       solution: Tests/shmath/shmath_2022.sln
       vsVersion: 17.0
-      platform: x64
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
   - task: VSBuild@1
-    displayName: Build solution shmath_2022.sln x64rel
-    inputs:
-      solution: Tests/shmath/shmath_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution XDSPTest_2022 x64dbg
+    displayName: Build solution XDSPTest_2022
     inputs:
       solution: Tests/xdsp/XDSPTest_2022.sln
       vsVersion: 17.0
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution XDSPTest_2022 x64rel
-    inputs:
-      solution: Tests/xdsp/XDSPTest_2022.sln
-      vsVersion: 17.0
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
 
 - job: CMAKE_BUILD_X64

--- a/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
@@ -32,7 +32,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
   drafts: false
 

--- a/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-MinGW.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.ps1
 

--- a/.azuredevops/pipelines/DirectXMath-GitHub.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub.yml
@@ -45,6 +45,21 @@ jobs:
 - job: BUILD_DEV16
   displayName: 'Visual Studio 2019 (v142)'
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 4
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -58,274 +73,74 @@ jobs:
     fetchDepth: 1
     path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86dbg
+    displayName: Build solution math3_2019.sln
     inputs:
       solution: Tests/math3/math3_2019.sln
       vsVersion: 16.0
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86rel
+    displayName: Build solution math3_2019.sln no-intrinsics
     inputs:
       solution: Tests/math3/math3_2019.sln
       vsVersion: 16.0
-      platform: x86
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: 'NI $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64dbg
+    displayName: Build solution math3_2019.sln SSE3
     inputs:
       solution: Tests/math3/math3_2019.sln
       vsVersion: 16.0
-      platform: x64
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: 'SSE3 $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64rel
+    displayName: Build solution math3_2019.sln SSE4
     inputs:
       solution: Tests/math3/math3_2019.sln
       vsVersion: 16.0
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: 'SSE4 $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2019.sln arm64dbg
+    displayName: Build solution math3_2019.sln AVX
     inputs:
       solution: Tests/math3/math3_2019.sln
       vsVersion: 16.0
-      platform: ARM64
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: 'AVX $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2019.sln arm64rel
+    displayName: Build solution math3_2019.sln AVX2
     inputs:
       solution: Tests/math3/math3_2019.sln
       vsVersion: 16.0
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: 'AVX2 $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86dbg sse3
+    displayName: Build solution math3_2019.sln x87
     inputs:
       solution: Tests/math3/math3_2019.sln
       vsVersion: 16.0
-      platform: x86
-      configuration: SSE3 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86rel sse3
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: SSE3 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64dbg sse3
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: SSE3 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64rel sse3
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: SSE3 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86dbg sse4
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: SSE4 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86rel sse4
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: SSE4 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64dbg sse4
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: SSE4 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64rel sse4
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: SSE4 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86dbg avx
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: AVX Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86rel avx
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: AVX Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64dbg avx
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: AVX Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64rel avx
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: AVX Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86dbg avx2
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: AVX2 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86rel avx2
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: AVX2 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64dbg avx2
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: AVX2 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64rel avx2
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: AVX2 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86dbg nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: NI Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86rel nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: NI Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64dbg nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: NI Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x64rel nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: NI Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln arm64dbg nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: ARM64
-      configuration: NI Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln arm86rel nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: ARM64
-      configuration: NI Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86dbg x87
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: x87 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2019.sln x86rel x87
-    inputs:
-      solution: Tests/math3/math3_2019.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: x87 Release
-  - task: VSBuild@1
-    displayName: Build solution shmath_2019.sln x64dbg
-    inputs:
-      solution: Tests/shmath/shmath_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution shmath_2019.sln x64rel
-    inputs:
-      solution: Tests/shmath/shmath_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution shmath_2019.sln arm64dbg
-    inputs:
-      solution: Tests/shmath/shmath_2019.sln
-      vsVersion: 16.0
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution shmath_2019.sln arm64rel
-    inputs:
-      solution: Tests/shmath/shmath_2019.sln
-      vsVersion: 16.0
-      platform: ARM64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution XDSPTest_2019 x64dbg
-    inputs:
-      solution: Tests/xdsp/XDSPTest_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution XDSPTest_2019 x64rel
-    inputs:
-      solution: Tests/xdsp/XDSPTest_2019.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution XDSPTest_2019 arm64dbg
-    inputs:
-      solution: Tests/xdsp/XDSPTest_2019.sln
-      vsVersion: 16.0
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution XDSPTest_2019 arm64rel
-    inputs:
-      solution: Tests/xdsp/XDSPTest_2019.sln
-      vsVersion: 16.0
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: 'x87 $(BuildConfiguration)'
+    condition: eq(variables['BuildPlatform'], 'x86')
 
-- job: BUILD_DEV15
-  displayName: 'Visual Studio 2019 (v141)'
+- job: BUILD_EXTS
+  displayName: 'Visual Studio 2019 (v142) SHMath and XDSP'
+  cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 1
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -339,212 +154,141 @@ jobs:
     fetchDepth: 1
     path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86dbg
+    displayName: Build solution shmath_2019.sln
     inputs:
-      solution: Tests/math3/math3_2017.sln
+      solution: Tests/shmath/shmath_2019.sln
       vsVersion: 16.0
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86rel
+    displayName: Build solution XDSPTest_2019
     inputs:
-      solution: Tests/math3/math3_2017.sln
+      solution: Tests/xdsp/XDSPTest_2019.sln
       vsVersion: 16.0
-      platform: x86
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
+
+- job: BUILD_LEGACY
+  displayName: 'Visual Studio 2019 (v141) Legacy'
+  strategy:
+    maxParallel: 4
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64dbg
+    displayName: Build solution math3_2017.sln
     inputs:
       solution: Tests/math3/math3_2017.sln
       vsVersion: 16.0
-      platform: x64
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64rel
+    displayName: Build solution math3_2017.sln no-intrinsics
     inputs:
       solution: Tests/math3/math3_2017.sln
       vsVersion: 16.0
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: 'NI $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86dbg sse3
+    displayName: Build solution math3_2017.sln SSE3
     inputs:
       solution: Tests/math3/math3_2017.sln
       vsVersion: 16.0
-      platform: x86
-      configuration: SSE3 Debug
+      platform: '$(BuildPlatform)'
+      configuration: 'SSE3 $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86rel sse3
+    displayName: Build solution math3_2017.sln SSE4
     inputs:
       solution: Tests/math3/math3_2017.sln
       vsVersion: 16.0
-      platform: x86
-      configuration: SSE3 Release
+      platform: '$(BuildPlatform)'
+      configuration: 'SSE4 $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64dbg sse3
+    displayName: Build solution math3_2017.sln AVX
     inputs:
       solution: Tests/math3/math3_2017.sln
       vsVersion: 16.0
-      platform: x64
-      configuration: SSE3 Debug
+      platform: '$(BuildPlatform)'
+      configuration: 'AVX $(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64rel sse3
+    displayName: Build solution math3_2017.sln AVX2
     inputs:
       solution: Tests/math3/math3_2017.sln
       vsVersion: 16.0
-      platform: x64
-      configuration: SSE3 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86dbg sse4
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: SSE4 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86rel sse4
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: SSE4 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64dbg sse4
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: SSE4 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64rel sse4
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: SSE4 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86dbg avx
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: AVX Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86rel avx
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: AVX Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64dbg avx
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: AVX Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64rel avx
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: AVX Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86dbg avx2
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: AVX2 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86rel avx2
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: AVX2 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64dbg avx2
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: AVX2 Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64rel avx2
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: AVX2 Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86dbg nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: NI Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86rel nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: NI Release
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64dbg nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: NI Debug
-  - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x64rel nointrinsics
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: NI Release
+      platform: '$(BuildPlatform)'
+      configuration: 'AVX2 $(BuildConfiguration)'
   - task: VSBuild@1
     displayName: Build solution math3_2017.sln x86dbg x87
     inputs:
       solution: Tests/math3/math3_2017.sln
       vsVersion: 16.0
-      platform: x86
-      configuration: x87 Debug
+      platform: '$(BuildPlatform)'
+      configuration: 'x87 $(BuildConfiguration)'
+    condition: eq(variables['BuildPlatform'], 'x86')
+
+- job: BUILD_EXTS_LEGACY
+  displayName: 'Visual Studio 2019 (v141) Legacy - SHMath and XDSP'
+  cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 1
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution math3_2017.sln x86rel x87
-    inputs:
-      solution: Tests/math3/math3_2017.sln
-      vsVersion: 16.0
-      platform: x86
-      configuration: x87 Release
-  - task: VSBuild@1
-    displayName: Build solution shmath_2017.sln x64dbg
+    displayName: Build solution shmath_2017.sln
     inputs:
       solution: Tests/shmath/shmath_2017.sln
       vsVersion: 16.0
-      platform: x64
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution shmath_2017.sln x64rel
-    inputs:
-      solution: Tests/shmath/shmath_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution XDSPTest_2017 x64dbg
+    displayName: Build solution XDSPTest_2017
     inputs:
       solution: Tests/xdsp/XDSPTest_2017.sln
       vsVersion: 16.0
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution XDSPTest_2017 x64rel
-    inputs:
-      solution: Tests/xdsp/XDSPTest_2017.sln
-      vsVersion: 16.0
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,12 +8,18 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
   schedule:

--- a/.github/workflows/cxx.yml
+++ b/.github/workflows/cxx.yml
@@ -8,12 +8,18 @@ name: 'CMake (Windows /std)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,18 @@ name: 'CMake (Windows)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,12 +8,18 @@ name: MSBuild
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*
 

--- a/.github/workflows/msbuildex.yml
+++ b/.github/workflows/msbuildex.yml
@@ -8,12 +8,18 @@ name: 'MSBuild (Extended)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -8,12 +8,18 @@ name: Microsoft C++ Code Analysis
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
 

--- a/.github/workflows/shmath.yml
+++ b/.github/workflows/shmath.yml
@@ -8,12 +8,18 @@ name: 'CMake (SHMath)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,18 @@ name: 'CTest (Windows)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
 

--- a/.github/workflows/wsl.yml
+++ b/.github/workflows/wsl.yml
@@ -8,12 +8,18 @@ name: 'CMake (WSL)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
 

--- a/.github/workflows/wslcxx.yml
+++ b/.github/workflows/wslcxx.yml
@@ -8,12 +8,18 @@ name: 'CMake (WSL -std)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
 

--- a/.github/workflows/xdsp.yml
+++ b/.github/workflows/xdsp.yml
@@ -8,12 +8,18 @@ name: 'CMake (XDSP)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.ps1
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.ps1
 


### PR DESCRIPTION
This PR adds the use of strategy to the existing ADO pipelines.

* I made use of `strategy` `matrix` to simplify the pipelines for GitHub and GitHub-Dev17

> Also updated pipeline trigger path filters: GHA should ignore everything under ``.azuredevops``, and ADO should ignore everything under ``.github``.
