### PR TITLE
Add GitHub Action for MacOS

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 - **Project Name**: DirectXMath SIMD C++ linear algebra library
 - **Language**: C++ (minimum C++11; C++14, C++17, and C++20 features used conditionally)
 - **Framework / Libraries**: STL / CMake / CTest
-- **Compiler Requirement**: Visual C++ 2017 or later (`_MSC_VER >= 1910`) when using MSVC
+- **Compiler Requirement**: Visual C++ 2019 (16.11), Visual Studio 2022, or Visual Studio 2026 or later when using MSVC.
 
 ## Getting Started
 
@@ -27,7 +27,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 - **Testing**: Unit tests for this project are implemented in a separate repository [Test Suite](https://github.com/walbourn/directxmathtest/) and can be run using CTest per the instructions at [Test Documentation](https://github.com/walbourn/directxmathtest/wiki). See [test copilot instructions](https://github.com/walbourn/directxmathtest/blob/main/.github/copilot-instructions.md) for additional information on the tests.
 - **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository.
 - **Dependencies**: The project has minimal dependencies, primarily relying on compiler intrinsics. It is designed to be self-contained and portable across different platforms and toolsets.
-- **Continuous Integration**: This project has 18 GitHub Actions workflows covering MSVC, Clang/LLVM, GCC (WSL), ARM64, Address Sanitizer, CodeQL, and super-linter. Workflows are in `.github/workflows/` and include compiler-specific builds (`msvc.yml`, `clangcl.yml`, `cxx.yml`), platform-specific builds (`arm64.yml`, `wsl.yml`), extension tests (`shmath.yml`, `xdsp.yml`), and static analysis (`codeql.yml`, `lint.yml`, `asan.yml`). Azure DevOps pipeline configurations are in `.azuredevops/`.
+- **Continuous Integration**: This project has 20 GitHub Actions workflows covering MSVC, Clang/LLVM, GCC (WSL), ARM64, macOS, Address Sanitizer, CodeQL, and super-linter. Workflows are in `.github/workflows/` and include compiler-specific builds (`msvc.yml`, `clangcl.yml`, `cxx.yml`), platform-specific builds (`arm64.yml`, `arm64test.yml`, `macos.yml`, `wsl.yml`, `wslcxx.yml`), extension tests (`shmath.yml`, `shmathclang.yml`, `xdsp.yml`, `xdspclang.yml`), and static analysis (`codeql.yml`, `lint.yml`, `asan.yml`). Additional workflows include `main.yml`, `msbuild.yml`, `msbuildex.yml`, and `test.yml`. Azure DevOps pipeline configurations are in `.azuredevops/`.
 - **Code of Conduct**: The project adheres to the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). All contributors are expected to follow this code of conduct in all interactions related to the project.
 
 ## File Structure

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -494,6 +494,8 @@ Use these established guards — do not invent new ones:
 | `_M_ARM64EC` | ARM64EC ABI (ARM64 code with x64 interop using ARM-NEON) for MSVC |
 | `__aarch64__` / `__x86_64__` / `__i386__` / `__powerpc64__` | Additional architecture-specific symbols for MinGW/GNUC (`#if`) |
 | `_M_ARM` / `__arm__` | This is the legacy 32-bit Windows on ARM which is deprecated. |
+| `__linux__` | This is used in some tests to check for Linux platform. |
+| `__APPLE__` | This is used in some tests to check for Apple platform. |
 
 > GNU predefined architecture macros (`__aarch64__`, `__x86_64__`, `__i386__`, `__powerpc64__`, `__arm__`) are always defined to `1` by the compiler — they are **not** merely defined/undefined like MSVC's `_M_ARM64`. Use them **bare** (without `defined()`) in `#if` expressions: `#if __aarch64__`, not `#if defined(__aarch64__)`. Using `defined()` is technically valid but inconsistent with the project's convention and suppresses `-Wundef` unnecessarily.
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,84 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkID=615560
+
+name: 'CMake (MacOS)'
+
+on:
+  push:
+    branches: "main"
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.github/*.md'
+      - '.nuget/*'
+      - build/*.ps1
+  pull_request:
+    branches: "main"
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.github/*.md'
+      - '.nuget/*'
+      - build/*.ps1
+
+permissions:
+  contents: read
+
+jobs:
+  buildx64:
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [x64-Debug-Linux, x64-Release-Linux]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Clone test repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: walbourn/directxmathtest
+          path: Tests
+          ref: main
+
+      - name: 'Configure CMake'
+        working-directory: ${{ github.workspace }}
+        run: cmake --preset=${{ matrix.build_type }}
+
+      - name: 'Build'
+        working-directory: ${{ github.workspace }}
+        run: cmake --build out/build/${{ matrix.build_type }}
+
+  build_aarch64:
+    runs-on: macos-latest-arm64
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [arm64-Debug-Linux, arm64-Release-Linux]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Clone test repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: walbourn/directxmathtest
+          path: Tests
+          ref: main
+
+      - name: 'Configure CMake'
+        working-directory: ${{ github.workspace }}
+        run: cmake --preset=${{ matrix.build_type }}
+
+      - name: 'Build'
+        working-directory: ${{ github.workspace }}
+        run: cmake --build out/build/${{ matrix.build_type }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,35 +29,8 @@ permissions:
   contents: read
 
 jobs:
-  buildx64:
+  build:
     runs-on: macos-latest
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        build_type: [x64-Debug-Linux, x64-Release-Linux]
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Clone test repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: walbourn/directxmathtest
-          path: Tests
-          ref: main
-
-      - name: 'Configure CMake'
-        working-directory: ${{ github.workspace }}
-        run: cmake --preset=${{ matrix.build_type }}
-
-      - name: 'Build'
-        working-directory: ${{ github.workspace }}
-        run: cmake --build out/build/${{ matrix.build_type }}
-
-  build_aarch64:
-    runs-on: macos-latest-arm64
 
     strategy:
       fail-fast: false

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -59,3 +59,34 @@ jobs:
       - name: 'Build'
         working-directory: ${{ github.workspace }}
         run: cmake --build out/build/${{ matrix.build_type }}
+
+  buildNew:
+    runs-on: windows-2025
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [x64-Debug-MinGW, x64-Release-MinGW]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Clone test repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: walbourn/directxmathtest
+          path: Tests
+          ref: main
+
+      - name: 'Install Ninja'
+        run: choco install ninja
+
+      - name: 'Configure CMake'
+        working-directory: ${{ github.workspace }}
+        run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON
+
+      - name: 'Build'
+        working-directory: ${{ github.workspace }}
+        run: cmake --build out/build/${{ matrix.build_type }}

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -30,7 +30,6 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
     timeout-minutes: 20
 
     strategy:

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -38,37 +38,9 @@ jobs:
 
       matrix:
         build_type: [x64-Debug-MinGW, x64-Release-MinGW]
+        os: [windows-2022, windows-2025]
 
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Clone test repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: walbourn/directxmathtest
-          path: Tests
-          ref: main
-
-      - name: 'Install Ninja'
-        run: choco install ninja
-
-      - name: 'Configure CMake'
-        working-directory: ${{ github.workspace }}
-        run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON
-
-      - name: 'Build'
-        working-directory: ${{ github.workspace }}
-        run: cmake --build out/build/${{ matrix.build_type }}
-
-  buildNew:
-    runs-on: windows-2025
-    timeout-minutes: 20
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        build_type: [x64-Debug-MinGW, x64-Release-MinGW]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -231,8 +231,10 @@
     { "name": "x86-Debug-MinGW"     , "description": "MinG-W32 (Debug) - SSE/SSE2", "inherits": [ "base", "x86", "Debug", "GNUC", "MinGW32" ] },
     { "name": "x86-Release-MinGW"   , "description": "MinG-W32 (Release) - SSE/SSE2", "inherits": [ "base", "x86", "Release", "GNUC", "MinGW32" ] },
 
-    { "name": "x64-Debug-Linux"     , "description": "WSL x64 (Debug) - SSE/SSE2", "inherits": [ "base", "x64", "Debug" ] },
-    { "name": "x64-Release-Linux"   , "description": "WSL x64 (Release) - SSE/SSE2", "inherits": [ "base", "x64", "Release" ] }
+    { "name": "x64-Debug-Linux",     "description": "WSL Linux x64 (Debug)", "inherits": [ "base", "x64", "Debug" ] },
+    { "name": "x64-Release-Linux",   "description": "WSL Linux x64 (Release)", "inherits": [ "base", "x64", "Release" ] },
+    { "name": "arm64-Debug-Linux",   "description": "WSL Linux AArch64 (Debug)", "inherits": [ "base", "ARM64", "Debug" ] },
+    { "name": "arm64-Release-Linux", "description": "WSL Linux AArch64 (Release)", "inherits": [ "base", "ARM64", "Release" ] }
   ],
 
   "testPresets": [
@@ -250,6 +252,11 @@
     { "name": "x86-Debug-Clang"    , "configurePreset": "x86-Debug-Clang" },
     { "name": "x86-Release-Clang"  , "configurePreset": "x86-Release-Clang" },
     { "name": "arm64-Debug-Clang"  , "configurePreset": "arm64-Debug-Clang" },
-    { "name": "arm64-Release-Clang", "configurePreset": "arm64-Release-Clang" }
+    { "name": "arm64-Release-Clang", "configurePreset": "arm64-Release-Clang" },
+
+    { "name": "x64-Debug-Linux", "configurePreset": "x64-Debug-Linux" },
+    { "name": "x64-Release-Linux", "configurePreset": "x64-Release-Linux" },
+    { "name": "arm64-Debug-Linux", "configurePreset": "arm64-Debug-Linux" },
+    { "name": "arm64-Release-Linux", "configurePreset": "arm64-Release-Linux" }
   ]
 }

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -155,6 +155,7 @@
 
 #include "sal.h"
 #include <assert.h>
+#include <stddef.h>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/README.md
+++ b/README.md
@@ -148,3 +148,5 @@ Thanks to Bruce Dawson for his help with the rounding functions.
 Thanks to Andrew Farrier for the fixes to ``XMVerifyCPUSupport`` to properly support clang.
 
 Thanks to Scott Matloff for his help in getting the library updated to use Intel SVML for VS 2019.
+
+Thanks to Shawn Hargreaves and Nada Ouf for their continued support for this library.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXMath/s
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXMath/blob/main/CHANGELOG.md).
 
+* The *directxmath* NuGet package is deprecated. The best way to integrate the latest DirectXMath into your C++ project is using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/directxmath).
+
 * The CMake projects require 3.21 or later. VS 2019 users will need to install a standalone version of CMake 3.21 or later and add it to their PATH.
 
 * The clang/LLVM toolset currently does not respect the ``float_control`` pragma for SSE instrinsics. Therefore, the use of ``/fp:fast`` is not recommended on clang/LLVM until this issue is fixed. See [55713](https://github.com/llvm/llvm-project/issues/55713).

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Thanks to Dave Eberly for his contributions particularly in improving the transc
 
 Thanks to Bruce Dawson for his help with the rounding functions.
 
-Thanks to Andrew Farrier for the fixes to ``XMVerifyCPUSupport`` to properly support clang.
+Thanks to Andrew Farrier and Ruiji-Shi for the fixes to ``XMVerifyCPUSupport`` to properly support clang.
 
 Thanks to Scott Matloff for his help in getting the library updated to use Intel SVML for VS 2019.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ copilot
 
 ## Compiler support
 
-Officially the library is supported with Microsoft Visual C++ 2019 (16.11) or later, clang/LLVM v12 or later, and GCC 10 or later. It should also compile with the Intel C++ and MinGW compilers.
+Officially the library is supported with Microsoft Visual C++ 2019 (16.11) or later, clang/LLVM v12 or later, and GCC 10 or later. It should also compile with the Intel C++, MinGW, and Apple Clang compilers.
 
 When building with clang/LLVM or other GNU C compilers, the ``_XM_NO_XMVECTOR_OVERLOADS_`` control define is set because these compilers do not support creating operator overloads for the ``XMVECTOR`` type. You can choose to enable this preprocessor define explicitly to do the same thing with Visual C++ for improved portability.
 


### PR DESCRIPTION
* Added a GHA to try to build the library using macOS's variant of Linux.

* This highlighted a minor conformance issue (``size_t`` requires `stddef.h`)

* Added a second case to the MinGW GHA to test a different version of the compiler: current 14.2 and 15.2.

> Includes some readme and copilot instructions edits as well.