### PR TITLE
Address MinGW test break when skipping including cpuid.h under Windows with Clang-cl

### DIFF
--- a/Extensions/DirectXMathAVX.h
+++ b/Extensions/DirectXMathAVX.h
@@ -28,7 +28,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathAVX2.h
+++ b/Extensions/DirectXMathAVX2.h
@@ -29,7 +29,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ namespace DirectX
             if (CPUInfo[0] < 7)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);
@@ -48,7 +48,7 @@ namespace DirectX
             if ((CPUInfo[2] & 0x38081001) != 0x38081001)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuidex(CPUInfo, 7, 0);

--- a/Extensions/DirectXMathBE.h
+++ b/Extensions/DirectXMathBE.h
@@ -59,7 +59,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -68,7 +68,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathF16C.h
+++ b/Extensions/DirectXMathF16C.h
@@ -29,7 +29,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -38,7 +38,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA3.h
+++ b/Extensions/DirectXMathFMA3.h
@@ -28,7 +28,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathFMA4.h
+++ b/Extensions/DirectXMathFMA4.h
@@ -33,7 +33,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -42,7 +42,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);
@@ -52,7 +52,7 @@ namespace DirectX
             if ((CPUInfo[2] & 0x18000000) != 0x18000000)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, static_cast<int>(0x80000000));
@@ -62,7 +62,7 @@ namespace DirectX
                 return false;
 
             // We check for FMA4
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0x80000001, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, static_cast<int>(0x80000001));

--- a/Extensions/DirectXMathSSE3.h
+++ b/Extensions/DirectXMathSSE3.h
@@ -29,7 +29,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Extensions/DirectXMathSSE4.h
+++ b/Extensions/DirectXMathSSE4.h
@@ -29,7 +29,7 @@ namespace DirectX
 
             // See https://msdn.microsoft.com/en-us/library/hskdteyh.aspx
             int CPUInfo[4] = { -1 };
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 0);
@@ -37,7 +37,7 @@ namespace DirectX
             if (CPUInfo[0] < 1)
                 return false;
 
-        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+        #if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
             __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
         #else
             __cpuid(CPUInfo, 1);

--- a/Inc/DirectXMathMisc.inl
+++ b/Inc/DirectXMathMisc.inl
@@ -1973,7 +1973,7 @@ inline bool XMVerifyCPUSupport() noexcept
 {
 #if defined(_XM_SSE_INTRINSICS_) && !defined(__powerpc64__) && !defined(_XM_NO_INTRINSICS_)
     int CPUInfo[4] = { -1 };
-#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
     __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 0);
@@ -1987,7 +1987,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false;
 #endif
 
-#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
     __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuid(CPUInfo, 1);
@@ -2022,7 +2022,7 @@ inline bool XMVerifyCPUSupport() noexcept
         return false; // No SSE2/SSE support
 
 #if defined(__AVX2__) || defined(_XM_AVX2_INTRINSICS_)
-#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER)
+#if (defined(__clang__) || defined(__GNUC__)) && !defined(_MSC_VER) && !defined(__MINGW32__)
     __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #else
     __cpuidex(CPUInfo, 7, 0);


### PR DESCRIPTION
There is build break after the last [PR](https://github.com/microsoft/DirectXMath/pull/296/changes#diff-9802c46c6b36ec264e623961a7c6864f7d729dff636cb4e297974172206b0dd4) that tests on the main branch. Add the extra check to address the MinGW test break.