### PR TITLE
Skip including cpuid.h under Windows with Clang-cl

### DIFF
--- a/Extensions/DirectXMathAVX.h
+++ b/Extensions/DirectXMathAVX.h
@@ -28,7 +28,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathAVX2.h
+++ b/Extensions/DirectXMathAVX2.h
@@ -48,7 +48,7 @@ namespace DirectX
             if ((CPUInfo[2] & 0x38081001) != 0x38081001)
                 return false;
 
-        #if defined(__clang__) || defined(__GNUC__)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuidex(CPUInfo, 7, 0);

--- a/Extensions/DirectXMathAVX2.h
+++ b/Extensions/DirectXMathAVX2.h
@@ -29,7 +29,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ namespace DirectX
             if (CPUInfo[0] < 7)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathBE.h
+++ b/Extensions/DirectXMathBE.h
@@ -59,7 +59,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -68,7 +68,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathF16C.h
+++ b/Extensions/DirectXMathF16C.h
@@ -29,7 +29,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA3.h
+++ b/Extensions/DirectXMathFMA3.h
@@ -28,7 +28,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -33,7 +33,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -42,7 +42,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);
@@ -52,20 +52,20 @@ namespace DirectX
             if ((CPUInfo[2] & 0x18000000) != 0x18000000)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
-            __cpuid(CPUInfo, 0x80000000);
+            __cpuid(CPUInfo, static_cast<int>(0x80000000));
         #endif
 
             if (uint32_t(CPUInfo[0]) < 0x80000001u)
                 return false;
 
             // We check for FMA4
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0x80000001, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
-            __cpuid(CPUInfo, 0x80000001);
+            __cpuid(CPUInfo, static_cast<int>(0x80000001));
         #endif
 
             return (CPUInfo[2] & 0x10000);

--- a/Extensions/DirectXMathSSE3.h
+++ b/Extensions/DirectXMathSSE3.h
@@ -29,7 +29,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathSSE4.h
+++ b/Extensions/DirectXMathSSE4.h
@@ -29,7 +29,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -124,7 +124,7 @@
 #pragma warning(pop)
 #endif
 
-#if (defined(__clang__) || defined(__GNUC__)) && (__x86_64__ || __i386__) && !defined(__MINGW32__)
+#if (defined(__clang__) || defined(__GNUC__)) && (__x86_64__ || __i386__) && !defined(__MINGW32__) && !defined(_MSC_VER)
 #include <cpuid.h>
 #endif
 

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -1973,7 +1973,7 @@ inline bool XMVerifyCPUSupport() noexcept
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(__powerpc64__) && !defined(_XM_NO_INTRINSICS_)
     int CPUInfo[4] = { -1 };
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -1987,7 +1987,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false;
 #endif
 
-#if (defined(__clang__) || defined(__GNUC__)) && defined(__cpuid)
+#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -2022,7 +2022,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false; // No SSE2/SSE support
 
 #if defined(__AVX2__) || defined(_XM_AVX2_INTRINSICS_)
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
     __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuidex(CPUInfo, 7, 0);


### PR DESCRIPTION
## Summary

The issue is it includes `<cpuid.h>` when `__clang__` is defined and `__x86_64__` is set, but NOT on MinGW. This is the standard DirectXMath header from the Windows SDK.

On Linux/Mac with Clang, `<cpuid.h>` is a Clang/GCC built-in header that provides `__cpuid` and `__cpuidex` intrinsics. But on Windows with Clang-cl, those intrinsics come from `<intrin.h>` instead (which is already included on line 118 for `_MSC_VER`).

Since Clang-cl defines both `__clang__` AND `_MSC_VER`, it hits both the `<intrin.h>` include (good) AND the `<cpuid.h>` include (bad, doesn't exist on Windows). The fix is to exclude `_MSC_VER` as in the PR.

## Change

Add `!defined(_MSC_VER)` to the `<cpuid.h>` include condition so it only applies to non-MSVC-compatible Clang/GCC on Linux/Mac x86 targets.