### PR TITLE
Fix __FINITE_MATH_ONLY__ guard to test the value, not definedness

### DIFF
--- a/Inc/DirectXMathVector.inl
+++ b/Inc/DirectXMathVector.inl
@@ -2186,7 +2186,7 @@ inline XMVECTOR XM_CALLCONV XMVectorIsNaN(FXMVECTOR V) noexcept
     return Control.v;
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
     XMVECTORU32 vResult = { { {
         isnan(vgetq_lane_f32(V, 0)) ? 0xFFFFFFFFU : 0,
         isnan(vgetq_lane_f32(V, 1)) ? 0xFFFFFFFFU : 0,
@@ -2200,7 +2200,7 @@ inline XMVECTOR XM_CALLCONV XMVectorIsNaN(FXMVECTOR V) noexcept
     return vreinterpretq_f32_u32(vmvnq_u32(vTempNan));
 #endif
 #elif defined(_XM_SSE_INTRINSICS_)
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
     XM_ALIGNED_DATA(16) float tmp[4];
     _mm_store_ps(tmp, V);
     XMVECTORU32 vResult = { { {
@@ -6653,7 +6653,7 @@ inline bool XM_CALLCONV XMVector2IsNaN(FXMVECTOR V) noexcept
     return (XMISNAN(V.vector4_f32[0]) ||
         XMISNAN(V.vector4_f32[1]));
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
     return isnan(vgetq_lane_f32(V, 0)) || isnan(vgetq_lane_f32(V, 1));
 #else
     float32x2_t VL = vget_low_f32(V);
@@ -6663,7 +6663,7 @@ inline bool XM_CALLCONV XMVector2IsNaN(FXMVECTOR V) noexcept
     return (vget_lane_u64(vreinterpret_u64_u32(vTempNan), 0) != 0xFFFFFFFFFFFFFFFFU);
 #endif
 #elif defined(_XM_SSE_INTRINSICS_)
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
     XM_ALIGNED_DATA(16) float tmp[4];
     _mm_store_ps(tmp, V);
     return isnan(tmp[0]) || isnan(tmp[1]);
@@ -9418,7 +9418,7 @@ inline bool XM_CALLCONV XMVector3IsNaN(FXMVECTOR V) noexcept
         XMISNAN(V.vector4_f32[2]));
 
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
     return isnan(vgetq_lane_f32(V, 0)) || isnan(vgetq_lane_f32(V, 1)) || isnan(vgetq_lane_f32(V, 2));
 #else
 // Test against itself. NaN is always not equal
@@ -9429,7 +9429,7 @@ inline bool XM_CALLCONV XMVector3IsNaN(FXMVECTOR V) noexcept
     return ((vget_lane_u32(vreinterpret_u32_u16(vTemp2.val[1]), 1) & 0xFFFFFFU) != 0xFFFFFFU);
 #endif
 #elif defined(_XM_SSE_INTRINSICS_)
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
     XM_ALIGNED_DATA(16) float tmp[4];
     _mm_store_ps(tmp, V);
     return isnan(tmp[0]) || isnan(tmp[1]) || isnan(tmp[2]);
@@ -13309,7 +13309,7 @@ inline bool XM_CALLCONV XMVector4IsNaN(FXMVECTOR V) noexcept
         XMISNAN(V.vector4_f32[2]) ||
         XMISNAN(V.vector4_f32[3]));
 #elif defined(_XM_ARM_NEON_INTRINSICS_)
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
     return isnan(vgetq_lane_f32(V, 0)) || isnan(vgetq_lane_f32(V, 1)) || isnan(vgetq_lane_f32(V, 2)) || isnan(vgetq_lane_f32(V, 3));
 #else
 // Test against itself. NaN is always not equal
@@ -13320,7 +13320,7 @@ inline bool XM_CALLCONV XMVector4IsNaN(FXMVECTOR V) noexcept
     return (vget_lane_u32(vreinterpret_u32_u16(vTemp2.val[1]), 1) != 0xFFFFFFFFU);
 #endif
 #elif defined(_XM_SSE_INTRINSICS_)
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
     XM_ALIGNED_DATA(16) float tmp[4];
     _mm_store_ps(tmp, V);
     return isnan(tmp[0]) || isnan(tmp[1]) || isnan(tmp[2]) || isnan(tmp[3]);


### PR DESCRIPTION
## Problem

`XMVectorIsNaN`, `XMVector2IsNaN`, `XMVector3IsNaN` and `XMVector4IsNaN` each guard a scalar fallback with:

```c
#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
```

Clang defines `__FINITE_MATH_ONLY__` **unconditionally** — `0` by default, and `1` only under `-ffast-math` / `-ffinite-math-only` (clang-cl `/fp:fast`). The guard tests *definedness* rather than the *value*, so it is always true under clang and the fallback is compiled into **every** clang build, not just finite-math ones.

Measured with clang-cl:

| | `__FINITE_MATH_ONLY__` | guard today | guard after this change |
|---|---|---|---|
| default (`/fp:precise`) | 0 | **true** | false |
| `/fp:fast` | 1 | true | true |

## Consequences

1. **Build breakage.** The fallback calls unqualified `isnan()`. Any clang target whose C++ library does not declare `isnan()` fails to compile. This is how we hit it: ~690 errors across 35 build directories in the Windows source tree, all `use of undeclared identifier 'isnan'` at these sites.
2. **Worse codegen where it does compile.** A single vector compare is replaced by a store, four scalar tests and a reassemble.

MSVC never defines the macro, so it always takes the intrinsic path — which is why this is clang-only.

## Change

Tests the macro's value instead. 8 sites: 4 functions × the NEON and SSE paths of each. No other file in the repo references the macro.

```diff
-#if defined(__clang__) && defined(__FINITE_MATH_ONLY__)
+#if defined(__clang__) && __FINITE_MATH_ONLY__
```

Preserves the file's CRLF line endings and ASCII-only content per `.editorconfig`.

## Open question for maintainers

While investigating I measured what actually happens under `/fp:fast`, i.e. the only configuration in which the fallback is now selected. Under clang, **every** scalar NaN test folds to constant `false` there — `__builtin_isnan`, `x != x`, and even explicit union bit-inspection of the exponent field all become `xor eax,eax; ret`, because `nnan`/`ninf` let the optimizer prove no NaN can occur.

If that holds generally, the fallback does not do anything even when correctly selected, and deleting it may be more honest than re-guarding it. I have kept this PR to the minimal, clearly-correct fix and am raising the broader question rather than acting on it, since it is a behavioural decision for the maintainers.

Related: MSVC folds `_mm_cmpneq_ps(V, V)` to an all-zero mask under `/fp:fast` as well, so `XMVectorIsNaN` already returns "no lane is NaN" in fast-math MSVC builds. That is independent of this change.