### PR TITLE
Upgrade to CMake 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.21)
 
 set(DIRECTXMATH_VERSION 3.20)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": 2,
+  "version": 3,
   "configurePresets": [
     {
       "name": "base",
@@ -8,7 +8,7 @@
       "generator": "Ninja",
       "hidden": true,
       "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "cacheVariables": { "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}" }
+      "installDir": "${sourceDir}/out/install/${presetName}"
     },
 
     {

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXMath/s
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXMath/blob/main/CHANGELOG.md).
 
+* The CMake projects require 3.21 or later. VS 2019 users will need to install a standalone version of CMake 3.21 or later and add it to their PATH.
+
 * The clang/LLVM toolset currently does not respect the ``float_control`` pragma for SSE instrinsics. Therefore, the use of ``/fp:fast`` is not recommended on clang/LLVM until this issue is fixed. See [55713](https://github.com/llvm/llvm-project/issues/55713).
 
 ## Support

--- a/SHMath/CMakeLists.txt
+++ b/SHMath/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.21)
 
 if(DEFINED DIRECTXMATH_VERSION)
    set(SHMATH_VERSION ${DIRECTXMATH_VERSION})
@@ -14,15 +14,6 @@ project(DirectXSH
   DESCRIPTION "C++ Spherical Harmonics Math Library"
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
   LANGUAGES CXX)
-
-if(CMAKE_VERSION VERSION_LESS 3.21)
-  get_property(not_top DIRECTORY PROPERTY PARENT_DIRECTORY)
-  if(not_top)
-    set(PROJECT_IS_TOP_LEVEL false)
-  else()
-    set(PROJECT_IS_TOP_LEVEL true)
-  endif()
-endif()
 
 if(PROJECT_IS_TOP_LEVEL)
   message(FATAL_ERROR "SHMath should be built by the main CMakeLists using BUILD_SHMATH")

--- a/XDSP/CMakeLists.txt
+++ b/XDSP/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.21)
 
 if(DEFINED DIRECTXMATH_VERSION)
    set(XDSP_VERSION ${DIRECTXMATH_VERSION})
@@ -14,15 +14,6 @@ project(XDSP
   DESCRIPTION "XDSP Digital Signal Processing (DSP) for DirectXMath"
   HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkID=615560"
   LANGUAGES CXX)
-
-if(CMAKE_VERSION VERSION_LESS 3.21)
-  get_property(not_top DIRECTORY PROPERTY PARENT_DIRECTORY)
-  if(not_top)
-    set(PROJECT_IS_TOP_LEVEL false)
-  else()
-    set(PROJECT_IS_TOP_LEVEL true)
-  endif()
-endif()
 
 if(PROJECT_IS_TOP_LEVEL)
   message(FATAL_ERROR "XSDP should be built by the main CMakeLists using BUILD_XDSP")


### PR DESCRIPTION
aCMake 3.21 comes with VS 2022.

> VS 2019 users will need to install a standalone version of a CMake newer than the 3.20 that comes with it.