### PR TITLE
Optimize orthonormal basis generation using Pixar 2017 method

### DIFF
--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -1504,6 +1504,7 @@ namespace DirectX
     XMVECTOR    XM_CALLCONV     XMVector3Refract(FXMVECTOR Incident, FXMVECTOR Normal, float RefractionIndex) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3RefractV(FXMVECTOR Incident, FXMVECTOR Normal, FXMVECTOR RefractionIndex) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3Orthogonal(FXMVECTOR V) noexcept;
+    void        XM_CALLCONV     XMVector3OrthogonalBasis(_Out_ XMVECTOR* pTangent, _Out_ XMVECTOR* pBitangent, _In_ FXMVECTOR Normal) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenNormalsEst(FXMVECTOR N1, FXMVECTOR N2) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenNormals(FXMVECTOR N1, FXMVECTOR N2) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenVectors(FXMVECTOR V1, FXMVECTOR V2) noexcept;

--- a/Inc/DirectXMath.h
+++ b/Inc/DirectXMath.h
@@ -1504,7 +1504,7 @@ namespace DirectX
     XMVECTOR    XM_CALLCONV     XMVector3Refract(FXMVECTOR Incident, FXMVECTOR Normal, float RefractionIndex) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3RefractV(FXMVECTOR Incident, FXMVECTOR Normal, FXMVECTOR RefractionIndex) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3Orthogonal(FXMVECTOR V) noexcept;
-    void        XM_CALLCONV     XMVector3OrthogonalBasis(_Out_ XMVECTOR* pTangent, _Out_ XMVECTOR* pBitangent, _In_ FXMVECTOR Normal) noexcept;
+    void        XM_CALLCONV     XMVector3OrthogonalBasis(_Out_opt_ XMVECTOR* pTangent, _Out_opt_ XMVECTOR* pBitangent, _In_ FXMVECTOR Normal) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenNormalsEst(FXMVECTOR N1, FXMVECTOR N2) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenNormals(FXMVECTOR N1, FXMVECTOR N2) noexcept;
     XMVECTOR    XM_CALLCONV     XMVector3AngleBetweenVectors(FXMVECTOR V1, FXMVECTOR V2) noexcept;

--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -10216,11 +10216,12 @@ inline XMVECTOR XM_CALLCONV XMVector3Orthogonal(FXMVECTOR V) noexcept
 
 //------------------------------------------------------------------------------
 
+_Use_decl_annotations_
 inline void XM_CALLCONV XMVector3OrthogonalBasis
 (
-    _Out_opt_ XMVECTOR* pTangent,
-    _Out_opt_ XMVECTOR* pBitangent,
-    _In_ FXMVECTOR Normal
+    XMVECTOR* pTangent,
+    XMVECTOR* pBitangent,
+    FXMVECTOR Normal
 ) noexcept
 {
 #if defined(_XM_NO_INTRINSICS_)

--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -10216,6 +10216,87 @@ inline XMVECTOR XM_CALLCONV XMVector3Orthogonal(FXMVECTOR V) noexcept
 
 //------------------------------------------------------------------------------
 
+inline void XM_CALLCONV XMVector3OrthogonalBasis
+(
+    _Out_ XMVECTOR* pTangent,
+    _Out_ XMVECTOR* pBitangent,
+    _In_ FXMVECTOR Normal
+) noexcept
+{
+    assert(pTangent != nullptr);
+    assert(pBitangent != nullptr);
+
+#if defined(_XM_NO_INTRINSICS_)
+    float sign = copysignf(1.0f, Normal.vector4_f32[2]);
+    float a = -1.0f / (sign + Normal.vector4_f32[2]);
+    float b = Normal.vector4_f32[0] * Normal.vector4_f32[1] * a;
+
+    pTangent->vector4_f32[0] = 1.0f + sign * Normal.vector4_f32[0] * Normal.vector4_f32[0] * a;
+    pTangent->vector4_f32[1] = sign * b;
+    pTangent->vector4_f32[2] = -sign * Normal.vector4_f32[0];
+    pTangent->vector4_f32[3] = 0.0f;
+
+    pBitangent->vector4_f32[0] = b;
+    pBitangent->vector4_f32[1] = sign + Normal.vector4_f32[1] * Normal.vector4_f32[1] * a;
+    pBitangent->vector4_f32[2] = -Normal.vector4_f32[1];
+    pBitangent->vector4_f32[3] = 0.0f;
+#else
+    XMVECTOR Z = XMVectorSplatZ(Normal);
+    XMVECTOR SignBitMask = g_XMNegativeZero.v;
+    XMVECTOR One = g_XMOne.v;
+
+    // sign = copysignf(1.0f, n.z)
+    XMVECTOR SignZ = XMVectorAndInt(Z, SignBitMask);
+    XMVECTOR Sign = XMVectorOrInt(SignZ, One);
+
+    // a = -1.0f / (sign + n.z)
+    XMVECTOR Denom = XMVectorAdd(Sign, Z);
+    XMVECTOR A = XMVectorDivide(g_XMNegativeOne.v, Denom);
+
+    // b = n.x * n.y * a
+    XMVECTOR X = XMVectorSplatX(Normal);
+    XMVECTOR Y = XMVectorSplatY(Normal);
+    XMVECTOR XY = XMVectorMultiply(X, Y);
+    XMVECTOR B = XMVectorMultiply(XY, A);
+
+    // b1.x = 1.0f + sign * n.x * n.x * a
+    XMVECTOR SignX = XMVectorMultiply(Sign, X);
+    XMVECTOR XXA = XMVectorMultiply(X, XMVectorMultiply(X, A));
+    XMVECTOR B1X = XMVectorMultiplyAdd(Sign, XXA, One);
+
+    // b1.y = sign * b
+    XMVECTOR B1Y = XMVectorMultiply(Sign, B);
+
+    // b1.z = -sign * n.x
+    XMVECTOR B1Z = XMVectorNegate(SignX);
+
+    // b2.x = b
+    XMVECTOR B2X = B;
+
+    // b2.y = sign + n.y * n.y * a
+    XMVECTOR YYA = XMVectorMultiply(Y, XMVectorMultiply(Y, A));
+    XMVECTOR B2Y = XMVectorAdd(Sign, YYA);
+
+    // b2.z = -n.y
+    XMVECTOR B2Z = XMVectorNegate(Y);
+
+    // Combine into tangent and bitangent
+    XMVECTOR Zero = XMVectorZero();
+
+    // pTangent = (B1X, B1Y, B1Z, 0)
+    XMVECTOR B1_XY = XMVectorMergeXY(B1X, B1Y);
+    XMVECTOR B1_Z0 = XMVectorMergeXY(B1Z, Zero);
+    *pTangent = XMVectorPermute<XM_PERMUTE_0X, XM_PERMUTE_0Y, XM_PERMUTE_1X, XM_PERMUTE_1Y>(B1_XY, B1_Z0);
+
+    // pBitangent = (B2X, B2Y, B2Z, 0)
+    XMVECTOR B2_XY = XMVectorMergeXY(B2X, B2Y);
+    XMVECTOR B2_Z0 = XMVectorMergeXY(B2Z, Zero);
+    *pBitangent = XMVectorPermute<XM_PERMUTE_0X, XM_PERMUTE_0Y, XM_PERMUTE_1X, XM_PERMUTE_1Y>(B2_XY, B2_Z0);
+#endif
+}
+
+//------------------------------------------------------------------------------
+
 inline XMVECTOR XM_CALLCONV XMVector3AngleBetweenNormalsEst
 (
     FXMVECTOR N1,

--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -10218,28 +10218,31 @@ inline XMVECTOR XM_CALLCONV XMVector3Orthogonal(FXMVECTOR V) noexcept
 
 inline void XM_CALLCONV XMVector3OrthogonalBasis
 (
-    _Out_ XMVECTOR* pTangent,
-    _Out_ XMVECTOR* pBitangent,
+    _Out_opt_ XMVECTOR* pTangent,
+    _Out_opt_ XMVECTOR* pBitangent,
     _In_ FXMVECTOR Normal
 ) noexcept
 {
-    assert(pTangent != nullptr);
-    assert(pBitangent != nullptr);
-
 #if defined(_XM_NO_INTRINSICS_)
-    float sign = copysignf(1.0f, Normal.vector4_f32[2]);
+    float sign = (Normal.vector4_u32[2] & 0x80000000) ? -1.0f : 1.0f;
     float a = -1.0f / (sign + Normal.vector4_f32[2]);
     float b = Normal.vector4_f32[0] * Normal.vector4_f32[1] * a;
 
-    pTangent->vector4_f32[0] = 1.0f + sign * Normal.vector4_f32[0] * Normal.vector4_f32[0] * a;
-    pTangent->vector4_f32[1] = sign * b;
-    pTangent->vector4_f32[2] = -sign * Normal.vector4_f32[0];
-    pTangent->vector4_f32[3] = 0.0f;
+    if (pTangent)
+    {
+        pTangent->vector4_f32[0] = 1.0f + sign * Normal.vector4_f32[0] * Normal.vector4_f32[0] * a;
+        pTangent->vector4_f32[1] = sign * b;
+        pTangent->vector4_f32[2] = -sign * Normal.vector4_f32[0];
+        pTangent->vector4_f32[3] = 0.0f;
+    }
 
-    pBitangent->vector4_f32[0] = b;
-    pBitangent->vector4_f32[1] = sign + Normal.vector4_f32[1] * Normal.vector4_f32[1] * a;
-    pBitangent->vector4_f32[2] = -Normal.vector4_f32[1];
-    pBitangent->vector4_f32[3] = 0.0f;
+    if (pBitangent)
+    {
+        pBitangent->vector4_f32[0] = b;
+        pBitangent->vector4_f32[1] = sign + Normal.vector4_f32[1] * Normal.vector4_f32[1] * a;
+        pBitangent->vector4_f32[2] = -Normal.vector4_f32[1];
+        pBitangent->vector4_f32[3] = 0.0f;
+    }
 #else
     XMVECTOR Z = XMVectorSplatZ(Normal);
     XMVECTOR SignBitMask = g_XMNegativeZero.v;
@@ -10283,15 +10286,21 @@ inline void XM_CALLCONV XMVector3OrthogonalBasis
     // Combine into tangent and bitangent
     XMVECTOR Zero = XMVectorZero();
 
-    // pTangent = (B1X, B1Y, B1Z, 0)
-    XMVECTOR B1_XY = XMVectorMergeXY(B1X, B1Y);
-    XMVECTOR B1_Z0 = XMVectorMergeXY(B1Z, Zero);
-    *pTangent = XMVectorPermute<XM_PERMUTE_0X, XM_PERMUTE_0Y, XM_PERMUTE_1X, XM_PERMUTE_1Y>(B1_XY, B1_Z0);
+    if (pTangent)
+    {
+        // pTangent = (B1X, B1Y, B1Z, 0)
+        XMVECTOR B1_XY = XMVectorMergeXY(B1X, B1Y);
+        XMVECTOR B1_Z0 = XMVectorMergeXY(B1Z, Zero);
+        *pTangent = XMVectorPermute<XM_PERMUTE_0X, XM_PERMUTE_0Y, XM_PERMUTE_1X, XM_PERMUTE_1Y>(B1_XY, B1_Z0);
+    }
 
-    // pBitangent = (B2X, B2Y, B2Z, 0)
-    XMVECTOR B2_XY = XMVectorMergeXY(B2X, B2Y);
-    XMVECTOR B2_Z0 = XMVectorMergeXY(B2Z, Zero);
-    *pBitangent = XMVectorPermute<XM_PERMUTE_0X, XM_PERMUTE_0Y, XM_PERMUTE_1X, XM_PERMUTE_1Y>(B2_XY, B2_Z0);
+    if (pBitangent)
+    {
+        // pBitangent = (B2X, B2Y, B2Z, 0)
+        XMVECTOR B2_XY = XMVectorMergeXY(B2X, B2Y);
+        XMVECTOR B2_Z0 = XMVectorMergeXY(B2Z, Zero);
+        *pBitangent = XMVectorPermute<XM_PERMUTE_0X, XM_PERMUTE_0Y, XM_PERMUTE_1X, XM_PERMUTE_1Y>(B2_XY, B2_Z0);
+    }
 #endif
 }
 


### PR DESCRIPTION
Resolves upstream issue microsoft/DirectXMath#73.

Implemented `XMVector3OrthogonalBasis` utilizing the Pixar 2017 method ("Building an Orthonormal Basis, Revisited" by Duff et al.) to compute a tangent and bitangent from a unit normal. This ensures numeric stability across all edge cases (particularly along the Z-axis, which causes singularities in naive cross-product derivations) while remaining branchless.

## changes:
- Added `XMVector3OrthogonalBasis` to `DirectXMath.h`
- Implemented `XMVector3OrthogonalBasis` in `DirectXMathVector.inl`
- Maintained scalar compatibility with `#if defined(_XM_NO_INTRINSICS_)`
- Optimized SIMD intrinsic execution pathway (reusing vectors and leveraging `XMVectorAndInt`/`XMVectorOrInt` for fast `copysign` replacement).

## how i verified.
I verified the implementation by writing a test script against the critical edge cases (vectors perfectly aligned with the axes, which often cause singularities in branchless ONB generation). 

```cpp
#include <iostream>
#include <DirectXMath.h>
using namespace DirectX;

void VerifyONB(float x, float y, float z) {
    XMVECTOR N = XMVectorSet(x, y, z, 0);
    XMVECTOR T, B;
    
    // Generate Orthogonal Basis
    XMVector3OrthogonalBasis(&T, &B, N);
    
    // Verify Orthogonality
    float dot_NT = XMVectorGetX(XMVector3Dot(N, T));
    float dot_NB = XMVectorGetX(XMVector3Dot(N, B));
    float dot_TB = XMVectorGetX(XMVector3Dot(T, B));
    
    XMFLOAT4 nf, tf, bf;
    XMStoreFloat4(&nf, N); XMStoreFloat4(&tf, T); XMStoreFloat4(&bf, B);
    
    std::cout << "Normal: (" << nf.x << ", " << nf.y << ", " << nf.z << ")\n";
    std::cout << "Tangent: (" << tf.x << ", " << tf.y << ", " << tf.z << ")\n";
    std::cout << "Bitangent: (" << bf.x << ", " << bf.y << ", " << bf.z << ")\n";
    std::cout << "Verification [N.T, N.B, T.B]: " << dot_NT << ", " << dot_NB << ", " << dot_TB << "\n\n";
}

int main() {
    VerifyONB(0, 0, 1);
    VerifyONB(0, 0, -1);
    VerifyONB(1, 0, 0);
    VerifyONB(0.57735f, 0.57735f, 0.57735f); // Arbitrary unit vector
    return 0;
}
```
the output :
```
Normal: (0, 0, 1)
Tangent: (1, -0, -0)
Bitangent: (-0, 1, -0)
Verification [N.T, N.B, T.B]: 0, 0, 0

Normal: (0, 0, -1)
Tangent: (1, -0, 0)
Bitangent: (0, -1, -0)
Verification [N.T, N.B, T.B]: 0, 0, 0

Normal: (1, 0, 0)
Tangent: (0, -0, -1)
Bitangent: (-0, 1, -0)
Verification [N.T, N.B, T.B]: 0, 0, 0

Normal: (0.57735, 0.57735, 0.57735)
Tangent: (0.788675, -0.211325, -0.57735)
Bitangent: (-0.211325, 0.788675, -0.57735)
Verification [N.T, N.B, T.B]: 3.35524e-07, 3.35524e-07, -1.10278e-07
```