### PR TITLE
ARM64 won't build with 19041 SDK

### DIFF
--- a/.azuredevops/pipelines/DirectXMath-GitHub-CMake-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-CMake-Dev17.yml
@@ -100,7 +100,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+            -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
       - task: CMake@1
         displayName: 'CMake (MSVC): Build ARM64 Debug'
         inputs:
@@ -198,7 +198,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+            -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
             -DBUILD_XDSP=ON
       - task: CMake@1
         displayName: 'CMake (MSVC): Build ARM64 Debug'
@@ -299,7 +299,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
+            -G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)
             -DBUILD_SHMATH=ON -DBUILD_DX11=ON -DBUILD_DX12=ON
       - task: CMake@1
         displayName: 'CMake (MSVC): Build ARM64 Debug'

--- a/.azuredevops/pipelines/DirectXMath-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/DirectXMath-GitHub-CMake.yml
@@ -94,25 +94,3 @@ jobs:
         inputs:
           cwd: Tests
           cmakeArgs: --build out -v
-      - task: CMake@1
-        displayName: CMake (MSVC ARM64)
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: >
-            -G "$(VS_GENERATOR)" -T v142 -A ARM64 -B out2 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
-      - task: CMake@1
-        displayName: CMake (Build ARM64)
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out2 -v
-      - task: CMake@1
-        displayName: CMake Test (MSVC ARM64)
-        inputs:
-          cwd: Tests
-          cmakeArgs: >
-            -G "$(VS_GENERATOR)" -T v142 -A ARM64 -B out2 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
-      - task: CMake@1
-        displayName: CMake Test (Build ARM64)
-        inputs:
-          cwd: Tests
-          cmakeArgs: --build out2 -v


### PR DESCRIPTION
The VS 2019 toolset support for ARM64 is deprecated. Removed that case from the build pipelines.

Use of the Windows SDK (19041) fails now with VS 2022 ARM64 because those libs were not built with `ehcont`. Moved to the 10.0.26100 SDK instead.