### PR TITLE
C++17 or later use inline constexpr vars

### DIFF
--- a/.github/workflows/wslcxx.yml
+++ b/.github/workflows/wslcxx.yml
@@ -29,7 +29,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  buildgcc:
     runs-on: ubuntu-latest
 
     strategy:
@@ -104,6 +104,85 @@ jobs:
         env:
           CC: gcc-${{ matrix.gcc }}
           CXX: g++-${{ matrix.gcc }}
+
+      - name: 'Build (C++20)'
+        working-directory: ${{ github.workspace }}/Tests
+        run: cmake --build out/build/${{ matrix.build_type }}
+
+  buildclang:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [x64-Debug-Linux, x64-Release-Linux]
+        clang: [16, 17, 18]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Clone test repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: walbourn/directxmathtest
+          path: Tests
+          ref: main
+
+      - uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
+
+      - name: 'Configure CMake (C++17)'
+        working-directory: ${{ github.workspace }}/Tests
+        run: cmake --preset=${{ matrix.build_type }}
+        env:
+          CC: clang-${{ matrix.clang }}
+          CXX: clang++-${{ matrix.clang }}
+
+      - name: 'Build (C++17)'
+        working-directory: ${{ github.workspace }}/Tests
+        run: cmake --build out/build/${{ matrix.build_type }}
+
+      - name: 'Clean up'
+        working-directory: ${{ github.workspace }}
+        run: rm -rf out
+
+      # Test suite requires C++17 features on Linux, so we only test the headers for C++11/C++14
+      - name: 'Configure CMake (C++11)'
+        working-directory: ${{ github.workspace }}/Tests/headertest
+        run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX11=ON
+        env:
+          CC: clang-${{ matrix.clang }}
+          CXX: clang++-${{ matrix.clang }}
+
+      - name: 'Build (C++11)'
+        working-directory: ${{ github.workspace }}/Tests/headertest
+        run: cmake --build out/build/${{ matrix.build_type }}
+
+      - name: 'Clean up'
+        working-directory: ${{ github.workspace }}/Tests/headertest
+        run: rm -rf out
+
+      - name: 'Configure CMake (C++14)'
+        working-directory: ${{ github.workspace }}/Tests/headertest
+        run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX14=ON
+        env:
+          CC: clang-${{ matrix.clang }}
+          CXX: clang++-${{ matrix.clang }}
+
+      - name: 'Build (C++14)'
+        working-directory: ${{ github.workspace }}/Tests/headertest
+        run: cmake --build out/build/${{ matrix.build_type }}
+
+      - name: 'Clean up'
+        working-directory: ${{ github.workspace }}/Tests/headertest
+        run: rm -rf out
+
+      - name: 'Configure CMake (C++20)'
+        working-directory: ${{ github.workspace }}/Tests
+        run: cmake --preset=${{ matrix.build_type }} -DBUILD_CXX20=ON
+        env:
+          CC: clang-${{ matrix.clang }}
+          CXX: clang++-${{ matrix.clang }}
 
       - name: 'Build (C++20)'
         working-directory: ${{ github.workspace }}/Tests

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -2006,7 +2006,9 @@ namespace DirectX
     // separate math routine it would be reloaded.
 
 #ifndef XMGLOBALCONST
-#if defined(__GNUC__) && !defined(__MINGW32__)
+#if __cplusplus >= 201703L
+#define XMGLOBALCONST inline constexpr
+#elif defined(__GNUC__) && !defined(__MINGW32__)
 #define XMGLOBALCONST extern const __attribute__((weak))
 #else
 #define XMGLOBALCONST extern const __declspec(selectany)


### PR DESCRIPTION
There were reports that DirectXMath `XMGLOBALCONST` variables were not working correctly with C++20 modules. The solution was to use `inline constexpr` which I now apply uniformly for C++17 or later.